### PR TITLE
test: isolate schema-mutating RDBMS tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -82,14 +83,28 @@ final class RdbmsSchemaVersionStoreIT {
   }
 
   @TestTemplate
-  void shouldRestartAfterPurgingHistory(final CamundaRdbmsTestApplication testApplication) {
+  void shouldRestartAfterPurgingHistory(final CamundaRdbmsTestApplication testApplication)
+      throws Exception {
     // given
+    final DataSource dataSource = testApplication.bean(DataSource.class);
+    final String schemaVersionBeforePurge = readSchemaVersion(dataSource);
     testApplication.getRdbmsService().createWriter(PARTITION_ID).getRdbmsPurger().purgeRdbms();
+    assertThat(readSchemaVersion(dataSource)).isEqualTo(schemaVersionBeforePurge);
 
     // when
     testApplication.restart();
 
     // then
-    assertThatCode(() -> testApplication.bean(DataSource.class)).doesNotThrowAnyException();
+    assertThat(readSchemaVersion(testApplication.bean(DataSource.class)))
+        .isEqualTo(schemaVersionBeforePurge);
+  }
+
+  private String readSchemaVersion(final DataSource dataSource) throws Exception {
+    try (final var connection = dataSource.getConnection();
+        final var statement = connection.createStatement();
+        final var result = statement.executeQuery("SELECT VERSION FROM RDBMS_SCHEMA_VERSION")) {
+      assertThat(result.next()).isTrue();
+      return result.getString(1);
+    }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
@@ -18,7 +18,9 @@ import io.camunda.zeebe.util.VersionUtil;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Verifies {@link RdbmsSchemaVersionStore#tableExists} finds {@code RDBMS_SCHEMA_VERSION} on every
@@ -27,8 +29,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * missed.
  */
 @Tag("rdbms")
-@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 final class RdbmsSchemaVersionStoreIT {
+
+  @RegisterExtension
+  static final CamundaRdbmsInvocationContextProviderExtension TEST_APPLICATIONS =
+      CamundaRdbmsInvocationContextProviderExtension.isolated();
 
   @TestTemplate
   void shouldFindExistingSchemaVersionRegardlessOfVendorIdentifierCasing(
@@ -67,8 +73,8 @@ final class RdbmsSchemaVersionStoreIT {
       assertThatThrownBy(versionStore::checkCompatibility)
           .isInstanceOf(RdbmsSchemaVersionIncompatibleException.class);
     } finally {
-      // Restore the version a real boot would have recorded, so any later test reusing this
-      // vendor's shared, cached test application observes a consistent, correctly-migrated state.
+      // Restore the version a real boot would have recorded so the next template invocation for
+      // this class observes a consistent, correctly migrated state.
       versionStore.recordCurrentVersion();
     }
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 @Execution(ExecutionMode.SAME_THREAD)
 final class RdbmsSchemaVersionStoreIT {
 
+  private static final long PARTITION_ID = 0L;
+
   @RegisterExtension
   static final CamundaRdbmsInvocationContextProviderExtension TEST_APPLICATIONS =
       CamundaRdbmsInvocationContextProviderExtension.isolated();
@@ -77,5 +79,17 @@ final class RdbmsSchemaVersionStoreIT {
       // this class observes a consistent, correctly migrated state.
       versionStore.recordCurrentVersion();
     }
+  }
+
+  @TestTemplate
+  void shouldRestartAfterPurgingHistory(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    testApplication.getRdbmsService().createWriter(PARTITION_ID).getRdbmsPurger().purgeRdbms();
+
+    // when
+    testApplication.restart();
+
+    // then
+    assertThatCode(() -> testApplication.bean(DataSource.class)).doesNotThrowAnyException();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaDatabaseTestApplicationResolver.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaDatabaseTestApplicationResolver.java
@@ -22,11 +22,15 @@ public class CamundaDatabaseTestApplicationResolver
 
   private final String standaloneCamundaKey;
   private final CamundaRdbmsTestApplication testApplication;
+  private final boolean shared;
 
   public CamundaDatabaseTestApplicationResolver(
-      final String standaloneCamundaKey, final CamundaRdbmsTestApplication testApplication) {
+      final String standaloneCamundaKey,
+      final CamundaRdbmsTestApplication testApplication,
+      final boolean shared) {
     this.standaloneCamundaKey = standaloneCamundaKey;
     this.testApplication = testApplication;
+    this.shared = shared;
   }
 
   @Override
@@ -38,6 +42,9 @@ public class CamundaDatabaseTestApplicationResolver
   @Override
   public Object resolveParameter(
       final ParameterContext parameterCtx, final ExtensionContext extensionCtx) {
+    if (!shared) {
+      return testApplication;
+    }
     final ExtensionContext rootContext = extensionCtx.getRoot();
     final ExtensionContext.Store store = rootContext.getStore(Namespace.GLOBAL);
     final String key = CamundaRdbmsTestApplication.class.getName() + "_" + standaloneCamundaKey;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
@@ -13,7 +13,10 @@ import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -23,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CamundaRdbmsInvocationContextProviderExtension
-    implements TestTemplateInvocationContextProvider, BeforeAllCallback, AutoCloseable {
+    implements TestTemplateInvocationContextProvider, BeforeAllCallback, AfterAllCallback {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(CamundaRdbmsInvocationContextProviderExtension.class);
@@ -105,17 +108,12 @@ public class CamundaRdbmsInvocationContextProviderExtension
   }
 
   private final Set<String> useTestApplications;
+  private final Map<String, CamundaRdbmsTestApplication> testApplications;
+  private final boolean shared;
 
   /** By default, only all default test applications will be used */
   public CamundaRdbmsInvocationContextProviderExtension() {
-    useTestApplications =
-        Set.of(
-            "camundaWithH2",
-            "camundaWithPostgresSQL",
-            "camundaWithMariaDB",
-            "camundaWithMySQL",
-            "camundaWithOracleDB",
-            "camundaWithMssqlDB");
+    this(defaultTestApplications());
   }
 
   /**
@@ -133,7 +131,32 @@ public class CamundaRdbmsInvocationContextProviderExtension
    * @param useTestApplications the test applications to use
    */
   public CamundaRdbmsInvocationContextProviderExtension(final String... useTestApplications) {
-    this.useTestApplications = Set.of(useTestApplications);
+    this(Set.of(useTestApplications));
+  }
+
+  private CamundaRdbmsInvocationContextProviderExtension(final Set<String> useTestApplications) {
+    this(useTestApplications, SUPPORTED_TEST_APPLICATIONS, true);
+  }
+
+  private CamundaRdbmsInvocationContextProviderExtension(
+      final Set<String> useTestApplications,
+      final Map<String, CamundaRdbmsTestApplication> testApplications,
+      final boolean shared) {
+    this.useTestApplications = useTestApplications;
+    this.testApplications = testApplications;
+    this.shared = shared;
+  }
+
+  public static CamundaRdbmsInvocationContextProviderExtension isolated() {
+    final var keys = defaultTestApplications();
+    return new CamundaRdbmsInvocationContextProviderExtension(
+        keys,
+        keys.stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    key -> key,
+                    CamundaRdbmsInvocationContextProviderExtension::createTestApplication)),
+        false);
   }
 
   @Override
@@ -149,20 +172,27 @@ public class CamundaRdbmsInvocationContextProviderExtension
 
   @Override
   public void beforeAll(final ExtensionContext context) {
-    useTestApplications.forEach(
-        key -> {
-          final CamundaRdbmsTestApplication testApplication = SUPPORTED_TEST_APPLICATIONS.get(key);
-          if (!testApplication.isStarted()) {
-            LOGGER.info("Start up CamundaDatabaseTestApplication '{}'...", key);
-            testApplication.start();
-            LOGGER.info("Start up of CamundaDatabaseTestApplication '{}' finished.", key);
-          }
-        });
+    try {
+      useTestApplications.forEach(
+          key -> {
+            final CamundaRdbmsTestApplication testApplication = testApplications.get(key);
+            if (!testApplication.isStarted()) {
+              LOGGER.info("Start up CamundaDatabaseTestApplication '{}'...", key);
+              testApplication.start();
+              LOGGER.info("Start up of CamundaDatabaseTestApplication '{}' finished.", key);
+            }
+          });
+    } catch (final RuntimeException | Error e) {
+      closeIsolatedApplications();
+      throw e;
+    }
 
     // Your "before all tests" startup logic goes here
     // The following line registers a callback hook when the root test context is shut down
-    final String key = "RDBMS DB - Multiple Database Tests";
-    context.getRoot().getStore(GLOBAL).put(key, this);
+    if (shared) {
+      final String key = "RDBMS DB - Multiple Database Tests";
+      context.getRoot().getStore(GLOBAL).put(key, this);
+    }
   }
 
   private TestTemplateInvocationContext invocationContext(final String standaloneCamundaKey) {
@@ -178,14 +208,60 @@ public class CamundaRdbmsInvocationContextProviderExtension
 
         return List.of(
             new CamundaDatabaseTestApplicationResolver(
-                standaloneCamundaKey, SUPPORTED_TEST_APPLICATIONS.get(standaloneCamundaKey)));
+                standaloneCamundaKey, testApplications.get(standaloneCamundaKey), shared));
       }
     };
   }
 
   @Override
-  public void close() {
-    LOGGER.info("Resource closed - Close CamundaRdbmsInvocationContextProviderExtension");
+  public void afterAll(final ExtensionContext context) {
+    closeIsolatedApplications();
+  }
+
+  private void closeIsolatedApplications() {
+    if (!shared) {
+      useTestApplications.forEach(
+          key -> {
+            try {
+              testApplications.get(key).close();
+            } catch (final Exception e) {
+              LOGGER.warn("Failed to close isolated RDBMS test application '{}'.", key, e);
+            }
+          });
+    }
+  }
+
+  private static Set<String> defaultTestApplications() {
+    return Set.of(
+        "camundaWithH2",
+        "camundaWithPostgresSQL",
+        "camundaWithMariaDB",
+        "camundaWithMySQL",
+        "camundaWithOracleDB",
+        "camundaWithMssqlDB");
+  }
+
+  private static CamundaRdbmsTestApplication createTestApplication(final String key) {
+    return switch (key) {
+      case "camundaWithH2" ->
+          createCamundaRdbmsTestApplication().withH2("isolated-" + UUID.randomUUID());
+      case "camundaWithPostgresSQL" ->
+          createCamundaRdbmsTestApplication()
+              .withDatabaseContainer(createDefaultPostgresContainer());
+      case "camundaWithMariaDB" ->
+          createCamundaRdbmsTestApplication()
+              .withDatabaseContainer(createDefaultMariaDBContainer());
+      case "camundaWithMySQL" ->
+          createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultMySQLContainer());
+      case "camundaWithOracleDB" ->
+          createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultOracleContainer());
+      case "camundaWithMssqlDB" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> c.getData().getSecondaryStorage().getRdbms().setUsername("sa"))
+              .withDatabaseContainer(createDefaultMSSQLServerContainer());
+      default -> throw new IllegalArgumentException("Unknown RDBMS test application: " + key);
+    };
   }
 
   private static CamundaRdbmsTestApplication createCamundaRdbmsTestApplication() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
@@ -34,77 +34,10 @@ public class CamundaRdbmsInvocationContextProviderExtension
   private static final Map<String, CamundaRdbmsTestApplication> SUPPORTED_TEST_APPLICATIONS;
 
   static {
-    final Map<String, CamundaRdbmsTestApplication> applications = new java.util.HashMap<>();
-    applications.put("camundaWithH2", createCamundaRdbmsTestApplication().withH2());
-    applications.put(
-        "camundaWithPostgresSQL",
-        createCamundaRdbmsTestApplication()
-            .withDatabaseContainer(createDefaultPostgresContainer()));
-    applications.put(
-        "camundaWithPostgresReplicationCluster",
-        createCamundaRdbmsTestApplication()
-            .withUnifiedConfig(
-                c -> {
-                  final var rdbms = c.getData().getSecondaryStorage().getRdbms();
-                  rdbms.getAsyncReplication().setEnabled(true);
-                  rdbms.getAsyncReplication().setMinSyncReplicas(1);
-                })
-            .withDatabaseContainer(new PostgresReplicationClusterContainer()));
-    applications.put(
-        "camundaWithManualPostgresSQL",
-        createCamundaRdbmsTestApplication()
-            .withUnifiedConfig(c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
-            .withDatabaseContainer(createManualPostgresContainer()));
-    applications.put(
-        "camundaWithMariaDB",
-        createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultMariaDBContainer()));
-    applications.put(
-        "camundaWithManualMariaDB",
-        createCamundaRdbmsTestApplication()
-            .withUnifiedConfig(c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
-            .withDatabaseContainer(createManualMariaDBContainer()));
-    applications.put(
-        "camundaWithMySQL",
-        createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultMySQLContainer()));
-    applications.put(
-        "camundaWithManualMySQL",
-        createCamundaRdbmsTestApplication()
-            .withUnifiedConfig(c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
-            .withDatabaseContainer(createManualMySQLContainer()));
-    applications.put(
-        "camundaWithOracleDB",
-        createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultOracleContainer()));
-    applications.put(
-        "camundaWithManualOracleDB",
-        createCamundaRdbmsTestApplication()
-            .withUnifiedConfig(c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
-            .withDatabaseContainer(createManualOracleContainer()));
-    applications.put(
-        "camundaWithMssqlDB",
-        createCamundaRdbmsTestApplication()
-            .withUnifiedConfig(
-                c -> {
-                  c.getData().getSecondaryStorage().getRdbms().setUsername("sa");
-                })
-            .withDatabaseContainer(createDefaultMSSQLServerContainer()));
-    applications.put(
-        "camundaWithMssqlReplicationCluster",
-        new CamundaRdbmsTestApplication(RdbmsTestConfiguration.class)
-            .withRdbms()
-            .withUnifiedConfig(
-                c -> {
-                  c.getData().getSecondaryStorage().getRdbms().setUsername("sa");
-                  final var rdbms = c.getData().getSecondaryStorage().getRdbms();
-                  rdbms.getAsyncReplication().setEnabled(true);
-                  rdbms.getAsyncReplication().setMinSyncReplicas(1);
-                })
-            .withDatabaseContainer(new MSSQLReplicationClusterContainer()));
-    applications.put(
-        "camundaWithManualMssqlDB",
-        createCamundaRdbmsTestApplication()
-            .withUnifiedConfig(c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
-            .withDatabaseContainer(createManualMSSQLServerContainer()));
-    SUPPORTED_TEST_APPLICATIONS = Map.copyOf(applications);
+    SUPPORTED_TEST_APPLICATIONS =
+        allTestApplications().stream()
+            .collect(
+                Collectors.toUnmodifiableMap(key -> key, key -> createTestApplication(key, false)));
   }
 
   private final Set<String> useTestApplications;
@@ -153,9 +86,7 @@ public class CamundaRdbmsInvocationContextProviderExtension
         keys,
         keys.stream()
             .collect(
-                Collectors.toUnmodifiableMap(
-                    key -> key,
-                    CamundaRdbmsInvocationContextProviderExtension::createTestApplication)),
+                Collectors.toUnmodifiableMap(key -> key, key -> createTestApplication(key, true))),
         false);
   }
 
@@ -241,25 +172,89 @@ public class CamundaRdbmsInvocationContextProviderExtension
         "camundaWithMssqlDB");
   }
 
-  private static CamundaRdbmsTestApplication createTestApplication(final String key) {
+  private static Set<String> allTestApplications() {
+    return Set.of(
+        "camundaWithH2",
+        "camundaWithPostgresSQL",
+        "camundaWithPostgresReplicationCluster",
+        "camundaWithManualPostgresSQL",
+        "camundaWithMariaDB",
+        "camundaWithManualMariaDB",
+        "camundaWithMySQL",
+        "camundaWithManualMySQL",
+        "camundaWithOracleDB",
+        "camundaWithManualOracleDB",
+        "camundaWithMssqlDB",
+        "camundaWithMssqlReplicationCluster",
+        "camundaWithManualMssqlDB");
+  }
+
+  private static CamundaRdbmsTestApplication createTestApplication(
+      final String key, final boolean isolated) {
     return switch (key) {
       case "camundaWithH2" ->
-          createCamundaRdbmsTestApplication().withH2("isolated-" + UUID.randomUUID());
+          isolated
+              ? createCamundaRdbmsTestApplication().withIsolatedH2("isolated-" + UUID.randomUUID())
+              : createCamundaRdbmsTestApplication().withH2();
       case "camundaWithPostgresSQL" ->
           createCamundaRdbmsTestApplication()
               .withDatabaseContainer(createDefaultPostgresContainer());
+      case "camundaWithPostgresReplicationCluster" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> {
+                    final var rdbms = c.getData().getSecondaryStorage().getRdbms();
+                    rdbms.getAsyncReplication().setEnabled(true);
+                    rdbms.getAsyncReplication().setMinSyncReplicas(1);
+                  })
+              .withDatabaseContainer(new PostgresReplicationClusterContainer());
+      case "camundaWithManualPostgresSQL" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
+              .withDatabaseContainer(createManualPostgresContainer());
       case "camundaWithMariaDB" ->
           createCamundaRdbmsTestApplication()
               .withDatabaseContainer(createDefaultMariaDBContainer());
+      case "camundaWithManualMariaDB" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
+              .withDatabaseContainer(createManualMariaDBContainer());
       case "camundaWithMySQL" ->
           createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultMySQLContainer());
+      case "camundaWithManualMySQL" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
+              .withDatabaseContainer(createManualMySQLContainer());
       case "camundaWithOracleDB" ->
           createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultOracleContainer());
+      case "camundaWithManualOracleDB" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
+              .withDatabaseContainer(createManualOracleContainer());
       case "camundaWithMssqlDB" ->
           createCamundaRdbmsTestApplication()
               .withUnifiedConfig(
                   c -> c.getData().getSecondaryStorage().getRdbms().setUsername("sa"))
               .withDatabaseContainer(createDefaultMSSQLServerContainer());
+      case "camundaWithMssqlReplicationCluster" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> {
+                    final var rdbms = c.getData().getSecondaryStorage().getRdbms();
+                    rdbms.setUsername("sa");
+                    rdbms.getAsyncReplication().setEnabled(true);
+                    rdbms.getAsyncReplication().setMinSyncReplicas(1);
+                  })
+              .withDatabaseContainer(new MSSQLReplicationClusterContainer());
+      case "camundaWithManualMssqlDB" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> c.getData().getSecondaryStorage().getRdbms().setAutoDdl(false))
+              .withDatabaseContainer(createManualMSSQLServerContainer());
       default -> throw new IllegalArgumentException("Unknown RDBMS test application: " + key);
     };
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -50,9 +50,13 @@ public final class CamundaRdbmsTestApplication
   }
 
   public CamundaRdbmsTestApplication withH2() {
+    return withH2("testdb");
+  }
+
+  public CamundaRdbmsTestApplication withH2(final String databaseName) {
     setSecondaryStorageToRdbms();
     final var rdbms = unifiedConfig.getData().getSecondaryStorage().getRdbms();
-    rdbms.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
+    rdbms.setUrl("jdbc:h2:mem:" + databaseName + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
     rdbms.setUsername("sa");
     rdbms.setPassword("");
     return this;
@@ -107,10 +111,13 @@ public final class CamundaRdbmsTestApplication
   @Override
   public void close() {
     LOGGER.info("Resource closed - Stop spring application ...");
-    super.stop();
-    if (databaseContainer != null) {
-      LOGGER.info("Stop database container '{}'...", databaseContainer.getContainerInfo());
-      databaseContainer.close();
+    try {
+      super.stop();
+    } finally {
+      if (databaseContainer != null) {
+        LOGGER.info("Stop database container '{}'...", databaseContainer.getContainerInfo());
+        databaseContainer.close();
+      }
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -92,11 +92,12 @@ public final class CamundaRdbmsTestApplication
       }
     }
 
-    LOGGER.info("Start spring application ...");
-    super.start();
-    Awaitility.await("until spring context is started").until(this::isStarted);
-    LOGGER.info("Spring application started");
-    return this;
+    return startSpringApplication();
+  }
+
+  public CamundaRdbmsTestApplication restart() {
+    super.stop();
+    return startSpringApplication();
   }
 
   @Override
@@ -147,6 +148,14 @@ public final class CamundaRdbmsTestApplication
     }
     return super.bean(RdbmsServiceFactory.class)
         .createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID, new SimpleMeterRegistry());
+  }
+
+  private CamundaRdbmsTestApplication startSpringApplication() {
+    LOGGER.info("Start spring application ...");
+    super.start();
+    Awaitility.await("until spring context is started").until(this::isStarted);
+    LOGGER.info("Spring application started");
+    return this;
   }
 
   private void setSecondaryStorageToRdbms() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -17,6 +17,8 @@ import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.util.Map;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
@@ -31,6 +33,7 @@ public final class CamundaRdbmsTestApplication
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaRdbmsTestApplication.class);
 
   private GenericContainer<?> databaseContainer;
+  private String isolatedH2Url;
 
   public CamundaRdbmsTestApplication(final Class<?>... springConfigurations) {
     super(springConfigurations);
@@ -50,10 +53,16 @@ public final class CamundaRdbmsTestApplication
   }
 
   public CamundaRdbmsTestApplication withH2() {
-    return withH2("testdb");
+    return configureH2("testdb");
   }
 
-  public CamundaRdbmsTestApplication withH2(final String databaseName) {
+  public CamundaRdbmsTestApplication withIsolatedH2(final String databaseName) {
+    final var application = configureH2(databaseName);
+    isolatedH2Url = application.unifiedConfig.getData().getSecondaryStorage().getRdbms().getUrl();
+    return application;
+  }
+
+  private CamundaRdbmsTestApplication configureH2(final String databaseName) {
     setSecondaryStorageToRdbms();
     final var rdbms = unifiedConfig.getData().getSecondaryStorage().getRdbms();
     rdbms.setUrl("jdbc:h2:mem:" + databaseName + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
@@ -115,9 +124,13 @@ public final class CamundaRdbmsTestApplication
     try {
       super.stop();
     } finally {
-      if (databaseContainer != null) {
-        LOGGER.info("Stop database container '{}'...", databaseContainer.getContainerInfo());
-        databaseContainer.close();
+      try {
+        shutdownIsolatedH2();
+      } finally {
+        if (databaseContainer != null) {
+          LOGGER.info("Stop database container '{}'...", databaseContainer.getContainerInfo());
+          databaseContainer.close();
+        }
       }
     }
   }
@@ -156,6 +169,18 @@ public final class CamundaRdbmsTestApplication
     Awaitility.await("until spring context is started").until(this::isStarted);
     LOGGER.info("Spring application started");
     return this;
+  }
+
+  private void shutdownIsolatedH2() {
+    if (isolatedH2Url == null) {
+      return;
+    }
+    try (final var connection = DriverManager.getConnection(isolatedH2Url, "sa", "");
+        final var statement = connection.createStatement()) {
+      statement.execute("SHUTDOWN");
+    } catch (final SQLException e) {
+      throw new IllegalStateException("Failed to shut down isolated H2 database", e);
+    }
   }
 
   private void setSecondaryStorageToRdbms() {


### PR DESCRIPTION
## Description

The multi-vendor RDBMS test extension currently stores six mutable `CamundaRdbmsTestApplication` instances in JUnit's root context and shares them across the entire test run. This is fast for ordinary data-layer tests, but unsafe for tests that change schema metadata: their result can depend on which unrelated class used or purged the shared database first.

Add an opt-in class-scoped mode to the existing extension. Isolated tests receive fresh vendor applications and databases, do not enter them in the global JUnit store, and close them after the class. H2 gets a unique in-memory database name and is explicitly shut down during teardown.

`RdbmsSchemaVersionStoreIT` opts into this mode and runs its schema-mutating template invocations on one thread. Existing RDBMS tests continue using the shared fixtures, so the broader suite does not pay the cost of creating six containers per class.

Shared and isolated modes use one vendor application factory to prevent their configurations from drifting. Isolated teardown attempts every cleanup and reports aggregated failures instead of leaving leaked containers behind a green result.

### Explicit purge/restart coverage

The original failure exposed a real product interaction between history purge and schema-version validation, but only accidentally through test order. This draft now covers that interaction directly for every supported vendor:

1. Start and migrate a class-owned database.
2. Read the recorded schema version.
3. Invoke the real `RdbmsPurger`.
4. Verify the exact schema-version row remains.
5. Stop only the Spring application, retaining the same database/container.
6. Restart the application against that database.
7. Verify startup succeeds and the exact schema version remains unchanged.

This PR is stacked on #62364 because the restart scenario requires that production fix. #62364 preserves `RDBMS_SCHEMA_VERSION`; this draft removes accidental cross-class coupling and makes the purge/restart contract explicit.

## Verification

- `./mvnw -B -T1C -DforkCount=1 -DskipUTs -DskipChecks -Dit.test=RdbmsSchemaVersionStoreIT -P rdbms -pl qa/acceptance-tests verify` (18 tests, all six vendors)
- `./mvnw -B -T1C -DforkCount=1 -DskipUTs -DskipChecks -Dit.test=RdbmsSchemaVersionStoreIT,SequenceFlowIT -P rdbms -pl qa/acceptance-tests verify` (isolated and shared modes together)
- `./mvnw install -Dquickly -T1C`

## Related issues

- [x] This PR does not need a linked issue