### PR TITLE
deps: pin preview-env/clean to released fix for PR-JSON word splitting

### DIFF
--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -50,7 +50,7 @@ jobs:
         vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
         vault-url: ${{ secrets.VAULT_ADDR }}
 
-    - uses: camunda/infra-global-github-actions/preview-env/clean@67d00e9260887361a31f6446252fffbecae4a02e # preview-env-1.0.12
+    - uses: camunda/infra-global-github-actions/preview-env/clean@50d6a648396f9cf5af51212986d9baa83f8c0129 # preview-env-1.0.13
       with:
         labels: deploy-preview
         pull-request: ${{ inputs.pull-request }}


### PR DESCRIPTION
## Summary

- `preview-env-clean.yml`'s scheduled runs have been failing since 2026-08-31 with a jq parse error: the clean job's PR-list JSON gets shattered by shell word splitting before `jq` can parse it.
- Fixed upstream in camunda/infra-global-github-actions#808 and released as `preview-env-1.0.13`.
- Bumps the `preview-env/clean` pin from `preview-env-1.0.12` to `preview-env-1.0.13` so the fix goes live. No other changes.

## Related issues

- [x] This PR does not need a linked issue

## Test plan

- [x] Diff limited to the single SHA/version-comment pin bump, verified against main
- [x] Confirmed `preview-env-1.0.13`'s tag commit contains infra-global-github-actions#808 (`git merge-base --is-ancestor`)
- [x] Watch next scheduled `preview-env-clean` run (06:00/22:00 UTC) for green