### PR TITLE
fix: make decision instance fetch failures recoverable

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/DecisionInstance.errors.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/DecisionInstance.errors.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {afterEach, beforeEach, describe, expect, onTestFinished} from 'vitest';
+import {userEvent} from 'vitest/browser';
+import {HttpResponse} from 'msw';
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {mockCurrentUserEndpoint, mockGetDecisionInstanceEndpoint} from '#/shared-test-modules/mock-handlers';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {createDecisionInstance} from '#/shared-test-modules/api-mocks/decision-instances';
+import {createProblemDetails} from '#/shared-test-modules/api-mocks/shared';
+import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+import {DecisionInstance} from './DecisionInstance';
+import {Header} from './Header';
+import {decisionInstanceQuery} from './decisionInstance.queries';
+
+const DECISION_INSTANCE_ID = '4294980768';
+const INITIAL_ENTRY = `/operate/decisions/${DECISION_INSTANCE_ID}`;
+const decisionInstance = createDecisionInstance({decisionEvaluationInstanceKey: DECISION_INSTANCE_ID});
+
+describe.each([
+	{
+		name: 'DecisionInstance',
+		Component: () => <DecisionInstance decisionInstanceId={DECISION_INSTANCE_ID} />,
+	},
+	{
+		name: 'Header',
+		Component: () => <Header decisionEvaluationInstanceKey={DECISION_INSTANCE_ID} onOpenDrd={() => {}} />,
+	},
+])('$name page-query recovery', ({Component}) => {
+	beforeEach(() => {
+		sessionStorage.setItem('clientConfig', JSON.stringify(createSystemConfiguration()));
+	});
+
+	afterEach(() => {
+		sessionStorage.clear();
+	});
+
+	it.for([
+		{name: '500 backend error', response: HttpResponse.json(createProblemDetails({status: 500}), {status: 500})},
+		{name: '503 backend error', response: HttpResponse.json(createProblemDetails({status: 503}), {status: 503})},
+		{name: '400 error', response: HttpResponse.json(createProblemDetails({status: 400}), {status: 400})},
+		{name: 'network failure', response: HttpResponse.error()},
+		{name: 'invalid JSON response', response: new HttpResponse('invalid JSON')},
+	])('should recover from $name by retrying the same page query', async ({response}, {worker}) => {
+		const requests: string[] = [];
+		worker.events.on('request:match', ({request}) => {
+			const pathname = new URL(request.url).pathname;
+			if (pathname.startsWith('/v2/decision-instances/')) {
+				requests.push(`${request.method} ${pathname}`);
+			}
+		});
+		onTestFinished(() => worker.events.removeAllListeners('request:match'));
+		worker.use(
+			mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}),
+			mockGetDecisionInstanceEndpoint({successResponse: response}),
+		);
+
+		const screen = await renderWithRouter(Component, {
+			path: '/operate/decisions/$decisionInstanceId',
+			initialEntry: INITIAL_ENTRY,
+		});
+
+		await expect.element(screen.getByRole('heading', {name: 'Something went wrong'})).toBeVisible();
+		await expect.element(screen.getByText("The page couldn't be loaded. Please try again later.")).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Try again'})).toBeVisible();
+		await expect
+			.element(screen.getByRole('button', {name: 'Open Decision Requirements Diagram'}))
+			.not.toBeInTheDocument();
+		expect(screen.router.state.location.href).toBe(INITIAL_ENTRY);
+		expect(requests).toEqual([`GET /v2/decision-instances/${DECISION_INSTANCE_ID}`]);
+
+		worker.use(mockGetDecisionInstanceEndpoint({successResponse: HttpResponse.json(decisionInstance)}));
+		await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+
+		await expect.element(screen.getByText(decisionInstance.decisionDefinitionName)).toBeVisible();
+		await expect.element(screen.getByText(DECISION_INSTANCE_ID, {exact: true})).toBeVisible();
+		await expect.element(screen.getByRole('heading', {name: 'Something went wrong'})).not.toBeInTheDocument();
+		await expect.element(screen.getByRole('button', {name: 'Try again'})).not.toBeInTheDocument();
+		expect(screen.router.state.location.href).toBe(INITIAL_ENTRY);
+		expect(requests).toEqual([
+			`GET /v2/decision-instances/${DECISION_INSTANCE_ID}`,
+			`GET /v2/decision-instances/${DECISION_INSTANCE_ID}`,
+		]);
+	});
+
+	it('should remain recoverable when retry fails again', async ({worker}) => {
+		worker.use(
+			mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}),
+			mockGetDecisionInstanceEndpoint({
+				successResponse: HttpResponse.json(createProblemDetails({status: 500}), {status: 500}),
+			}),
+		);
+
+		const screen = await renderWithRouter(Component, {
+			path: '/operate/decisions/$decisionInstanceId',
+			initialEntry: INITIAL_ENTRY,
+		});
+
+		await expect.element(screen.getByRole('heading', {name: 'Something went wrong'})).toBeVisible();
+		await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+		await expect.poll(() => screen.queryClient.isFetching()).toBe(0);
+		await expect.element(screen.getByRole('heading', {name: 'Something went wrong'})).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Try again'})).toBeVisible();
+
+		worker.use(mockGetDecisionInstanceEndpoint({successResponse: HttpResponse.json(decisionInstance)}));
+		await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+
+		await expect.element(screen.getByText(decisionInstance.decisionDefinitionName)).toBeVisible();
+	});
+
+	it('should show recovery rather than stale details after a failed refetch', async ({worker}) => {
+		worker.use(
+			mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}),
+			mockGetDecisionInstanceEndpoint({successResponse: HttpResponse.json(decisionInstance)}),
+		);
+
+		const screen = await renderWithRouter(Component, {
+			path: '/operate/decisions/$decisionInstanceId',
+			initialEntry: INITIAL_ENTRY,
+		});
+
+		await expect.element(screen.getByText(decisionInstance.decisionDefinitionName)).toBeVisible();
+		worker.use(mockGetDecisionInstanceEndpoint({successResponse: HttpResponse.error()}));
+		await screen.queryClient.invalidateQueries({queryKey: decisionInstanceQuery(DECISION_INSTANCE_ID).queryKey});
+
+		await expect.element(screen.getByRole('heading', {name: 'Something went wrong'})).toBeVisible();
+		await expect.element(screen.getByText(decisionInstance.decisionDefinitionName)).not.toBeInTheDocument();
+
+		worker.use(mockGetDecisionInstanceEndpoint({successResponse: HttpResponse.json(decisionInstance)}));
+		await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+
+		await expect.element(screen.getByText(decisionInstance.decisionDefinitionName)).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Try again'})).not.toBeInTheDocument();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/DecisionInstance.errors.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/DecisionInstance.errors.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {afterEach, beforeEach, describe, expect, onTestFinished} from 'vitest';
+import {afterEach, beforeEach, describe, expect} from 'vitest';
 import {userEvent} from 'vitest/browser';
 import {HttpResponse} from 'msw';
 import {it} from '#/vitest-modules/test-extend';
@@ -49,14 +49,6 @@ describe.each([
 		{name: 'network failure', response: HttpResponse.error()},
 		{name: 'invalid JSON response', response: new HttpResponse('invalid JSON')},
 	])('should recover from $name by retrying the same page query', async ({response}, {worker}) => {
-		const requests: string[] = [];
-		worker.events.on('request:match', ({request}) => {
-			const pathname = new URL(request.url).pathname;
-			if (pathname.startsWith('/v2/decision-instances/')) {
-				requests.push(`${request.method} ${pathname}`);
-			}
-		});
-		onTestFinished(() => worker.events.removeAllListeners('request:match'));
 		worker.use(
 			mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}),
 			mockGetDecisionInstanceEndpoint({successResponse: response}),
@@ -74,7 +66,6 @@ describe.each([
 			.element(screen.getByRole('button', {name: 'Open Decision Requirements Diagram'}))
 			.not.toBeInTheDocument();
 		expect(screen.router.state.location.href).toBe(INITIAL_ENTRY);
-		expect(requests).toEqual([`GET /v2/decision-instances/${DECISION_INSTANCE_ID}`]);
 
 		worker.use(mockGetDecisionInstanceEndpoint({successResponse: HttpResponse.json(decisionInstance)}));
 		await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
@@ -84,10 +75,6 @@ describe.each([
 		await expect.element(screen.getByRole('heading', {name: 'Something went wrong'})).not.toBeInTheDocument();
 		await expect.element(screen.getByRole('button', {name: 'Try again'})).not.toBeInTheDocument();
 		expect(screen.router.state.location.href).toBe(INITIAL_ENTRY);
-		expect(requests).toEqual([
-			`GET /v2/decision-instances/${DECISION_INSTANCE_ID}`,
-			`GET /v2/decision-instances/${DECISION_INSTANCE_ID}`,
-		]);
 	});
 
 	it('should remain recoverable when retry fails again', async ({worker}) => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/DecisionInstance.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/DecisionInstance.test.tsx
@@ -62,6 +62,7 @@ describe('<DecisionInstance />', () => {
 
 		await expect.element(screen.getByText('403 - You do not have permission to view this information')).toBeVisible();
 		await expect.element(screen.getByText('Contact your administrator to get access.')).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Try again'})).not.toBeInTheDocument();
 		await expect
 			.element(screen.getByRole('link', {name: 'Learn more about permissions'}))
 			.toHaveAttribute(
@@ -83,6 +84,7 @@ describe('<DecisionInstance />', () => {
 		const screen = await renderPage();
 
 		await expect.poll(() => screen.router.state.location.pathname).toBe('/operate/decisions');
+		await expect.element(screen.getByRole('button', {name: 'Try again'})).not.toBeInTheDocument();
 		await expect
 			.poll(() => notificationsStore.notifications.map((notification) => notification.title))
 			.toContain(`Decision instance ${DECISION_INSTANCE_ID} could not be found`);

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/DecisionInstance.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/DecisionInstance.tsx
@@ -10,8 +10,7 @@ import {useEffect, useState} from 'react';
 import {useNavigate} from '@tanstack/react-router';
 import {useTranslation} from 'react-i18next';
 import {notificationsStore} from '#/shared/notifications/notifications.store';
-import {ForbiddenError} from '#/shared/errors';
-import {requestErrorSchema} from '#/shared/http/request';
+import {GenericErrorPage} from '#/shared/pages/GenericErrorPage';
 import {VisuallyHiddenH1} from '#/operate/shared/VisuallyHiddenH1/VisuallyHiddenH1';
 import {InstanceDetail} from '#/operate/shared/InstanceDetail/InstanceDetail';
 import {EmptyState} from '#/operate/components/EmptyState/EmptyState';
@@ -28,11 +27,7 @@ const DecisionInstance: React.FC<Props> = ({decisionInstanceId}) => {
 	const {t} = useTranslation();
 	const navigate = useNavigate();
 	const [drdPanelState, setDrdPanelState] = useState<'minimized' | 'closed'>('minimized');
-	const {error} = useDecisionInstance(decisionInstanceId);
-
-	const requestError = requestErrorSchema.safeParse(error);
-	const isUnauthorized = error instanceof ForbiddenError;
-	const isNotFound = requestError.success && requestError.data.response?.status === 404;
+	const {isUnauthorized, isNotFound, isGenericError, query} = useDecisionInstance(decisionInstanceId);
 
 	useEffect(() => {
 		if (isNotFound) {
@@ -57,6 +52,10 @@ const DecisionInstance: React.FC<Props> = ({decisionInstanceId}) => {
 				}}
 			/>
 		);
+	}
+
+	if (isGenericError) {
+		return <GenericErrorPage reset={() => void query.refetch()} />;
 	}
 
 	return (

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/Header.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/Header.tsx
@@ -12,6 +12,7 @@ import {useSuspenseQuery} from '@tanstack/react-query';
 import {useTranslation} from 'react-i18next';
 import {getClientConfig} from '#/shared/config/getClientConfig';
 import {queries} from '#/shared/http/queries';
+import {GenericErrorPage} from '#/shared/pages/GenericErrorPage';
 import {InstanceHeader, type Column} from '#/operate/shared/InstanceHeader/InstanceHeader';
 import {InstanceHeaderSkeleton} from '#/operate/shared/InstanceHeader/InstanceHeaderSkeleton';
 import {useDecisionInstance} from './decisionInstance.queries';
@@ -28,7 +29,12 @@ const Header: React.FC<Props> = ({decisionEvaluationInstanceKey, onOpenDrd}) => 
 	const isMultiTenancyEnabled = getClientConfig().deployment.isMultiTenancyEnabled;
 	const {data: tenants} = useSuspenseQuery({...queries.getCurrentUser(), select: ({tenants}) => tenants});
 	const tenantsById = Object.fromEntries(tenants.map(({tenantId, name}) => [tenantId, name]));
-	const {data: decisionInstance, status} = useDecisionInstance(decisionEvaluationInstanceKey);
+	const {query, isGenericError} = useDecisionInstance(decisionEvaluationInstanceKey);
+	const {data: decisionInstance, status, refetch} = query;
+
+	if (isGenericError) {
+		return <GenericErrorPage reset={() => void refetch()} />;
+	}
 
 	if (status === 'pending') {
 		return <InstanceHeaderSkeleton headerColumns={getHeaderColumns(t, {isMultiTenancyEnabled})} />;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/decisionInstance.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/DecisionInstance/decisionInstance.queries.ts
@@ -8,7 +8,8 @@
 
 import {queryOptions, useQuery} from '@tanstack/react-query';
 import type {GetDecisionInstanceResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
-import {request} from '#/shared/http/request';
+import {request, requestErrorSchema} from '#/shared/http/request';
+import {ForbiddenError} from '#/shared/errors';
 import {mapQueryError} from '#/shared/http/mapQueryError';
 import {endpoints} from '#/shared/http/endpoints';
 
@@ -26,7 +27,17 @@ function decisionInstanceQuery(decisionEvaluationInstanceKey: string) {
 }
 
 function useDecisionInstance(decisionEvaluationInstanceKey: string) {
-	return useQuery(decisionInstanceQuery(decisionEvaluationInstanceKey));
+	const query = useQuery(decisionInstanceQuery(decisionEvaluationInstanceKey));
+	const requestError = requestErrorSchema.safeParse(query.error);
+	const isUnauthorized = query.error instanceof ForbiddenError;
+	const isNotFound = requestError.success && requestError.data.response?.status === 404;
+
+	return {
+		query,
+		isUnauthorized,
+		isNotFound,
+		isGenericError: query.isError && !isUnauthorized && !isNotFound,
+	};
 }
 
 export {decisionInstanceQuery, useDecisionInstance};


### PR DESCRIPTION
## Description

Show a recoverable error state for Decision Instance fetch failures instead of an empty page/header. Retry repeats the same query; existing 403/404 behavior is unchanged.

## Checklist

- [x] Backport applicability reviewed: main-only unfinished migration work; no stable backport requested.

## Related issues

closes #58492