### PR TITLE
Enforce jobKey/jobLease requiredness on agent-instance UPDATE

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -60,6 +60,10 @@ public class AgentInstanceRequestValidator {
             validatePositiveKeyFormat(request.getJobKey(), "jobKey", violations);
           }
 
+          if (request.getJobLease() == null || request.getJobLease().isBlank()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobLease"));
+          }
+
           final var history = request.getHistory();
 
           if (history == null || history.isEmpty()) {
@@ -93,15 +97,17 @@ public class AgentInstanceRequestValidator {
             validateKeyFormat(request.getElementInstanceKey(), "elementInstanceKey", violations);
           }
 
-          if (request.getJobKey() != null) {
+          if (request.getJobKey() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobKey"));
+          } else {
             validatePositiveKeyFormat(request.getJobKey(), "jobKey", violations);
           }
 
-          if (request.getHistory() != null && !request.getHistory().isEmpty()) {
-            if (request.getJobKey() == null) {
-              violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobKey"));
-            }
+          if (request.getJobLease() == null || request.getJobLease().isBlank()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobLease"));
+          }
 
+          if (request.getHistory() != null && !request.getHistory().isEmpty()) {
             for (int i = 0; i < request.getHistory().size(); i++) {
               validateHistoryItem(i, request.getHistory().get(i), violations);
             }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -77,9 +77,8 @@ class AgentInstanceRequestValidatorTest {
     }
 
     @Test
-    @DisplayName(
-        "Should accept a missing jobKey when no history is provided (enforcement deferred to #60864)")
-    void shouldAcceptMissingJobKeyOnUpdateForNow() {
+    @DisplayName("Should reject missing jobKey even when no history is provided")
+    void shouldRejectMissingJobKeyOnUpdate() {
       final var request =
           AgentInstanceUpdateRequest.Builder.create()
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
@@ -90,7 +89,42 @@ class AgentInstanceRequestValidatorTest {
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
 
-      assertThat(result).isEmpty();
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No jobKey provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject missing (null) jobLease")
+    void shouldRejectNullJobLeaseOnUpdate() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .jobKey(JOB_KEY)
+              .jobLease(null)
+              .build();
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No jobLease provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject blank jobLease")
+    void shouldRejectBlankJobLeaseOnUpdate() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .jobKey(JOB_KEY)
+              .jobLease("   ")
+              .build();
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No jobLease provided.");
     }
   }
 
@@ -1269,6 +1303,40 @@ class AgentInstanceRequestValidatorTest {
           .isEqualTo(
               "The provided jobKey 'not-a-number' is not a valid key. Expected a numeric value."
                   + " Did you pass an entity id instead of an entity key?.");
+    }
+
+    @Test
+    @DisplayName("Should reject missing (null) jobLease on create")
+    void shouldRejectNullJobLeaseOnCreate() {
+      final var request =
+          AgentInstanceCreationRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .jobKey(JOB_KEY)
+              .jobLease(null)
+              .history(validRequest(JOB_KEY).getHistory())
+              .build();
+
+      final Optional<ProblemDetail> result = validator.validateCreateRequest(request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No jobLease provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject blank jobLease on create")
+    void shouldRejectBlankJobLeaseOnCreate() {
+      final var request =
+          AgentInstanceCreationRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .jobKey(JOB_KEY)
+              .jobLease("   ")
+              .history(validRequest(JOB_KEY).getHistory())
+              .build();
+
+      final Optional<ProblemDetail> result = validator.validateCreateRequest(request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No jobLease provided.");
     }
 
     @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -111,6 +111,7 @@ class AgentInstanceAuthorizationIT {
   private static long elementInstanceKey3;
   private static long jobKey1;
   private static long jobKey3;
+  private static String jobLease3;
 
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
@@ -125,7 +126,7 @@ class AgentInstanceAuthorizationIT {
         .newUpdateAgentInstanceCommand(agentInstanceKey1)
         .elementInstanceKey(elementInstanceKey1)
         .jobKey(jobKey1)
-        .jobLease("test-job-lease")
+        .jobLease(result1.jobLease())
         .history(
             List.of(
                 new AgentInstanceHistoryItem()
@@ -145,6 +146,7 @@ class AgentInstanceAuthorizationIT {
     agentInstanceKey3 = result3.agentInstanceKey();
     elementInstanceKey3 = result3.elementInstanceKey();
     jobKey3 = result3.jobKey();
+    jobLease3 = result3.jobLease();
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey1);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey2);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey3);
@@ -317,7 +319,7 @@ class AgentInstanceAuthorizationIT {
                     .newUpdateAgentInstanceCommand(agentInstanceKey3)
                     .elementInstanceKey(elementInstanceKey3)
                     .jobKey(jobKey3)
-                    .jobLease("test-job-lease")
+                    .jobLease(jobLease3)
                     .execute());
   }
 
@@ -363,7 +365,7 @@ class AgentInstanceAuthorizationIT {
                     .newUpdateAgentInstanceCommand(agentInstanceKey3)
                     .elementInstanceKey(elementInstanceKey3)
                     .jobKey(jobKey3)
-                    .jobLease("test-job-lease")
+                    .jobLease(jobLease3)
                     .history(
                         List.of(
                             new AgentInstanceHistoryItem()
@@ -455,20 +457,21 @@ class AgentInstanceAuthorizationIT {
         .as("expected to activate one agent job for process instance %d", processInstanceKey)
         .isNotEmpty();
     final long jobKey = activatedJobs.get(0).getKey();
+    final String jobLease = activatedJobs.get(0).getLeaseToken();
 
     final var agentInstanceKey =
         adminClient
             .newCreateAgentInstanceCommand()
             .elementInstanceKey(elementInstanceKey)
             .jobKey(jobKey)
-            .jobLease("test-job-lease")
+            .jobLease(jobLease)
             .history(
                 List.of(
                     configurationHistoryItem("gpt-4o", "openai", "You are a helpful assistant.")))
             .execute()
             .getAgentInstanceKey();
 
-    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey, jobKey);
+    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey, jobKey, jobLease);
   }
 
   private static AgentInstanceHistoryItem configurationHistoryItem(
@@ -485,5 +488,5 @@ class AgentInstanceAuthorizationIT {
   }
 
   private record AgentInstanceCreationResult(
-      long agentInstanceKey, long elementInstanceKey, long jobKey) {}
+      long agentInstanceKey, long elementInstanceKey, long jobKey, String jobLease) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -450,6 +450,7 @@ class AgentInstanceAuthorizationIT {
             .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .timeout(Duration.ofMinutes(5))
+            .withLease(true)
             .send()
             .join()
             .getJobs();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -138,7 +138,7 @@ class AgentInstanceAuthorizationIT {
         .execute();
     // Complete job1 so JobCompleteProcessor emits AGENT_HISTORY:COMMIT, transitioning
     // the history item to COMMITTED so it becomes searchable.
-    adminClient.newCompleteCommand(jobKey1).execute();
+    adminClient.newCompleteCommand(jobKey1).withLeaseToken(result1.jobLease()).execute();
 
     agentInstanceKey2 = createAgentInstance(adminClient, PROCESS_ID_2).agentInstanceKey();
     final var result3 = createAgentInstance(adminClient, PROCESS_ID_3);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -236,6 +236,7 @@ public class AgentInstanceFetchIT {
             .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .timeout(Duration.ofMinutes(5))
+            .withLease(true)
             .send()
             .join()
             .getJobs();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -96,7 +96,7 @@ public class AgentInstanceFetchIT {
             .newCreateAgentInstanceCommand()
             .elementInstanceKey(ei1)
             .jobKey(activatedJob1.getKey())
-            .jobLease("test-job-lease")
+            .jobLease(activatedJob1.getLeaseToken())
             .history(
                 List.of(
                     new AgentInstanceHistoryItem()
@@ -136,7 +136,7 @@ public class AgentInstanceFetchIT {
             .newCreateAgentInstanceCommand()
             .elementInstanceKey(ei2)
             .jobKey(activatedJob2.getKey())
-            .jobLease("test-job-lease")
+            .jobLease(activatedJob2.getLeaseToken())
             .history(
                 List.of(
                     new AgentInstanceHistoryItem()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.it.orchestration;
 
-import static io.camunda.it.util.TestHelper.activateAndCompleteJobs;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
@@ -86,7 +85,18 @@ public class AgentInstanceMigrationIT {
     final long sourceAgentDefinitionKey =
         client.newAgentInstanceGetRequest(agentInstanceKey).execute().getAgentDefinitionKey();
 
-    activateAndCompleteJobs(client, agentJobType, "test-worker", 1);
+    final var reactivatedJob =
+        client
+            .newActivateJobsCommand()
+            .jobType(agentJobType)
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMinutes(5))
+            .withLease(true)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+    client.newCompleteCommand(reactivatedJob).execute();
     waitForElementInstances(
         client, f -> f.elementId(sourceNextElementId).processInstanceKey(processInstanceKey), 1);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -189,7 +189,7 @@ public class AgentInstanceMigrationIT {
             .newCreateAgentInstanceCommand()
             .elementInstanceKey(elementInstanceKey)
             .jobKey(activatedJob.getKey())
-            .jobLease("test-job-lease")
+            .jobLease(activatedJob.getLeaseToken())
             .history(
                 List.of(
                     configurationHistoryItem("gpt-4o", "openai", "You are a helpful assistant.")))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -179,6 +179,7 @@ public class AgentInstanceMigrationIT {
             .jobType(agentJobType)
             .maxJobsToActivate(1)
             .timeout(Duration.ofMinutes(5))
+            .withLease(true)
             .send()
             .join()
             .getJobs()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -405,6 +405,7 @@ public class AgentInstanceTenancyIT {
             .maxJobsToActivate(1)
             .tenantIds(tenantId)
             .timeout(Duration.ofMinutes(5))
+            .withLease(true)
             .send()
             .join()
             .getJobs();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -106,7 +106,7 @@ public class AgentInstanceTenancyIT {
         .newUpdateAgentInstanceCommand(agentInstanceKeyA)
         .elementInstanceKey(elementInstanceKeyA)
         .jobKey(jobKeyA)
-        .jobLease("test-job-lease")
+        .jobLease(resultA.jobLease())
         .history(
             List.of(
                 new AgentInstanceHistoryItem()
@@ -129,7 +129,7 @@ public class AgentInstanceTenancyIT {
         .newUpdateAgentInstanceCommand(agentInstanceKeyB)
         .elementInstanceKey(elementInstanceKeyB)
         .jobKey(jobKeyB)
-        .jobLease("test-job-lease")
+        .jobLease(resultB.jobLease())
         .history(
             List.of(
                 new AgentInstanceHistoryItem()
@@ -412,20 +412,21 @@ public class AgentInstanceTenancyIT {
         .as("expected to activate one agent job for process instance %d", processInstanceKey)
         .isNotEmpty();
     final long jobKey = activatedJobs.get(0).getKey();
+    final String jobLease = activatedJobs.get(0).getLeaseToken();
 
     final var agentInstanceKey =
         client
             .newCreateAgentInstanceCommand()
             .elementInstanceKey(elementInstanceKey)
             .jobKey(jobKey)
-            .jobLease("test-job-lease")
+            .jobLease(jobLease)
             .history(
                 List.of(
                     configurationHistoryItem("gpt-4o", "openai", "You are a helpful assistant.")))
             .execute()
             .getAgentInstanceKey();
 
-    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey, jobKey);
+    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey, jobKey, jobLease);
   }
 
   private static AgentInstanceHistoryItem configurationHistoryItem(
@@ -442,5 +443,5 @@ public class AgentInstanceTenancyIT {
   }
 
   private record AgentInstanceCreationResult(
-      long agentInstanceKey, long elementInstanceKey, long jobKey) {}
+      long agentInstanceKey, long elementInstanceKey, long jobKey, String jobLease) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -117,7 +117,7 @@ public class AgentInstanceTenancyIT {
                     .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))))
         .execute();
     // Complete job A so JobCompleteProcessor emits AGENT_HISTORY:COMMIT for its items.
-    adminClient.newCompleteCommand(jobKeyA).execute();
+    adminClient.newCompleteCommand(jobKeyA).withLeaseToken(resultA.jobLease()).execute();
 
     final var resultB = createAgentInstanceWithResult(adminClient, TENANT_B);
     agentInstanceKeyB = resultB.agentInstanceKey();
@@ -140,7 +140,7 @@ public class AgentInstanceTenancyIT {
                     .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))))
         .execute();
     // Complete job B so its history items also transition to COMMITTED.
-    adminClient.newCompleteCommand(jobKeyB).execute();
+    adminClient.newCompleteCommand(jobKeyB).withLeaseToken(resultB.jobLease()).execute();
 
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyA);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyB);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/tests/request-validation/agentinstances-validation-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/tests/request-validation/agentinstances-validation-api-tests.spec.ts
@@ -8,8 +8,8 @@
 
 /*
  * GENERATED FILE - DO NOT EDIT MANUALLY
- * Generated At: 2026-08-21T16:01:38.423Z
- * Spec Commit: c30231a08a134faa0138733d391778da818845e3
+ * Generated At: 2026-09-07T13:36:17.477Z
+ * Spec Commit: 5f7d6db03a540f2f64d48063c8aff8f3aa9fd908
  */
 import {test, expect} from '@playwright/test';
 import {jsonHeaders, buildUrl} from '../../../utils/http';
@@ -24,7 +24,7 @@ test.describe('Agentinstances Validation API Tests', () => {
       jobLease: 'x',
       history: [
         {
-          historyItemId: 'x',
+          historyItemId: null,
           loopIteration: null,
           role: null,
           content: [null],
@@ -55,60 +55,6 @@ test.describe('Agentinstances Validation API Tests', () => {
     //   }
     expect(res.status()).toBe(400);
   });
-  test('createAgentInstance - Param history.0.historyItemId wrong type (#1)', async ({
-    request,
-  }) => {
-    const requestBody = {
-      elementInstanceKey: null,
-      jobKey: null,
-      jobLease: 'x',
-      history: [
-        {
-          historyItemId: 123,
-          loopIteration: null,
-          role: null,
-          content: [null],
-          producedAt: 'x',
-        },
-      ],
-    };
-    const res = await request.post(buildUrl('/agent-instances', undefined), {
-      headers: jsonHeaders(),
-      data: requestBody,
-    });
-    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
-    //   if (res.status() !== 400) {
-    //     try { console.error(await res.text()); } catch {}
-    //   }
-    expect(res.status()).toBe(400);
-  });
-  test('createAgentInstance - Param history.0.historyItemId wrong type (#2)', async ({
-    request,
-  }) => {
-    const requestBody = {
-      elementInstanceKey: null,
-      jobKey: null,
-      jobLease: 'x',
-      history: [
-        {
-          historyItemId: true,
-          loopIteration: null,
-          role: null,
-          content: [null],
-          producedAt: 'x',
-        },
-      ],
-    };
-    const res = await request.post(buildUrl('/agent-instances', undefined), {
-      headers: jsonHeaders(),
-      data: requestBody,
-    });
-    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
-    //   if (res.status() !== 400) {
-    //     try { console.error(await res.text()); } catch {}
-    //   }
-    expect(res.status()).toBe(400);
-  });
   test('createAgentInstance - Param history.0.producedAt wrong type (#1)', async ({
     request,
   }) => {
@@ -118,7 +64,7 @@ test.describe('Agentinstances Validation API Tests', () => {
       jobLease: 'x',
       history: [
         {
-          historyItemId: 'x',
+          historyItemId: null,
           loopIteration: null,
           role: null,
           content: [null],
@@ -145,7 +91,7 @@ test.describe('Agentinstances Validation API Tests', () => {
       jobLease: 'x',
       history: [
         {
-          historyItemId: 'x',
+          historyItemId: null,
           loopIteration: null,
           role: null,
           content: [null],
@@ -172,7 +118,7 @@ test.describe('Agentinstances Validation API Tests', () => {
       jobLease: 123,
       history: [
         {
-          historyItemId: 'x',
+          historyItemId: null,
           loopIteration: null,
           role: null,
           content: [null],
@@ -199,13 +145,32 @@ test.describe('Agentinstances Validation API Tests', () => {
       jobLease: true,
       history: [
         {
-          historyItemId: 'x',
+          historyItemId: null,
           loopIteration: null,
           role: null,
           content: [null],
           producedAt: 'x',
         },
       ],
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('createAgentInstance - Constraint violation history', async ({
+    request,
+  }) => {
+    const requestBody = {
+      elementInstanceKey: null,
+      jobKey: null,
+      jobLease: 'x',
+      history: [],
     };
     const res = await request.post(buildUrl('/agent-instances', undefined), {
       headers: jsonHeaders(),
@@ -225,7 +190,7 @@ test.describe('Agentinstances Validation API Tests', () => {
       jobLease: 'x',
       history: [
         {
-          historyItemId: 'x',
+          historyItemId: null,
           loopIteration: null,
           role: null,
           content: [null],
@@ -265,7 +230,31 @@ test.describe('Agentinstances Validation API Tests', () => {
       jobLease: 'x',
       history: [
         {
-          historyItemId: 'x',
+          historyItemId: null,
+          loopIteration: null,
+          role: null,
+          content: [null],
+          producedAt: 'x',
+        },
+      ],
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('createAgentInstance - Missing jobLease (#1)', async ({request}) => {
+    const requestBody = {
+      elementInstanceKey: null,
+      jobKey: null,
+      history: [
+        {
+          historyItemId: null,
           loopIteration: null,
           role: null,
           content: [null],
@@ -292,7 +281,7 @@ test.describe('Agentinstances Validation API Tests', () => {
       jobLease: 'x',
       history: [
         {
-          historyItemId: 'x',
+          historyItemId: null,
           loopIteration: null,
           role: null,
           content: [null],
@@ -348,6 +337,22 @@ test.describe('Agentinstances Validation API Tests', () => {
     const requestBody = {
       elementInstanceKey: 'x',
       jobLease: 'x',
+      history: [],
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('createAgentInstance - Missing jobLease (#2)', async ({request}) => {
+    const requestBody = {
+      elementInstanceKey: 'x',
+      jobKey: 'x',
       history: [],
     };
     const res = await request.post(buildUrl('/agent-instances', undefined), {
@@ -420,12 +425,111 @@ test.describe('Agentinstances Validation API Tests', () => {
     //   }
     expect(res.status()).toBe(400);
   });
+  test('createAgentInstance - Missing combo elementInstanceKey,jobKey,jobLease', async ({
+    request,
+  }) => {
+    const requestBody = {
+      history: [],
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('createAgentInstance - Missing combo elementInstanceKey,jobLease', async ({
+    request,
+  }) => {
+    const requestBody = {
+      jobKey: 'x',
+      history: [],
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('createAgentInstance - Missing combo elementInstanceKey,jobLease,history', async ({
+    request,
+  }) => {
+    const requestBody = {
+      jobKey: 'x',
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
   test('createAgentInstance - Missing combo jobKey,history', async ({
     request,
   }) => {
     const requestBody = {
       elementInstanceKey: 'x',
       jobLease: 'x',
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('createAgentInstance - Missing combo jobKey,jobLease', async ({
+    request,
+  }) => {
+    const requestBody = {
+      elementInstanceKey: 'x',
+      history: [],
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('createAgentInstance - Missing combo jobKey,jobLease,history', async ({
+    request,
+  }) => {
+    const requestBody = {
+      elementInstanceKey: 'x',
+    };
+    const res = await request.post(buildUrl('/agent-instances', undefined), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('createAgentInstance - Missing combo jobLease,history', async ({
+    request,
+  }) => {
+    const requestBody = {
+      elementInstanceKey: 'x',
+      jobKey: 'x',
     };
     const res = await request.post(buildUrl('/agent-instances', undefined), {
       headers: jsonHeaders(),
@@ -914,6 +1018,42 @@ test.describe('Agentinstances Validation API Tests', () => {
     //   }
     expect(res.status()).toBe(400);
   });
+  test('updateAgentInstance - Missing jobKey (#1)', async ({request}) => {
+    const requestBody = {
+      elementInstanceKey: null,
+      jobLease: 'x',
+    };
+    const res = await request.patch(
+      buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
+      {
+        headers: jsonHeaders(),
+        data: requestBody,
+      },
+    );
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('updateAgentInstance - Missing jobLease (#1)', async ({request}) => {
+    const requestBody = {
+      elementInstanceKey: null,
+      jobKey: null,
+    };
+    const res = await request.patch(
+      buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
+      {
+        headers: jsonHeaders(),
+        data: requestBody,
+      },
+    );
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
   test('updateAgentInstance - Missing elementInstanceKey (#2)', async ({
     request,
   }) => {
@@ -934,11 +1074,121 @@ test.describe('Agentinstances Validation API Tests', () => {
     //   }
     expect(res.status()).toBe(400);
   });
+  test('updateAgentInstance - Missing jobKey (#2)', async ({request}) => {
+    const requestBody = {
+      elementInstanceKey: 'x',
+      jobLease: 'x',
+    };
+    const res = await request.patch(
+      buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
+      {
+        headers: jsonHeaders(),
+        data: requestBody,
+      },
+    );
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('updateAgentInstance - Missing jobLease (#2)', async ({request}) => {
+    const requestBody = {
+      elementInstanceKey: 'x',
+      jobKey: 'x',
+    };
+    const res = await request.patch(
+      buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
+      {
+        headers: jsonHeaders(),
+        data: requestBody,
+      },
+    );
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
   test('updateAgentInstance - Missing body', async ({request}) => {
     const res = await request.patch(
       buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
       {
         headers: jsonHeaders(),
+      },
+    );
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('updateAgentInstance - Missing combo elementInstanceKey,jobKey', async ({
+    request,
+  }) => {
+    const requestBody = {
+      jobLease: 'x',
+    };
+    const res = await request.patch(
+      buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
+      {
+        headers: jsonHeaders(),
+        data: requestBody,
+      },
+    );
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('updateAgentInstance - Missing combo elementInstanceKey,jobKey,jobLease', async ({
+    request,
+  }) => {
+    const requestBody = {};
+    const res = await request.patch(
+      buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
+      {
+        headers: jsonHeaders(),
+        data: requestBody,
+      },
+    );
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('updateAgentInstance - Missing combo elementInstanceKey,jobLease', async ({
+    request,
+  }) => {
+    const requestBody = {
+      jobKey: 'x',
+    };
+    const res = await request.patch(
+      buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
+      {
+        headers: jsonHeaders(),
+        data: requestBody,
+      },
+    );
+    // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.
+    //   if (res.status() !== 400) {
+    //     try { console.error(await res.text()); } catch {}
+    //   }
+    expect(res.status()).toBe(400);
+  });
+  test('updateAgentInstance - Missing combo jobKey,jobLease', async ({
+    request,
+  }) => {
+    const requestBody = {
+      elementInstanceKey: 'x',
+    };
+    const res = await request.patch(
+      buildUrl('/agent-instances/{agentInstanceKey}', {agentInstanceKey: 'x'}),
+      {
+        headers: jsonHeaders(),
+        data: requestBody,
       },
     );
     // Conditionals are banned by eslint in qa tests. The following block can be uncommented for debugging purposes.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistorybatch/AgentHistoryBatchCleanUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistorybatch/AgentHistoryBatchCleanUpProcessor.java
@@ -37,8 +37,12 @@ public final class AgentHistoryBatchCleanUpProcessor
     implements TypedRecordProcessor<AgentHistoryBatchRecord>,
         SuspensionAware<AgentHistoryBatchRecord> {
 
-  // number of history-item ids deleted, combined across the committed and metrics-accumulated
-  // indexes, per AGENT_HISTORY_BATCH:CLEANED cycle
+  /**
+   * Number of history-item ids deleted, combined across the committed and metrics-accumulated
+   * indexes, per {@code AGENT_HISTORY_BATCH:CLEANED} cycle. Each history-item id is capped at 256
+   * characters, so this bound keeps a cycle's worst case around 256 KB — comfortably within the
+   * default max message size, and smaller configured ones too.
+   */
   public static final int CHUNK_SIZE = 1000;
 
   private final StateWriter stateWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistorybatch/AgentHistoryBatchCleanUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistorybatch/AgentHistoryBatchCleanUpProcessor.java
@@ -40,10 +40,13 @@ public final class AgentHistoryBatchCleanUpProcessor
   /**
    * Number of history-item ids deleted, combined across the committed and metrics-accumulated
    * indexes, per {@code AGENT_HISTORY_BATCH:CLEANED} cycle. Each history-item id is capped at 256
-   * characters, so this bound keeps a cycle's worst case around 256 KB — comfortably within the
-   * default max message size, and smaller configured ones too.
+   * characters, and a single character can take up to 4 bytes in UTF-8, so the extreme worst case
+   * (every character an emoji) is 100 items * 256 chars * 4 bytes * 100 commands per processing
+   * batch = ~10 MB. Under normal conditions (assuming ~1.5 bytes per character on average, which
+   * still allows for the occasional non-Latin character) that same batch is only 100 items * 256
+   * chars * ~1.5 bytes * 100 commands = ~3.84 MB — comfortably within the default max message size.
    */
-  public static final int CHUNK_SIZE = 1000;
+  public static final int CHUNK_SIZE = 100;
 
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -59,6 +59,9 @@ public final class AgentHistoryBatchBehavior {
   static final String ERROR_MSG_JOB_KEY_REQUIRED =
       "Expected to update agent instance, but no jobKey was provided. A command must always be "
           + "attributed to the active job that produced it.";
+  static final String ERROR_MSG_JOB_LEASE_REQUIRED =
+      "Expected to update agent instance related to job with key '%d', but no jobLease was "
+          + "provided. A command must always carry the lease its job was activated with.";
   static final String ERROR_MSG_JOB_NOT_ACTIVE =
       "Expected to update agent instance related to job with key '%d', but job was not active.";
   static final String ERROR_MSG_JOB_LEASE_MISMATCH =
@@ -109,10 +112,10 @@ public final class AgentHistoryBatchBehavior {
   }
 
   /**
-   * Validates the job context a command carries. {@code jobKey} is always required — a command must
-   * always be attributed to the active job that produced it, and is rejected outright if unset. The
-   * referenced job must be currently active, must hold a lease, and must belong to {@code
-   * elementInstanceKey}.
+   * Validates the job context a command carries. {@code jobKey} and {@code jobLease} are always
+   * required — a command must always be attributed to the active job that produced it and carry the
+   * lease it was activated with, and is rejected outright if either is unset. The referenced job
+   * must be currently active, must hold a lease, and must belong to {@code elementInstanceKey}.
    *
    * <p>{@code jobLease} is a fencing token, not an authorization check (see ADR 0005-810): whether
    * a mismatch against the job's current lease is fatal depends on {@code leaseMismatchHandling},
@@ -129,6 +132,12 @@ public final class AgentHistoryBatchBehavior {
 
     if (jobKey == -1L) {
       return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, ERROR_MSG_JOB_KEY_REQUIRED));
+    }
+
+    if (jobLease == null || jobLease.isBlank()) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT, ERROR_MSG_JOB_LEASE_REQUIRED.formatted(jobKey)));
     }
 
     final var jobState = processingState.getJobState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -56,17 +56,20 @@ public final class AgentHistoryBatchBehavior {
   static final String ERROR_MSG_LOOP_ITERATION_MISSING =
       "Expected to add history item with historyItemId '%s' to agent instance, but loopIteration "
           + "is missing (got %d). Each history item must declare a positive loopIteration.";
+  static final String ERROR_MSG_JOB_KEY_REQUIRED =
+      "Expected to update agent instance, but no jobKey was provided. A command must always be "
+          + "attributed to the active job that produced it.";
   static final String ERROR_MSG_JOB_NOT_ACTIVE =
       "Expected to update agent instance related to job with key '%d', but job was not active.";
   static final String ERROR_MSG_JOB_LEASE_MISMATCH =
       "Expected to update agent instance related to job with key '%d', but job did not hold the "
           + "supplied lease. The job may have been re-activated.";
+  static final String ERROR_MSG_JOB_NOT_LEASED =
+      "Expected to update agent instance related to job with key '%d', but job has no lease "
+          + "token. The job must be activated with a lease before it can be referenced.";
   static final String ERROR_MSG_JOB_ELEMENT_MISMATCH =
       "Expected to update agent instance related to job with key '%d', but job belongs to element "
           + "instance '%d' instead of the requested element instance '%d'.";
-  static final String ERROR_MSG_JOB_REQUIRED_FOR_HISTORY =
-      "Expected a job to be provided for the embedded history batch, but no jobKey was set."
-          + " A history batch must be attributed to the active job that produced it.";
   static final String ERROR_MSG_DUPLICATE_HISTORY_ITEM_ID_IN_REQUEST =
       "Expected to create or update agent instance history, but historyItemId '%s' is used by more "
           + "than one history item. Each history item must have a unique historyItemId.";
@@ -106,34 +109,26 @@ public final class AgentHistoryBatchBehavior {
   }
 
   /**
-   * Validates the job context a command carries. {@code jobKey} may be omitted only when no history
-   * batch is present; once a batch is attached to the command, {@code jobKey} becomes required — a
-   * batch must always be attributed to the active job that produced it. When a job is supplied
-   * (with or without a batch), it must refer to a currently-active job, and the job must belong to
-   * {@code elementInstanceKey}.
+   * Validates the job context a command carries. {@code jobKey} is always required — a command must
+   * always be attributed to the active job that produced it, and is rejected outright if unset. The
+   * referenced job must be currently active, must hold a lease, and must belong to {@code
+   * elementInstanceKey}.
    *
    * <p>{@code jobLease} is a fencing token, not an authorization check (see ADR 0005-810): whether
-   * a mismatch is fatal depends on {@code leaseMismatchHandling}, see {@link
-   * LeaseMismatchHandling}.
+   * a mismatch against the job's current lease is fatal depends on {@code leaseMismatchHandling},
+   * see {@link LeaseMismatchHandling}.
    *
-   * @return the active {@link JobRecord} if a job was supplied and is valid, {@code null} wrapped
-   *     in {@link Either#right} if no job was supplied and none was required, otherwise the {@link
-   *     Rejection} to surface
+   * @return the active {@link JobRecord} if {@code jobKey} refers to a valid job, otherwise the
+   *     {@link Rejection} to surface
    */
   public Either<Rejection, JobRecord> validateJobContext(
       final long jobKey,
       final String jobLease,
       final long elementInstanceKey,
-      final List<? extends AgentHistoryRecordValue> history,
       final LeaseMismatchHandling leaseMismatchHandling) {
 
     if (jobKey == -1L) {
-      if (history != null && !history.isEmpty()) {
-        return Either.left(
-            new Rejection(RejectionType.INVALID_ARGUMENT, ERROR_MSG_JOB_REQUIRED_FOR_HISTORY));
-      } else {
-        return Either.right(null);
-      }
+      return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, ERROR_MSG_JOB_KEY_REQUIRED));
     }
 
     final var jobState = processingState.getJobState();
@@ -143,8 +138,12 @@ public final class AgentHistoryBatchBehavior {
     }
 
     final var job = jobState.getJob(jobKey);
+    if (!job.hasLeaseToken()) {
+      return Either.left(
+          new Rejection(RejectionType.NOT_FOUND, ERROR_MSG_JOB_NOT_LEASED.formatted(jobKey)));
+    }
+
     if (leaseMismatchHandling == LeaseMismatchHandling.REJECT
-        && job.hasLeaseToken()
         && !Objects.equals(jobLease, job.getLeaseToken())) {
       return Either.left(
           new Rejection(RejectionType.NOT_FOUND, ERROR_MSG_JOB_LEASE_MISMATCH.formatted(jobKey)));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -192,7 +192,6 @@ public final class AgentInstanceCreateProcessor
             commandValue.getJobKey(),
             commandValue.getJobLease(),
             commandValue.getElementInstanceKey(),
-            commandValue.getHistory(),
             LeaseMismatchHandling.REJECT);
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -211,7 +211,6 @@ public final class AgentInstanceUpdateProcessor
             commandValue.getJobKey(),
             commandValue.getJobLease(),
             commandValue.getElementInstanceKey(),
-            commandValue.getHistory(),
             LeaseMismatchHandling.ALLOW_STALE);
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -83,19 +83,27 @@ public class AgentHistoryCommitTest {
             .withElementId(EXTERNAL_SERVICE_TASK_ID)
             .getFirst();
     final long elementInstanceKey = serviceTaskInstance.getKey();
-    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
 
-    ENGINE.jobs().withType(EXTERNAL_SERVICE_TASK_JOB_TYPE).activate();
+    final var jobBatch =
+        ENGINE.jobs().withType(EXTERNAL_SERVICE_TASK_JOB_TYPE).withLease().activate();
     final long jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(EXTERNAL_SERVICE_TASK_JOB_TYPE)
             .getFirst()
             .getKey();
-    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+    final String jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final long agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobKey, jobLease).getKey();
+    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, jobLease);
 
     // when
-    ENGINE.job().withKey(jobKey).complete();
+    ENGINE.job().withKey(jobKey).withLeaseToken(jobLease).complete();
 
     // then
     final var committed =
@@ -137,19 +145,26 @@ public class AgentHistoryCommitTest {
             .withElementId(EXTERNAL_AD_HOC_SUB_PROCESS_ID)
             .getFirst();
     final long elementInstanceKey = adHocSubProcessInstance.getKey();
-    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
 
-    ENGINE.jobs().withType(EXTERNAL_AD_HOC_JOB_TYPE).activate();
+    final var jobBatch = ENGINE.jobs().withType(EXTERNAL_AD_HOC_JOB_TYPE).withLease().activate();
     final long jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(EXTERNAL_AD_HOC_JOB_TYPE)
             .getFirst()
             .getKey();
-    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+    final String jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final long agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobKey, jobLease).getKey();
+    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, jobLease);
 
     // when
-    ENGINE.job().withKey(jobKey).complete();
+    ENGINE.job().withKey(jobKey).withLeaseToken(jobLease).complete();
 
     // then
     final var committed =
@@ -207,19 +222,27 @@ public class AgentHistoryCommitTest {
             .withElementId(EXTERNAL_MULTI_INSTANCE_TASK_ID)
             .getFirst();
     final long elementInstanceKey = serviceTaskInstance.getKey();
-    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
 
-    ENGINE.jobs().withType(EXTERNAL_MULTI_INSTANCE_JOB_TYPE).activate();
+    final var jobBatch =
+        ENGINE.jobs().withType(EXTERNAL_MULTI_INSTANCE_JOB_TYPE).withLease().activate();
     final long jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(EXTERNAL_MULTI_INSTANCE_JOB_TYPE)
             .getFirst()
             .getKey();
-    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+    final String jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final long agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobKey, jobLease).getKey();
+    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, jobLease);
 
     // when
-    ENGINE.job().withKey(jobKey).complete();
+    ENGINE.job().withKey(jobKey).withLeaseToken(jobLease).complete();
 
     // then
     final var committed =
@@ -239,16 +262,18 @@ public class AgentHistoryCommitTest {
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
 
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
-    final var itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+    final var job = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, job.key(), job.leaseToken()).getKey();
+    final var itemKey =
+        createHistoryItem(agentInstanceKey, job.key(), elementInstanceKey, job.leaseToken());
 
-    final var committed = ENGINE.agentHistories().withJobKey(jobKey).commit();
+    final var committed = ENGINE.agentHistories().withJobKey(job.key()).commit();
 
     // AgentHistoryCommitProcessor emits COMMITTED carrying only identity/routing fields
     assertThat(committed.getRecordType()).isEqualTo(RecordType.EVENT);
     assertThat(committed.getKey()).isEqualTo(itemKey);
-    assertThat(committed.getValue().getJobKey()).isEqualTo(jobKey);
+    assertThat(committed.getValue().getJobKey()).isEqualTo(job.key());
     assertThat(committed.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
     assertThat(committed.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
   }
@@ -258,8 +283,9 @@ public class AgentHistoryCommitTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var job = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, job.key(), job.leaseToken()).getKey();
 
     final var item =
         new AgentHistoryRecord()
@@ -282,11 +308,12 @@ public class AgentHistoryCommitTest {
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
-        .withJobKey(jobKey)
+        .withJobKey(job.key())
+        .withJobLease(job.leaseToken())
         .withHistory(List.of(item))
         .update();
 
-    final var committed = ENGINE.agentHistories().withJobKey(jobKey).commit();
+    final var committed = ENGINE.agentHistories().withJobKey(job.key()).commit();
 
     // The item was created with content/toolCalls/metrics, but they are stripped at primary-storage
     // insert — the emitted COMMITTED event must carry none of them.
@@ -302,15 +329,16 @@ public class AgentHistoryCommitTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var job = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, job.key(), job.leaseToken()).getKey();
 
     // Two items share jobKey but have different leases — COMMIT with no lease must commit both
     // regardless of lease.
     final long firstItemKey =
-        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-a");
+        createHistoryItem(agentInstanceKey, job.key(), elementInstanceKey, "lease-a");
     final long secondItemKey =
-        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-b");
+        createHistoryItem(agentInstanceKey, job.key(), elementInstanceKey, "lease-b");
     // Guard against the lease-b item silently collapsing into the lease-a item: if it did, the
     // assertion below would pass vacuously with only one item ever having existed.
     assertThat(secondItemKey).isNotEqualTo(firstItemKey);
@@ -318,7 +346,7 @@ public class AgentHistoryCommitTest {
     // An item on an unrelated job must not be committed.
     createUnrelatedJobHistoryItem("lease-a");
 
-    final var firstCommitted = ENGINE.agentHistories().withJobKey(jobKey).commit();
+    final var firstCommitted = ENGINE.agentHistories().withJobKey(job.key()).commit();
     final long commitPosition = firstCommitted.getSourceRecordPosition();
     final long clockResetKey = ENGINE.clock().reset().getKey();
 
@@ -340,22 +368,23 @@ public class AgentHistoryCommitTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var job = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, job.key(), job.leaseToken()).getKey();
 
     // lease-1 and lease-2 items share jobKey; the unrelated job's item also carries lease-1 — it
     // must not be affected by the COMMIT, proving the filter is scoped to jobKey.
     final long lease1ItemKey =
-        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-1");
+        createHistoryItem(agentInstanceKey, job.key(), elementInstanceKey, "lease-1");
     final long lease2ItemKey =
-        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-2");
+        createHistoryItem(agentInstanceKey, job.key(), elementInstanceKey, "lease-2");
     // Guard against the lease-2 item silently collapsing into the lease-1 item: if it did, the
     // assertions below would pass vacuously with only one item ever having existed.
     assertThat(lease2ItemKey).isNotEqualTo(lease1ItemKey);
     createUnrelatedJobHistoryItem("lease-1");
 
     final var firstCommitted =
-        ENGINE.agentHistories().withJobKey(jobKey).withJobLease("lease-1").commit();
+        ENGINE.agentHistories().withJobKey(job.key()).withJobLease("lease-1").commit();
     final long commitPosition = firstCommitted.getSourceRecordPosition();
     final long clockResetKey = ENGINE.clock().reset().getKey();
 
@@ -385,10 +414,10 @@ public class AgentHistoryCommitTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-
     // Activation 1 (superseded): create a history item, then fail to trigger re-activation.
     final var job1 = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, job1.key(), job1.leaseToken()).getKey();
     final long supersededItemKey =
         createHistoryItem(agentInstanceKey, job1.key(), elementInstanceKey, job1.leaseToken());
 
@@ -455,11 +484,11 @@ public class AgentHistoryCommitTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-
     // Activation 1 (superseded): an AGENT_INSTANCE:UPDATE accumulates its item's metrics onto the
     // agent instance immediately, before the job later fails and is re-activated.
     final var job1 = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, job1.key(), job1.leaseToken()).getKey();
     final var supersededItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-superseded")
@@ -701,17 +730,14 @@ public class AgentHistoryCommitTest {
         .getFirst();
   }
 
-  private static long activateJobForProcessInstance(final long processInstanceKey) {
-    ENGINE.jobs().withType(JOB_TYPE).activate();
-    return RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withType(JOB_TYPE)
-        .getFirst()
-        .getKey();
-  }
-
-  private static Record<?> createAgentInstance(final long elementInstanceKey) {
-    return ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create();
+  private static Record<?> createAgentInstance(
+      final long elementInstanceKey, final long jobKey, final String jobLease) {
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
+        .create();
   }
 
   private static long createHistoryItem(
@@ -759,10 +785,11 @@ public class AgentHistoryCommitTest {
             .getFirst();
     final long elementInstanceKey = serviceTaskInstance.getKey();
 
-    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final long jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var job = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final long agentInstanceKey =
+        createAgentInstance(elementInstanceKey, job.key(), job.leaseToken()).getKey();
 
-    return createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, jobLease);
+    return createHistoryItem(agentInstanceKey, job.key(), elementInstanceKey, jobLease);
   }
 
   private static ActivatedJob activateJobForProcessInstanceWithLease(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -93,6 +93,7 @@ public class AgentHistoryDiscardOnJobDestructionTest {
         .job()
         .ofInstance(fixture.processInstanceKey)
         .withType(AGENTIC_JOB_TYPE)
+        .withLeaseToken(fixture.jobLease)
         .withErrorCode(ERROR_CODE)
         .throwError();
 
@@ -146,6 +147,7 @@ public class AgentHistoryDiscardOnJobDestructionTest {
         .job()
         .ofInstance(fixture.processInstanceKey)
         .withType(EXTERNAL_AGENT_JOB_TYPE)
+        .withLeaseToken(fixture.jobLease)
         .withErrorCode(ERROR_CODE)
         .throwError();
 
@@ -267,16 +269,28 @@ public class AgentHistoryDiscardOnJobDestructionTest {
             .getFirst();
     final long elementInstanceKey = serviceTaskInstance.getKey();
 
-    ENGINE.jobs().withType(jobType).activate();
+    final var jobBatch = ENGINE.jobs().withType(jobType).withLease().activate();
     final long jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(jobType)
             .getFirst()
             .getKey();
+    final String jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     final long agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
+            .getKey();
 
     final var historyItemId = Strings.newRandomValidBpmnId();
     ENGINE
@@ -284,6 +298,7 @@ public class AgentHistoryDiscardOnJobDestructionTest {
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
         .withJobKey(jobKey)
+        .withJobLease(jobLease)
         .withHistory(
             List.of(
                 new AgentHistoryRecord()
@@ -302,9 +317,13 @@ public class AgentHistoryDiscardOnJobDestructionTest {
             .getFirst()
             .getKey();
 
-    return new Fixture(processInstanceKey, elementInstanceKey, jobKey, itemKey);
+    return new Fixture(processInstanceKey, elementInstanceKey, jobKey, jobLease, itemKey);
   }
 
   private record Fixture(
-      long processInstanceKey, long elementInstanceKey, long jobKey, long itemKey) {}
+      long processInstanceKey,
+      long elementInstanceKey,
+      long jobKey,
+      String jobLease,
+      long itemKey) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
@@ -49,8 +49,10 @@ public class AgentHistoryDiscardTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var activatedJob = activateJobForProcessInstance(processInstanceKey);
+    final var jobKey = activatedJob.jobKey();
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobKey, activatedJob.jobLease()).getKey();
 
     // Two items share jobKey but have different leases — DISCARD with no lease must discard both
     // regardless of lease.
@@ -84,8 +86,10 @@ public class AgentHistoryDiscardTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var activatedJob = activateJobForProcessInstance(processInstanceKey);
+    final var jobKey = activatedJob.jobKey();
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobKey, activatedJob.jobLease()).getKey();
 
     final long lease1ItemKey =
         createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-1");
@@ -118,8 +122,10 @@ public class AgentHistoryDiscardTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var activatedJob = activateJobForProcessInstance(processInstanceKey);
+    final var jobKey = activatedJob.jobKey();
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobKey, activatedJob.jobLease()).getKey();
     final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
 
     final var discarded = ENGINE.agentHistories().withJobKey(jobKey).discard();
@@ -136,8 +142,10 @@ public class AgentHistoryDiscardTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var activatedJob = activateJobForProcessInstance(processInstanceKey);
+    final var jobKey = activatedJob.jobKey();
+    final var agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobKey, activatedJob.jobLease()).getKey();
 
     final var item =
         new AgentHistoryRecord()
@@ -161,6 +169,7 @@ public class AgentHistoryDiscardTest {
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
         .withJobKey(jobKey)
+        .withJobLease(activatedJob.jobLease())
         .withHistory(List.of(item))
         .update();
 
@@ -179,7 +188,7 @@ public class AgentHistoryDiscardTest {
   public void shouldNotEmitAnyEventWhenNoItemsExistForJobKey() {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var jobKey = activateJobForProcessInstance(processInstanceKey).jobKey();
 
     // No CREATED items for the job — DISCARD must be a no-op. The client helper would block
     // waiting for a follow-up event, which a no-op never produces, so write the command directly.
@@ -219,17 +228,31 @@ public class AgentHistoryDiscardTest {
         .getFirst();
   }
 
-  private static long activateJobForProcessInstance(final long processInstanceKey) {
-    ENGINE.jobs().withType(JOB_TYPE).activate();
-    return RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withType(JOB_TYPE)
-        .getFirst()
-        .getKey();
+  private static ActivatedJob activateJobForProcessInstance(final long processInstanceKey) {
+    final var jobBatch = ENGINE.jobs().withType(JOB_TYPE).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    return new ActivatedJob(jobKey, jobLease);
   }
 
-  private static Record<?> createAgentInstance(final long elementInstanceKey) {
-    return ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create();
+  private static Record<?> createAgentInstance(
+      final long elementInstanceKey, final long jobKey, final String jobLease) {
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
+        .create();
   }
 
   private static long createHistoryItem(
@@ -277,9 +300,13 @@ public class AgentHistoryDiscardTest {
             .getFirst();
     final long elementInstanceKey = serviceTaskInstance.getKey();
 
-    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final long jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var activatedJob = activateJobForProcessInstance(processInstanceKey);
+    final long jobKey = activatedJob.jobKey();
+    final long agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobKey, activatedJob.jobLease()).getKey();
 
     return createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, jobLease);
   }
+
+  private record ActivatedJob(long jobKey, String jobLease) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
@@ -65,7 +65,7 @@ public class AgentHistoryDiscardTest {
     assertThat(secondItemKey).isNotEqualTo(firstItemKey);
 
     // An item on an unrelated job must not be discarded.
-    createUnrelatedJobHistoryItem("");
+    createUnrelatedJobHistoryItem("lease-unrelated");
 
     final var firstDiscarded = ENGINE.agentHistories().withJobKey(jobKey).discard();
     final long discardPosition = firstDiscarded.getSourceRecordPosition();
@@ -126,7 +126,7 @@ public class AgentHistoryDiscardTest {
     final var jobKey = activatedJob.jobKey();
     final var agentInstanceKey =
         createAgentInstance(elementInstanceKey, jobKey, activatedJob.jobLease()).getKey();
-    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-x");
 
     final var discarded = ENGINE.agentHistories().withJobKey(jobKey).discard();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryItemIdPersistenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryItemIdPersistenceTest.java
@@ -66,14 +66,26 @@ public class AgentHistoryItemIdPersistenceTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(JOB_TYPE).activate();
+    final var jobBatch = ENGINE.jobs().withType(JOB_TYPE).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(JOB_TYPE)
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
 
     final var committedUpdate =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
@@ -53,9 +53,13 @@ public class AgentHistorySuspensionGateTest {
     final long elementInstanceKey = serviceTaskActivated.getKey();
     final long processInstanceKey = serviceTaskActivated.getValue().getProcessInstanceKey();
 
-    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final long jobKey = activateJobForProcessInstance(processInstanceKey);
-    final long historyItemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey);
+    final var jobLease = activateJobForProcessInstance(processInstanceKey);
+    final long agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobLease.jobKey(), jobLease.leaseToken()).getKey();
+    final long jobKey = jobLease.jobKey();
+    final long historyItemKey =
+        createHistoryItem(
+            agentInstanceKey, jobLease.jobKey(), jobLease.leaseToken(), elementInstanceKey);
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
@@ -85,9 +89,13 @@ public class AgentHistorySuspensionGateTest {
     final long elementInstanceKey = serviceTaskActivated.getKey();
     final long processInstanceKey = serviceTaskActivated.getValue().getProcessInstanceKey();
 
-    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final long jobKey = activateJobForProcessInstance(processInstanceKey);
-    final long historyItemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey);
+    final var jobLease = activateJobForProcessInstance(processInstanceKey);
+    final long agentInstanceKey =
+        createAgentInstance(elementInstanceKey, jobLease.jobKey(), jobLease.leaseToken()).getKey();
+    final long jobKey = jobLease.jobKey();
+    final long historyItemKey =
+        createHistoryItem(
+            agentInstanceKey, jobLease.jobKey(), jobLease.leaseToken(), elementInstanceKey);
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
@@ -129,29 +137,47 @@ public class AgentHistorySuspensionGateTest {
         .getFirst();
   }
 
-  private static Record<?> createAgentInstance(final long elementInstanceKey) {
-    return ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create();
+  private static Record<?> createAgentInstance(
+      final long elementInstanceKey, final long jobKey, final String jobLease) {
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
+        .create();
   }
 
-  private static long activateJobForProcessInstance(final long processInstanceKey) {
-    ENGINE.jobs().withType(JOB_TYPE).activate();
-    return RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withType(JOB_TYPE)
-        .getFirst()
-        .getKey();
+  private static JobLease activateJobForProcessInstance(final long processInstanceKey) {
+    final var jobBatch = ENGINE.jobs().withType(JOB_TYPE).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var leaseToken =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    return new JobLease(jobKey, leaseToken);
   }
 
   // AGENT_HISTORY:CREATE is dead; AGENT_INSTANCE:UPDATE with a history batch is the only live
   // path that produces AGENT_HISTORY:CREATED events, so this seeds the item through it.
   private static long createHistoryItem(
-      final long agentInstanceKey, final long jobKey, final long elementInstanceKey) {
+      final long agentInstanceKey,
+      final long jobKey,
+      final String jobLease,
+      final long elementInstanceKey) {
     final var historyItemId = Strings.newRandomValidBpmnId();
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
         .withJobKey(jobKey)
+        .withJobLease(jobLease)
         .withHistory(
             List.of(
                 new AgentHistoryRecord()
@@ -169,4 +195,6 @@ public class AgentHistorySuspensionGateTest {
         .getFirst()
         .getKey();
   }
+
+  private record JobLease(long jobKey, String leaseToken) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
@@ -63,16 +63,23 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var agentTaskInstance = awaitElementActivated(processInstanceKey, AGENT_TASK_ID);
+    final var job = awaitAndActivateAgentJob(processInstanceKey, AGENT_JOB_TYPE);
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(agentTaskInstance.getKey())
+            .withJobKey(job.jobKey())
+            .withJobLease(job.leaseToken())
             .create()
             .getKey();
-    awaitAndActivateJob(AGENT_JOB_TYPE);
 
     // when
-    ENGINE.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(AGENT_JOB_TYPE)
+        .withLeaseToken(job.leaseToken())
+        .complete();
 
     // then — the batch AGENT_INSTANCE:COMPLETE command is emitted as a follow-up to
     // PROCESS:COMPLETE_ELEMENT, and the agent instance itself is completed from it
@@ -125,10 +132,13 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
             .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
             .getFirst()
             .getKey();
+    final var job = awaitAndActivateAgentJob(processInstanceKey, AGENT_JOB_TYPE);
     final long agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(adHocSubProcessInstanceKey)
+            .withJobKey(job.jobKey())
+            .withJobLease(job.leaseToken())
             .create()
             .getKey();
 
@@ -139,6 +149,7 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .job()
         .ofInstance(processInstanceKey)
         .withType(AGENT_JOB_TYPE)
+        .withLeaseToken(job.leaseToken())
         .withResult(jobResult)
         .complete();
 
@@ -182,13 +193,15 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var agentTaskInstance = awaitElementActivated(processInstanceKey, AGENT_TASK_ID);
+    final var job = awaitAndActivateAgentJob(processInstanceKey, AGENT_JOB_TYPE);
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(agentTaskInstance.getKey())
+            .withJobKey(job.jobKey())
+            .withJobLease(job.leaseToken())
             .create()
             .getKey();
-    awaitAndActivateJob(AGENT_JOB_TYPE);
 
     // when — the agentic job is still active (never completed) when cancellation happens
     ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
@@ -222,15 +235,14 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var agentTaskInstance = awaitElementActivated(processInstanceKey, AGENT_TASK_ID);
     final long elementInstanceKey = agentTaskInstance.getKey();
+    final var job = awaitAndActivateAgentJob(processInstanceKey, agenticJobType);
     final long agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-
-    awaitAndActivateJob(agenticJobType);
-    final long jobKey =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(agenticJobType)
-            .getFirst()
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(job.jobKey())
+            .withJobLease(job.leaseToken())
+            .create()
             .getKey();
 
     final var historyItemId = Strings.newRandomValidBpmnId();
@@ -238,7 +250,8 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
-        .withJobKey(jobKey)
+        .withJobKey(job.jobKey())
+        .withJobLease(job.leaseToken())
         .withHistory(
             List.of(
                 new AgentHistoryRecord()
@@ -306,20 +319,24 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var firstTaskInstance = awaitElementActivated(processInstanceKey, AGENT_TASK_ID);
     final var secondTaskInstance = awaitElementActivated(processInstanceKey, otherAgentTaskId);
+    final var firstJob = awaitAndActivateAgentJob(processInstanceKey, AGENT_JOB_TYPE);
+    final var secondJob = awaitAndActivateAgentJob(processInstanceKey, otherAgentJobType);
     final var firstAgentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(firstTaskInstance.getKey())
+            .withJobKey(firstJob.jobKey())
+            .withJobLease(firstJob.leaseToken())
             .create()
             .getKey();
     final var secondAgentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(secondTaskInstance.getKey())
+            .withJobKey(secondJob.jobKey())
+            .withJobLease(secondJob.leaseToken())
             .create()
             .getKey();
-    awaitAndActivateJob(AGENT_JOB_TYPE);
-    awaitAndActivateJob(otherAgentJobType);
 
     final String unrelatedProcessId = "unrelated-process";
     final String unrelatedAgentJobType = "unrelated-agent";
@@ -338,17 +355,31 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         ENGINE.processInstance().ofBpmnProcessId(unrelatedProcessId).create();
     final var unrelatedTaskInstance =
         awaitElementActivated(unrelatedProcessInstanceKey, AGENT_TASK_ID);
+    final var unrelatedJob =
+        awaitAndActivateAgentJob(unrelatedProcessInstanceKey, unrelatedAgentJobType);
     final var unrelatedAgentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(unrelatedTaskInstance.getKey())
+            .withJobKey(unrelatedJob.jobKey())
+            .withJobLease(unrelatedJob.leaseToken())
             .create()
             .getKey();
 
     // when — only the process instance under test completes; the unrelated one's agentic job is
     // left active on purpose
-    ENGINE.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
-    ENGINE.job().ofInstance(processInstanceKey).withType(otherAgentJobType).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(AGENT_JOB_TYPE)
+        .withLeaseToken(firstJob.leaseToken())
+        .complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(otherAgentJobType)
+        .withLeaseToken(secondJob.leaseToken())
+        .complete();
 
     // then — a single AGENT_INSTANCE:COMPLETE command is written as a follow-up of the process
     // instance completing
@@ -448,18 +479,24 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
     final long childProcessInstanceKey = childProcessInstance.getValue().getProcessInstanceKey();
 
     final var agentTaskInstance = awaitElementActivated(childProcessInstanceKey, AGENT_TASK_ID);
+    final var job = awaitAndActivateAgentJob(childProcessInstanceKey, AGENT_JOB_TYPE);
     final long agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(agentTaskInstance.getKey())
+            .withJobKey(job.jobKey())
+            .withJobLease(job.leaseToken())
             .create()
             .getKey();
 
-    awaitAndActivateJob(AGENT_JOB_TYPE);
-
     // when — the child process instance completes (completing its agent instance), while the
     // parent's own parallel branch (parentTaskId) is still active
-    ENGINE.job().ofInstance(childProcessInstanceKey).withType(AGENT_JOB_TYPE).complete();
+    ENGINE
+        .job()
+        .ofInstance(childProcessInstanceKey)
+        .withType(AGENT_JOB_TYPE)
+        .withLeaseToken(job.leaseToken())
+        .complete();
 
     // then
     assertThat(
@@ -542,14 +579,15 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
     final long childProcessInstanceKey = childProcessInstance.getValue().getProcessInstanceKey();
 
     final var agentTaskInstance = awaitElementActivated(childProcessInstanceKey, AGENT_TASK_ID);
+    final var job = awaitAndActivateAgentJob(childProcessInstanceKey, AGENT_JOB_TYPE);
     final long agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(agentTaskInstance.getKey())
+            .withJobKey(job.jobKey())
+            .withJobLease(job.leaseToken())
             .create()
             .getKey();
-
-    awaitAndActivateJob(AGENT_JOB_TYPE);
 
     // when — the agentic job on the child process instance is still active when the parent
     // (and, cascading from it, the child) is canceled
@@ -702,4 +740,28 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
     RecordingExporter.jobRecords(JobIntent.CREATED).withType(jobType).await();
     ENGINE.jobs().withType(jobType).activate();
   }
+
+  private static ActivatedAgentJob awaitAndActivateAgentJob(
+      final long processInstanceKey, final String jobType) {
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(jobType)
+        .await();
+    final var jobBatch = ENGINE.jobs().withType(jobType).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(jobType)
+            .getFirst()
+            .getKey();
+    final var leaseToken =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    return new ActivatedAgentJob(jobKey, leaseToken);
+  }
+
+  private record ActivatedAgentJob(long jobKey, String leaseToken) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
@@ -143,22 +143,67 @@ public class AgentInstanceCompleteTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .withElementId(thirdTaskId)
             .getFirst();
+    final var firstJobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var firstJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var firstJobLease =
+        firstJobBatch
+            .getValue()
+            .getJobs()
+            .get(firstJobBatch.getValue().getJobKeys().indexOf(firstJobKey))
+            .getLeaseToken();
+    final var secondJobBatch = ENGINE.jobs().withType("other-agent").withLease().activate();
+    final var secondJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("other-agent")
+            .getFirst()
+            .getKey();
+    final var secondJobLease =
+        secondJobBatch
+            .getValue()
+            .getJobs()
+            .get(secondJobBatch.getValue().getJobKeys().indexOf(secondJobKey))
+            .getLeaseToken();
+    final var thirdJobBatch = ENGINE.jobs().withType("third-agent").withLease().activate();
+    final var thirdJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("third-agent")
+            .getFirst()
+            .getKey();
+    final var thirdJobLease =
+        thirdJobBatch
+            .getValue()
+            .getJobs()
+            .get(thirdJobBatch.getValue().getJobKeys().indexOf(thirdJobKey))
+            .getLeaseToken();
     final var firstAgentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(firstTaskInstance.getKey())
+            .withJobKey(firstJobKey)
+            .withJobLease(firstJobLease)
             .create()
             .getKey();
     final var secondAgentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(secondTaskInstance.getKey())
+            .withJobKey(secondJobKey)
+            .withJobLease(secondJobLease)
             .create()
             .getKey();
     final var thirdAgentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(thirdTaskInstance.getKey())
+            .withJobKey(thirdJobKey)
+            .withJobLease(thirdJobLease)
             .create()
             .getKey();
 
@@ -263,10 +308,25 @@ public class AgentInstanceCompleteTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteWithoutCommandBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteWithoutCommandBatchingTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -73,16 +74,46 @@ public class AgentInstanceCompleteWithoutCommandBatchingTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .withElementId(SECOND_TASK_ID)
             .getFirst();
+    final var firstJobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var firstJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var firstJobLease =
+        firstJobBatch
+            .getValue()
+            .getJobs()
+            .get(firstJobBatch.getValue().getJobKeys().indexOf(firstJobKey))
+            .getLeaseToken();
+    final var secondJobBatch = ENGINE.jobs().withType("other-agent").withLease().activate();
+    final var secondJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("other-agent")
+            .getFirst()
+            .getKey();
+    final var secondJobLease =
+        secondJobBatch
+            .getValue()
+            .getJobs()
+            .get(secondJobBatch.getValue().getJobKeys().indexOf(secondJobKey))
+            .getLeaseToken();
     final var firstAgentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(firstTaskInstance.getKey())
+            .withJobKey(firstJobKey)
+            .withJobLease(firstJobLease)
             .create()
             .getKey();
     final var secondAgentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(secondTaskInstance.getKey())
+            .withJobKey(secondJobKey)
+            .withJobLease(secondJobLease)
             .create()
             .getKey();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateAuthorizationTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
@@ -89,12 +90,28 @@ public final class AgentInstanceCreateAuthorizationTest {
         PermissionType.UPDATE_PROCESS_INSTANCE,
         AuthorizationResourceMatcher.ID,
         PROCESS_ID);
+    final var jobBatch =
+        engine.jobs().withType("agent").withLease().activate(DEFAULT_USER.getUsername());
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withType("agent")
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when
     final var created =
         engine
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create(user.getUsername());
 
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
@@ -71,13 +71,19 @@ public class AgentInstanceCreateTest {
             .setName("seeded-tool")
             .setDescription("a tool seeded by the client")
             .setElementId("inner-task");
-    ENGINE.jobs().withType("agent").activate();
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType("agent")
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var configItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-config")
@@ -99,6 +105,7 @@ public class AgentInstanceCreateTest {
             .withMetricsDelta(50L, 25L, 5, 3)
             .withTools(List.of(seededTool))
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem))
             .create();
 
@@ -151,10 +158,28 @@ public class AgentInstanceCreateTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .withElementId(customElementId)
             .getFirst();
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when
     final var created =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstance.getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create();
 
     // then
     assertThat(created.getValue().getElementInstanceKey()).isEqualTo(elementInstance.getKey());
@@ -199,10 +224,28 @@ public class AgentInstanceCreateTest {
             .withElementType(BpmnElementType.PROCESS)
             .getFirst();
     final var childServiceTaskInstance = awaitServiceTaskActivated(childProcessInstance.getKey());
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(childProcessInstance.getKey())
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when
     final var created =
-        ENGINE.agentInstances().withElementInstanceKey(childServiceTaskInstance.getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(childServiceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create();
 
     // then
     assertThat(created.getValue().getProcessInstanceKey()).isEqualTo(childProcessInstance.getKey());
@@ -229,10 +272,28 @@ public class AgentInstanceCreateTest {
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when
     final var created =
-        ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create();
 
     // then
     assertThat(created.getValue().getProcessDefinitionVersionTag())
@@ -266,10 +327,28 @@ public class AgentInstanceCreateTest {
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when
     final var created =
-        ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create();
 
     // then -- the CREATED event links back to the element's AgentDefinition version.
     assertThat(created.getValue().getAgentDefinitionKey()).isEqualTo(agentDefinitionKey);
@@ -323,6 +402,19 @@ public class AgentInstanceCreateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when -- the command tries to set a different status; engine must ignore it.
     final var created =
@@ -330,6 +422,8 @@ public class AgentInstanceCreateTest {
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
             .withStatus(AgentInstanceStatus.THINKING)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create();
 
     // then
@@ -351,6 +445,19 @@ public class AgentInstanceCreateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when -- even when the command carries non-default metrics, the engine resets them.
     final var created =
@@ -358,6 +465,8 @@ public class AgentInstanceCreateTest {
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
             .withMetricsDelta(50L, 25L, 5, 3)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create();
 
     // then
@@ -383,13 +492,19 @@ public class AgentInstanceCreateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
-    ENGINE.jobs().withType("agent").activate();
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType("agent")
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when -- limits supplied via a CONFIGURATION history item in CREATE's own history batch are
     // applied inline by AgentInstanceCreateProcessor, before it appends AGENT_INSTANCE:CREATED.
@@ -405,6 +520,7 @@ public class AgentInstanceCreateTest {
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem))
             .create();
 
@@ -429,10 +545,28 @@ public class AgentInstanceCreateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when
     final var created =
-        ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create();
 
     // then
     assertThat(created.getIntent()).isEqualTo(AgentInstanceIntent.CREATED);
@@ -441,8 +575,8 @@ public class AgentInstanceCreateTest {
 
   @Test
   public void shouldAcceptAdHocSubProcessElementType() {
-    // given -- an ad-hoc subprocess with an inner task and a completion condition that keeps the
-    // ad-hoc subprocess element active long enough for us to attach an agent instance to it.
+    // given -- an ad-hoc subprocess with an inner task whose job is never completed, which keeps
+    // the ad-hoc subprocess element active long enough for us to attach an agent instance to it.
     ENGINE
         .deployment()
         .withXmlResource(
@@ -452,28 +586,41 @@ public class AgentInstanceCreateTest {
                     AD_HOC_SUB_PROCESS_ID,
                     asp -> {
                       asp.zeebeAiAgentSubProcessDefinition();
+                      asp.zeebeJobType("agent");
                       asp.task("inner-task");
-                      asp.completionCondition("=completionCondition");
                     })
                 .endEvent()
                 .done())
         .deploy();
-    final var processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withVariables(Map.of("completionCondition", false))
-            .create();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     final var adHocInstance =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
             .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
             .getFirst();
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when
     final var created =
-        ENGINE.agentInstances().withElementInstanceKey(adHocInstance.getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(adHocInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create();
 
     // then
     assertThat(created.getIntent()).isEqualTo(AgentInstanceIntent.CREATED);
@@ -517,11 +664,45 @@ public class AgentInstanceCreateTest {
             .toList();
     assertThat(children).hasSize(2);
 
+    final var jobBatch =
+        ENGINE.jobs().withType("agent").withMaxJobsToActivate(2).withLease().activate();
+    final var jobKeys =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .limit(2)
+            .map(Record::getKey)
+            .toList();
+    final var firstJobKey = jobKeys.get(0);
+    final var firstJobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(firstJobKey))
+            .getLeaseToken();
+    final var secondJobKey = jobKeys.get(1);
+    final var secondJobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(secondJobKey))
+            .getLeaseToken();
+
     // when -- create an agent instance for each child element instance.
     final var firstAgent =
-        ENGINE.agentInstances().withElementInstanceKey(children.get(0).getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(children.get(0).getKey())
+            .withJobKey(firstJobKey)
+            .withJobLease(firstJobLease)
+            .create();
     final var secondAgent =
-        ENGINE.agentInstances().withElementInstanceKey(children.get(1).getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(children.get(1).getKey())
+            .withJobKey(secondJobKey)
+            .withJobLease(secondJobLease)
+            .create();
 
     // then -- each child gets its own agent instance with distinct keys.
     assertThat(firstAgent.getValue().getElementInstanceKey()).isEqualTo(children.get(0).getKey());
@@ -546,10 +727,28 @@ public class AgentInstanceCreateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     // when
     final var first =
-        ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create();
     final var secondRejection =
         ENGINE
             .agentInstances()
@@ -644,11 +843,34 @@ public class AgentInstanceCreateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     final var first =
-        ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create();
 
-    ENGINE.job().ofInstance(processInstanceKey).withType("agent").complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType("agent")
+        .withLeaseToken(jobLease)
+        .complete();
     RecordingExporter.incidentRecords(IncidentIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
         .getFirst();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -1067,6 +1067,73 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldRejectStatusOnlyUpdateWithoutJobKey() {
+    // given — the missing-jobKey tests above all attach a nonempty history batch, exercising only
+    // the branch that used to permit an omitted jobKey once the batch itself was empty. A
+    // status-only UPDATE never carries a history batch at all, so jobKey must be proven required
+    // on that path too, independently of the history-batch-driven checks.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
+            .getKey();
+
+    // when — no withJobKey(...) call and no withHistory(...) call: a pure status update
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .expectRejection()
+            .update();
+
+    // then — jobKey defaults to -1 when unset, and validateJobContext rejects it regardless of
+    // whether a history batch is attached.
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance, but no jobKey was provided. A command must always "
+                + "be attributed to the active job that produced it.");
+  }
+
+  @Test
   public void shouldRejectHistoryBatchWithoutJobLeaseOnUpdate() {
     // given — UPDATE runs with LeaseMismatchHandling.ALLOW_STALE, which skips the lease-mismatch
     // check entirely; jobLease must still be rejected as missing before that check is even

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -971,6 +971,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(999999999L)
+            .withJobLease(jobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -5221,6 +5222,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei2)
             .withJobKey(job1Key)
+            .withJobLease(job1Lease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -1208,6 +1208,151 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldRejectCreateWhenJobNotLeased() {
+    // given — the job is activated without a lease at all; a nonblank jobLease supplied on the
+    // command can never match a lease the job never held, so this must be rejected before the
+    // lease-mismatch check is even reached.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("some-nonblank-lease-token")
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance related to job with key '%d', but job has no "
+                    .formatted(jobKey)
+                + "lease token. The job must be activated with a lease before it can be "
+                + "referenced.");
+  }
+
+  @Test
+  public void shouldRejectUpdateWhenJobNotLeased() {
+    // given — jobKey1 is activated with a lease and creates the agent instance, exactly like any
+    // other CREATE. jobKey2 belongs to a second process instance of the same job type and is
+    // activated without a lease: once a job has ever carried a lease token, JobBatchCollector
+    // skips it for any later lease-less activation (SKIPPED_LEASED), so a job can only end up
+    // ACTIVATED with no lease token at all by never having been leased in the first place. The
+    // UPDATE command below references jobKey2 to exercise that state; validateJobContext checks
+    // the referenced job's own lease before it ever compares elementInstanceKey, so jobKey2 not
+    // actually belonging to elementInstanceKey1 doesn't stand in the way of reaching that check.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey1 = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey1 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey1)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var leasedBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobKey1 =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey1)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var leasedToken =
+        leasedBatch
+            .getValue()
+            .getJobs()
+            .get(leasedBatch.getValue().getJobKeys().indexOf(jobKey1))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey1)
+            .withJobKey(jobKey1)
+            .withJobLease(leasedToken)
+            .create()
+            .getKey();
+
+    final var processInstanceKey2 = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey2 =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey2)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey1)
+            .withJobKey(jobKey2)
+            .withJobLease("some-nonblank-lease-token")
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance related to job with key '%d', but job has no "
+                    .formatted(jobKey2)
+                + "lease token. The job must be activated with a lease before it can be "
+                + "referenced.");
+  }
+
+  @Test
   public void shouldAcceptUpdateWithSupersededJobLeaseAndAccumulateItsMetrics() {
     // given
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -96,12 +96,13 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .expectRejection()
             .create();
 
-    // then
+    // then — jobKey defaults to -1 when unset, and validateJobContext rejects the missing jobKey
+    // outright rather than looking it up as a job reference.
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            "Expected a job to be provided for the embedded history batch, but no jobKey was "
-                + "set. A history batch must be attributed to the active job that produced it.");
+            "Expected to update agent instance, but no jobKey was provided. A command must always "
+                + "be attributed to the active job that produced it.");
   }
 
   @Test
@@ -221,13 +222,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var item =
         new AgentHistoryRecord()
             .setHistoryItemId("item-" + role)
@@ -244,6 +251,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .withHistory(List.of(item))
             .expectRejection()
@@ -281,13 +289,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var item =
         new AgentHistoryRecord()
             .setHistoryItemId("item-unspecified")
@@ -304,6 +318,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .withHistory(List.of(item))
             .expectRejection()
@@ -375,13 +390,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var userItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-user")
@@ -399,6 +420,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .withHistory(List.of(userItem))
             .expectRejection()
@@ -436,13 +458,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var userItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-user")
@@ -460,6 +488,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .withHistory(List.of(userItem))
             .create();
@@ -492,13 +521,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var configurationItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-configuration")
@@ -521,6 +556,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .withHistory(List.of(configurationItem, userItem))
             .create();
@@ -552,14 +588,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var validItem =
         new AgentHistoryRecord()
@@ -579,6 +627,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(validItem, invalidItem))
             .expectRejection()
             .update();
@@ -616,14 +665,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var invalidItem = new AgentHistoryRecord().setHistoryItemId("item-1");
 
@@ -634,6 +695,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(invalidItem))
             .expectRejection()
             .update();
@@ -669,14 +731,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var invalidItem =
         new AgentHistoryRecord().setHistoryItemId("item-1").setRole(AgentHistoryRole.USER);
@@ -688,6 +762,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(invalidItem))
             .expectRejection()
             .update();
@@ -724,14 +799,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var invalidItem =
         new AgentHistoryRecord()
@@ -747,6 +834,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(invalidItem))
             .expectRejection()
             .update();
@@ -784,14 +872,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var invalidItem =
         new AgentHistoryRecord()
@@ -806,6 +906,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(invalidItem))
             .expectRejection()
             .update();
@@ -841,9 +942,27 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
+            .getKey();
 
     // when — a jobKey that was never activated
     final var rejection =
@@ -896,9 +1015,27 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
+            .getKey();
 
     // when — no withJobKey(...) call at all
     final var rejection =
@@ -919,12 +1056,13 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .expectRejection()
             .update();
 
-    // then
+    // then — jobKey defaults to -1 when unset, and validateJobContext rejects the missing jobKey
+    // outright rather than looking it up as a job reference.
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            "Expected a job to be provided for the embedded history batch, but no jobKey was "
-                + "set. A history batch must be attributed to the active job that produced it.");
+            "Expected to update agent instance, but no jobKey was provided. A command must always "
+                + "be attributed to the active job that produced it.");
   }
 
   @Test
@@ -1101,16 +1239,42 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var ei1 = children.get(0).getKey();
     final var ei2 = children.get(1).getKey();
 
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(ei1).create().getKey();
-
-    ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).activate();
+    final var jobBatch =
+        ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).withLease().activate();
+    final var ei1JobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .filter(r -> r.getValue().getElementInstanceKey() == ei1)
+            .getFirst()
+            .getKey();
+    final var ei1JobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(ei1JobKey))
+            .getLeaseToken();
     final var ei2JobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .filter(r -> r.getValue().getElementInstanceKey() == ei2)
             .getFirst()
+            .getKey();
+    final var ei2JobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(ei2JobKey))
+            .getLeaseToken();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withJobKey(ei1JobKey)
+            .withJobLease(ei1JobLease)
+            .create()
             .getKey();
 
     // when — targets EI1 (the current writer, so the writer check passes), but supplies EI2's
@@ -1121,6 +1285,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei1)
             .withJobKey(ei2JobKey)
+            .withJobLease(ei2JobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -1170,14 +1335,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var userItem =
         new AgentHistoryRecord()
@@ -1215,6 +1392,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(userItem, assistantItem, toolResultItem))
             .update();
 
@@ -1272,14 +1450,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var firstAssistantItem =
         new AgentHistoryRecord()
@@ -1301,6 +1491,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(firstAssistantItem))
             .update();
 
@@ -1344,6 +1535,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(secondAssistantItem, thirdAssistantItem))
             .update();
 
@@ -1380,14 +1572,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var assistantItem =
         new AgentHistoryRecord()
@@ -1411,6 +1615,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(assistantItem))
             .update();
 
@@ -1443,14 +1648,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var toolResultItem =
         new AgentHistoryRecord()
@@ -1470,6 +1687,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(toolResultItem))
             .update();
 
@@ -1501,14 +1719,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var userItem =
         new AgentHistoryRecord()
@@ -1527,6 +1757,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(userItem))
             .update();
 
@@ -1557,13 +1788,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     // baseline: applied inline by CREATE, see AgentInstanceCreateProcessor.
     final var baselineConfigItem =
         new AgentHistoryRecord()
@@ -1581,6 +1818,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(baselineConfigItem))
             .create()
             .getKey();
@@ -1613,6 +1851,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem))
             .update();
 
@@ -1698,13 +1937,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     // baseline: applied inline by CREATE, see AgentInstanceCreateProcessor.
     final var baselineConfigItem =
         new AgentHistoryRecord()
@@ -1718,6 +1963,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(baselineConfigItem))
             .create()
             .getKey();
@@ -1736,6 +1982,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem))
             .update();
 
@@ -1784,13 +2031,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     // baseline: applied inline by CREATE, see AgentInstanceCreateProcessor.
     final var baselineConfigItem =
         new AgentHistoryRecord()
@@ -1804,6 +2057,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(baselineConfigItem))
             .create()
             .getKey();
@@ -1826,6 +2080,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(userItem))
             .update();
 
@@ -1857,14 +2112,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
 
     // when — old-style direct metrics delta combined with a history batch in the same request:
@@ -1876,6 +2143,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -1920,14 +2188,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
 
     // when — direct metrics delta, no history batch at all
@@ -1937,6 +2217,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withMetricsDelta(10L, 5L, 1, 0)
             .expectRejection()
             .update();
@@ -1971,14 +2252,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
 
     // when — old-style direct tools change combined with a history batch in the same request
@@ -1988,6 +2281,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -2032,14 +2326,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
 
     // when — direct tools change, no history batch at all
@@ -2049,6 +2355,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withTools(List.of(AgentInstanceClient.tool("calc", "a calculator", "calc-task")))
             .expectRejection()
             .update();
@@ -2083,13 +2390,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var userItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-user")
@@ -2106,6 +2419,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(userItem))
             .create();
 
@@ -2144,13 +2458,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var configItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-config")
@@ -2170,6 +2490,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementInstanceKey(elementInstanceKey)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem))
             .create();
 
@@ -2214,13 +2535,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     // content/toolCalls are conversation-payload fields that a CONFIGURATION item should never
     // carry in practice, but setting them here proves the COMMITTED event is genuinely built by
     // reading the trimmed record back from state — reusing the untrimmed in-memory `item` instead
@@ -2248,6 +2575,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem))
             .create();
 
@@ -2312,13 +2640,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var configItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-config")
@@ -2338,6 +2672,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem, userItem))
             .create();
 
@@ -2387,13 +2722,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var modelItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-config-model")
@@ -2416,6 +2757,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementInstanceKey(elementInstanceKey)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(modelItem, toolsItem))
             .create();
 
@@ -2457,13 +2799,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var configItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-config")
@@ -2478,6 +2826,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementInstanceKey(elementInstanceKey)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem))
             .create();
     final var agentInstanceKey = created.getKey();
@@ -2533,13 +2882,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var userItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-user")
@@ -2551,6 +2906,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(userItem))
             .create();
     final var userHistoryKey =
@@ -2589,20 +2945,33 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
+            .getKey();
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
         .withJobKey(jobKey)
+        .withJobLease(jobLease)
         .withHistory(
             List.of(
                 new AgentHistoryRecord()
@@ -2621,6 +2990,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withStatus(AgentInstanceStatus.THINKING)
             .update();
 
@@ -2655,14 +3026,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
 
     // when — first submission creates the item
@@ -2672,6 +3055,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -2693,6 +3077,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -2748,14 +3133,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var assistantItem =
         new AgentHistoryRecord()
@@ -2777,6 +3174,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(assistantItem))
             .update();
     assertThat(firstUpdate.getValue().getMetrics().getInputTokens()).isEqualTo(100L);
@@ -2802,6 +3200,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(resentAssistantItem))
             .update();
 
@@ -2837,13 +3236,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     // baseline: applied inline by CREATE, see AgentInstanceCreateProcessor.
     final var baselineConfigItem =
         new AgentHistoryRecord()
@@ -2858,6 +3263,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(baselineConfigItem))
             .create()
             .getKey();
@@ -2876,6 +3282,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(configItem))
             .update();
     assertThat(firstUpdate.getValue().getDefinition().getModel()).isEqualTo("gpt-4o");
@@ -2897,6 +3304,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(resentConfigItem))
             .update();
     assertThat(secondUpdate.getValue().getChangedAttributes()).doesNotContain("model");
@@ -2938,14 +3346,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
 
     final var userItem =
@@ -2990,6 +3410,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(userItem, assistantItem, toolResultItem, configItem))
             .update();
     final var originalKeys =
@@ -3004,6 +3425,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -3072,14 +3494,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var itemA =
         new AgentHistoryRecord()
@@ -3105,6 +3539,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(itemA, itemB))
             .update();
     final var keyA = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
@@ -3118,6 +3553,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -3196,14 +3632,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
     final var firstItem =
         new AgentHistoryRecord()
@@ -3231,6 +3679,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(List.of(firstItem, secondItem))
             .expectRejection()
             .update();
@@ -3294,17 +3743,43 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var ei1 = children.get(0).getKey();
     final var ei2 = children.get(1).getKey();
 
-    // the agent instance is created on EI1; EI1 remains active (parallel multi-instance).
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(ei1).create().getKey();
-
-    ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).activate();
+    final var jobBatch =
+        ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).withLease().activate();
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .filter(r -> r.getValue().getElementInstanceKey() == ei1)
+            .getFirst()
+            .getKey();
+    final var job1Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
     final var job2Key =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .filter(r -> r.getValue().getElementInstanceKey() == ei2)
             .getFirst()
+            .getKey();
+    final var job2Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job2Key))
+            .getLeaseToken();
+
+    // the agent instance is created on EI1; EI1 remains active (parallel multi-instance).
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
+            .create()
             .getKey();
 
     // when — EI2, a second, still-active element instance, attempts to push a history batch to
@@ -3315,6 +3790,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei2)
             .withJobKey(job2Key)
+            .withJobLease(job2Lease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -3379,10 +3855,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var ei1 = children.get(0).getKey();
     final var ei2 = children.get(1).getKey();
 
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(ei1).create().getKey();
-
-    ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).activate();
+    final var jobBatch =
+        ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).withLease().activate();
     final var activatedJobs =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -3395,17 +3869,38 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .findFirst()
             .orElseThrow()
             .getKey();
+    final var job1Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
     final var job2Key =
         activatedJobs.stream()
             .filter(r -> r.getValue().getElementInstanceKey() == ei2)
             .findFirst()
             .orElseThrow()
             .getKey();
+    final var job2Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job2Key))
+            .getLeaseToken();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
+            .create()
+            .getKey();
 
     // EI1's job fails with no retries left, raising an incident. EI1 itself stays active — job
     // failure and element-instance completion are independent, so the element instance does not
     // reflect that its writer is done.
-    ENGINE.job().withKey(job1Key).withRetries(0).fail();
+    ENGINE.job().withKey(job1Key).withRetries(0).withLeaseToken(job1Lease).fail();
 
     // when — EI2 pushes a history batch to the same agent instance. EI1 is still active, but its
     // job is no longer ACTIVATED, so EI1 can no longer be mid-write.
@@ -3415,6 +3910,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei2)
             .withJobKey(job2Key)
+            .withJobLease(job2Lease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -3471,10 +3967,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var ei1 = children.get(0).getKey();
     final var ei2 = children.get(1).getKey();
 
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(ei1).create().getKey();
-
-    ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).activate();
+    final var jobBatch =
+        ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).withLease().activate();
     final var activatedJobs =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -3487,12 +3981,40 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .findFirst()
             .orElseThrow()
             .getKey();
+    final var job1Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
+    final var job2Key =
+        activatedJobs.stream()
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2)
+            .findFirst()
+            .orElseThrow()
+            .getKey();
+    final var job2Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job2Key))
+            .getLeaseToken();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
+            .create()
+            .getKey();
 
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(ei1)
         .withJobKey(job1Key)
+        .withJobLease(job1Lease)
         .withHistory(
             List.of(
                 new AgentHistoryRecord()
@@ -3512,6 +4034,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei2)
+            .withJobKey(job2Key)
+            .withJobLease(job2Lease)
             .withStatus(AgentInstanceStatus.THINKING)
             .withChangedAttributes(List.of("status"))
             .expectRejection()
@@ -3539,6 +4063,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei1)
             .withJobKey(job1Key)
+            .withJobLease(job1Lease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -3578,9 +4103,6 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-
     final var batch1 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
@@ -3590,6 +4112,15 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .getKey();
     final var jobIndex1 = batch1.getValue().getJobKeys().indexOf(jobKey);
     final var lease1 = batch1.getValue().getJobs().get(jobIndex1).getLeaseToken();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(lease1)
+            .create()
+            .getKey();
 
     ENGINE
         .agentInstances()
@@ -3673,9 +4204,6 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-
     // Activation 1 (superseded): push the item under lease1, carrying non-zero token/tool-call
     // deltas, then fail the job to trigger re-activation. Its copy stays pending — never
     // committed, never discarded.
@@ -3688,6 +4216,15 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .getKey();
     final var jobIndex1 = batch1.getValue().getJobKeys().indexOf(jobKey);
     final var lease1 = batch1.getValue().getJobs().get(jobIndex1).getLeaseToken();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(lease1)
+            .create()
+            .getKey();
 
     final var firstItem =
         new AgentHistoryRecord()
@@ -3807,11 +4344,35 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .getFirst()
             .getKey();
 
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(ei1).create().getKey();
+    final var job1Batch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var job1Lease =
+        job1Batch
+            .getValue()
+            .getJobs()
+            .get(job1Batch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
 
-    ENGINE.jobs().withType(helper.getJobType()).activate();
-    ENGINE.job().ofInstance(processInstanceKey).withType(helper.getJobType()).complete();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
+            .create()
+            .getKey();
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(helper.getJobType())
+        .withLeaseToken(job1Lease)
+        .complete();
 
     final var ei2 =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -3823,7 +4384,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .get(1)
             .getKey();
 
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var job2Batch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var job2Key =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -3831,6 +4392,12 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .filter(r -> r.getValue().getElementInstanceKey() == ei2)
             .getFirst()
             .getKey();
+    final var job2Lease =
+        job2Batch
+            .getValue()
+            .getJobs()
+            .get(job2Batch.getValue().getJobKeys().indexOf(job2Key))
+            .getLeaseToken();
 
     // when
     final var updated =
@@ -3839,6 +4406,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei2)
             .withJobKey(job2Key)
+            .withJobLease(job2Lease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -3892,15 +4460,27 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(ei1).create().getKey();
-
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var job1Batch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var job1Key =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var job1Lease =
+        job1Batch
+            .getValue()
+            .getJobs()
+            .get(job1Batch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
+            .create()
             .getKey();
 
     // when — job1 pushes "item-x", then completes, committing it
@@ -3910,6 +4490,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei1)
             .withJobKey(job1Key)
+            .withJobLease(job1Lease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -3923,7 +4504,12 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .update();
     final var originalKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
 
-    ENGINE.job().ofInstance(processInstanceKey).withType(helper.getJobType()).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(helper.getJobType())
+        .withLeaseToken(job1Lease)
+        .complete();
     RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
         .withJobKey(job1Key)
         .getFirst();
@@ -3937,7 +4523,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .toList()
             .get(1)
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var job2Batch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var job2Key =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -3945,6 +4531,12 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .filter(r -> r.getValue().getElementInstanceKey() == ei2)
             .getFirst()
             .getKey();
+    final var job2Lease =
+        job2Batch
+            .getValue()
+            .getJobs()
+            .get(job2Batch.getValue().getJobKeys().indexOf(job2Key))
+            .getLeaseToken();
 
     // when — job2 (a brand-new job, on a brand-new element instance) resends "item-x", with
     // different content
@@ -3954,6 +4546,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei2)
             .withJobKey(job2Key)
+            .withJobLease(job2Lease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -4009,14 +4602,27 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKeyA =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKeyA).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobABatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobAKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKeyA)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobALease =
+        jobABatch
+            .getValue()
+            .getJobs()
+            .get(jobABatch.getValue().getJobKeys().indexOf(jobAKey))
+            .getLeaseToken();
+
+    final var agentInstanceKeyA =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withJobKey(jobAKey)
+            .withJobLease(jobALease)
+            .create()
             .getKey();
 
     final var firstUpdate =
@@ -4025,6 +4631,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKeyA)
             .withElementInstanceKey(elementInstanceKeyA)
             .withJobKey(jobAKey)
+            .withJobLease(jobALease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -4049,6 +4656,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKeyA)
             .withElementInstanceKey(elementInstanceKeyA)
             .withJobKey(jobAKey)
+            .withJobLease(jobALease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -4077,14 +4685,27 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKeyB =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKeyB).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobBKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKeyB)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobBLease =
+        jobBBatch
+            .getValue()
+            .getJobs()
+            .get(jobBBatch.getValue().getJobKeys().indexOf(jobBKey))
+            .getLeaseToken();
+
+    final var agentInstanceKeyB =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyB)
+            .withJobKey(jobBKey)
+            .withJobLease(jobBLease)
+            .create()
             .getKey();
 
     // when — the SAME historyItemId ("item-shared") is sent under agent instance B for the first
@@ -4095,6 +4716,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKeyB)
             .withElementInstanceKey(elementInstanceKeyB)
             .withJobKey(jobBKey)
+            .withJobLease(jobBLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -4137,14 +4759,27 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKeyA =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKeyA).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobABatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobAKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKeyA)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobALease =
+        jobABatch
+            .getValue()
+            .getJobs()
+            .get(jobABatch.getValue().getJobKeys().indexOf(jobAKey))
+            .getLeaseToken();
+
+    final var agentInstanceKeyA =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withJobKey(jobAKey)
+            .withJobLease(jobALease)
+            .create()
             .getKey();
 
     final var itemForA =
@@ -4163,6 +4798,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKeyA)
             .withElementInstanceKey(elementInstanceKeyA)
             .withJobKey(jobAKey)
+            .withJobLease(jobALease)
             .withHistory(List.of(itemForA))
             .update();
 
@@ -4179,14 +4815,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKeyB =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKeyB).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobBKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKeyB)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobBLease =
+        jobBBatch
+            .getValue()
+            .getJobs()
+            .get(jobBBatch.getValue().getJobKeys().indexOf(jobBKey))
+            .getLeaseToken();
+    final var agentInstanceKeyB =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyB)
+            .withJobKey(jobBKey)
+            .withJobLease(jobBLease)
+            .create()
             .getKey();
 
     // when — the SAME historyItemId ("item-shared") is sent to agent instance B for the first
@@ -4207,6 +4855,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKeyB)
             .withElementInstanceKey(elementInstanceKeyB)
             .withJobKey(jobBKey)
+            .withJobLease(jobBLease)
             .withHistory(List.of(itemForB))
             .update();
 
@@ -4249,14 +4898,26 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
             .getKey();
 
     final var committedItem =
@@ -4341,6 +5002,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withHistory(
                 List.of(
                     new AgentHistoryRecord()
@@ -4436,11 +5098,36 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .getFirst()
             .getKey();
 
-    final var agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(ei1).create().getKey();
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .filter(r -> r.getValue().getElementInstanceKey() == ei1)
+            .getFirst()
+            .getKey();
+    final var job1Batch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var job1Lease =
+        job1Batch
+            .getValue()
+            .getJobs()
+            .get(job1Batch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
 
-    ENGINE.jobs().withType(helper.getJobType()).activate();
-    ENGINE.job().ofInstance(processInstanceKey).withType(helper.getJobType()).complete();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
+            .create()
+            .getKey();
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(helper.getJobType())
+        .withLeaseToken(job1Lease)
+        .complete();
 
     final var ei2 =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -4454,14 +5141,6 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // when — a resend reuses job1 (EI1's own, now-completed job) but targets EI2 (still active),
     // so the rejection reflects job1's own state, not EI2's — which is otherwise valid.
-    final var job1Key =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(helper.getJobType())
-            .filter(r -> r.getValue().getElementInstanceKey() == ei1)
-            .getFirst()
-            .getKey();
-
     final var rejection =
         ENGINE
             .agentInstances()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -1066,6 +1066,80 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldRejectHistoryBatchWithoutJobLeaseOnUpdate() {
+    // given — UPDATE runs with LeaseMismatchHandling.ALLOW_STALE, which skips the lease-mismatch
+    // check entirely; jobLease must still be rejected as missing before that check is even
+    // reached, or an UPDATE could go through with no fencing token at all.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var jobBatch = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
+            .create()
+            .getKey();
+
+    // when — jobKey is supplied but no withJobLease(...) call at all, so jobLease defaults to ""
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance related to job with key '%d', but no jobLease was "
+                    .formatted(jobKey)
+                + "provided. A command must always carry the lease its job was activated with.");
+  }
+
+  @Test
   public void shouldAcceptUpdateWithSupersededJobLeaseAndAccumulateItsMetrics() {
     // given
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
@@ -98,8 +99,7 @@ public class AgentInstanceSuspensionGateTest {
             .getValue()
             .getProcessInstanceKey();
 
-    final long agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey, processInstanceKey);
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
@@ -164,8 +164,7 @@ public class AgentInstanceSuspensionGateTest {
             .getValue()
             .getProcessInstanceKey();
 
-    final long agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey, processInstanceKey);
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
@@ -210,8 +209,7 @@ public class AgentInstanceSuspensionGateTest {
             .getValue()
             .getProcessInstanceKey();
 
-    final long agentInstanceKey =
-        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey, processInstanceKey);
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
@@ -225,6 +223,30 @@ public class AgentInstanceSuspensionGateTest {
             .withRecordKey(agentInstanceKey)
             .getFirst();
     assertThat(completed).isNotNull();
+  }
+
+  private static long createAgentInstance(
+      final long elementInstanceKey, final long processInstanceKey) {
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
+        .create()
+        .getKey();
   }
 
   private static long activateServiceTask() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -101,6 +102,8 @@ public final class AgentInstanceUpdateAuthorizationTest {
             .withAgentInstanceKey(instance.agentInstanceKey())
             .withElementInstanceKey(instance.elementInstanceKey())
             .withStatus(AgentInstanceStatus.THINKING)
+            .withJobKey(instance.jobKey())
+            .withJobLease(instance.jobLease())
             .update(user.getUsername());
 
     // then
@@ -185,15 +188,36 @@ public final class AgentInstanceUpdateAuthorizationTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
+    final var jobBatch =
+        engine
+            .jobs()
+            .withType("agent")
+            .withTenantIds(List.of(tenantId))
+            .withLease()
+            .activate(DEFAULT_USER.getUsername());
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         engine
             .agentInstances()
             .withElementInstanceKey(elementInstanceKey)
             .withAuthorizedTenantIds(tenantId)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create(DEFAULT_USER.getUsername())
             .getValue()
             .getAgentInstanceKey();
-    return new AgentInstanceRef(agentInstanceKey, elementInstanceKey);
+    return new AgentInstanceRef(agentInstanceKey, elementInstanceKey, jobKey, jobLease);
   }
 
   private void assignUserToTenant(final String tenantId, final String username) {
@@ -234,5 +258,6 @@ public final class AgentInstanceUpdateAuthorizationTest {
         .create(DEFAULT_USER.getUsername());
   }
 
-  private record AgentInstanceRef(long agentInstanceKey, long elementInstanceKey) {}
+  private record AgentInstanceRef(
+      long agentInstanceKey, long elementInstanceKey, long jobKey, String jobLease) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -53,10 +54,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -67,6 +83,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withStatus(AgentInstanceStatus.THINKING)
             .withChangedAttributes(List.of("status"))
             .update();
@@ -92,10 +110,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -107,6 +140,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withStatus(AgentInstanceStatus.THINKING)
             .withMetricsDelta(99L, 88L, 7, 5)
             .withTools(tools(tool("calc", "Calculator", "calc-task")))
@@ -138,10 +173,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -153,6 +203,8 @@ public class AgentInstanceUpdateTest {
               .agentInstances()
               .withAgentInstanceKey(agentInstanceKey)
               .withElementInstanceKey(serviceTaskInstance.getKey())
+              .withJobKey(jobKey)
+              .withJobLease(jobLease)
               .withChangedAttributes(List.of(unknownAttr))
               .expectRejection()
               .update();
@@ -179,10 +231,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -193,6 +260,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withChangedAttributes(List.of("limits"))
             .expectRejection()
             .update();
@@ -238,10 +307,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -252,6 +336,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withStatus(AgentInstanceStatus.INITIALIZING)
             .withChangedAttributes(List.of("status"))
             .update();
@@ -276,10 +362,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -291,6 +392,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withStatus(AgentInstanceStatus.UNSPECIFIED)
             .withChangedAttributes(List.of("status"))
             .expectRejection()
@@ -341,10 +444,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -355,6 +473,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withStatus(AgentInstanceStatus.COMPLETED)
             .withChangedAttributes(List.of("status"))
             .expectRejection()
@@ -396,10 +516,25 @@ public class AgentInstanceUpdateTest {
         final var processInstanceKey =
             ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
         final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+        final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+        final var jobKey =
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType("agent")
+                .getFirst()
+                .getKey();
+        final var jobLease =
+            jobBatch
+                .getValue()
+                .getJobs()
+                .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+                .getLeaseToken();
         final var agentInstanceKey =
             ENGINE
                 .agentInstances()
                 .withElementInstanceKey(serviceTaskInstance.getKey())
+                .withJobKey(jobKey)
+                .withJobLease(jobLease)
                 .create()
                 .getValue()
                 .getAgentInstanceKey();
@@ -409,6 +544,8 @@ public class AgentInstanceUpdateTest {
               .agentInstances()
               .withAgentInstanceKey(agentInstanceKey)
               .withElementInstanceKey(serviceTaskInstance.getKey())
+              .withJobKey(jobKey)
+              .withJobLease(jobLease)
               .withStatus(from)
               .withChangedAttributes(List.of("status"))
               .update();
@@ -419,6 +556,8 @@ public class AgentInstanceUpdateTest {
                 .agentInstances()
                 .withAgentInstanceKey(agentInstanceKey)
                 .withElementInstanceKey(serviceTaskInstance.getKey())
+                .withJobKey(jobKey)
+                .withJobLease(jobLease)
                 .withStatus(to)
                 .withChangedAttributes(List.of("status"))
                 .update();
@@ -468,15 +607,49 @@ public class AgentInstanceUpdateTest {
             .toList();
     final var ei1 = children.get(0);
     final var ei2 = children.get(1);
+    final var jobBatch =
+        ENGINE.jobs().withType("agent").withLease().withMaxJobsToActivate(2).activate();
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .filter(r -> r.getValue().getElementInstanceKey() == ei1.getKey())
+            .getFirst()
+            .getKey();
+    final var job1Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
+    final var job2Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2.getKey())
+            .getFirst()
+            .getKey();
+    final var job2Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job2Key))
+            .getLeaseToken();
 
     // Create agent instance on EI₁.
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(ei1.getKey())
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
             .create()
             .getValue()
             .getAgentInstanceKey();
+
+    // EI₁'s job fails (retries remaining, no backoff) so it retries immediately and stops
+    // being ACTIVATED, releasing it as the active writer (validateSingleActiveWriter).
+    ENGINE.job().withKey(job1Key).withRetries(1).withLeaseToken(job1Lease).fail();
 
     // when — UPDATE supplying EI₂ (new association)
     final var updated =
@@ -484,6 +657,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei2.getKey())
+            .withJobKey(job2Key)
+            .withJobLease(job2Lease)
             .withStatus(AgentInstanceStatus.THINKING)
             .update();
 
@@ -530,20 +705,73 @@ public class AgentInstanceUpdateTest {
             .toList();
     final var ei1 = children.get(0);
     final var ei2 = children.get(1);
+    final var jobBatch =
+        ENGINE.jobs().withType("agent").withLease().withMaxJobsToActivate(2).activate();
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .filter(r -> r.getValue().getElementInstanceKey() == ei1.getKey())
+            .getFirst()
+            .getKey();
+    final var job1Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
+    final var job2Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2.getKey())
+            .getFirst()
+            .getKey();
+    final var job2Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job2Key))
+            .getLeaseToken();
 
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(ei1.getKey())
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
             .create()
             .getValue()
             .getAgentInstanceKey();
+
+    // EI₁'s job fails (retries remaining, no backoff) so it retries immediately and stops
+    // being ACTIVATED, releasing it as the active writer, so the agent can move to EI₂
+    // (validateSingleActiveWriter).
+    ENGINE.job().withKey(job1Key).withRetries(1).withLeaseToken(job1Lease).fail();
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(ei2.getKey())
+        .withJobKey(job2Key)
+        .withJobLease(job2Lease)
         .withStatus(AgentInstanceStatus.THINKING)
         .update();
+
+    // EI₂'s job likewise retries immediately, releasing it as the active writer so the agent
+    // can move back to EI₁. EI₁'s job (still tied to the never-completed EI₁ element instance,
+    // and already activatable again since its own retry) is re-activated, producing a fresh
+    // lease for the re-entry.
+    ENGINE.job().withKey(job2Key).withRetries(1).withLeaseToken(job2Lease).fail();
+    // Cap at 1: EI₂'s job is activatable again too, and must stay that way so it keeps
+    // failing validateSingleActiveWriter's ACTIVATED check.
+    final var reactivation =
+        ENGINE.jobs().withType("agent").withLease().withMaxJobsToActivate(1).activate();
+    final var reactivatedJob1Lease =
+        reactivation
+            .getValue()
+            .getJobs()
+            .get(reactivation.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
 
     // when — UPDATE re-supplies EI₁ (already in the plural list) alongside a status change
     final var updated =
@@ -551,6 +779,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei1.getKey())
+            .withJobKey(job1Key)
+            .withJobLease(reactivatedJob1Lease)
             .withStatus(AgentInstanceStatus.IDLE)
             .update();
 
@@ -576,10 +806,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -616,10 +861,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -671,16 +931,36 @@ public class AgentInstanceUpdateTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .withElementId(SERVICE_TASK_ID)
             .getFirst();
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
 
     // Complete the job — output mapping fails, raises incident, EI is stuck in COMPLETING.
-    ENGINE.job().ofInstance(processInstanceKey).withType("agent").complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType("agent")
+        .withLeaseToken(jobLease)
+        .complete();
     RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).getFirst();
 
     // when — attempt to UPDATE referencing the now-inactive (COMPLETING) element instance
@@ -735,11 +1015,26 @@ public class AgentInstanceUpdateTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .withElementId("other-task")
             .getFirst();
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -790,11 +1085,26 @@ public class AgentInstanceUpdateTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .withElementId(SERVICE_TASK_ID)
             .getFirst();
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(pi1Key)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(ei1.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -856,11 +1166,41 @@ public class AgentInstanceUpdateTest {
             .toList();
     final var ei1Key = children.get(0).getKey();
     final var ei2Key = children.get(1).getKey();
+    final var jobBatch =
+        ENGINE.jobs().withType("agent").withLease().withMaxJobsToActivate(2).activate();
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .filter(r -> r.getValue().getElementInstanceKey() == ei1Key)
+            .getFirst()
+            .getKey();
+    final var job1Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job1Key))
+            .getLeaseToken();
+    final var job2Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2Key)
+            .getFirst()
+            .getKey();
+    final var job2Lease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(job2Key))
+            .getLeaseToken();
 
     final var agentInstance1Key =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(ei1Key)
+            .withJobKey(job1Key)
+            .withJobLease(job1Lease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -868,6 +1208,8 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withElementInstanceKey(ei2Key)
+            .withJobKey(job2Key)
+            .withJobLease(job2Lease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -905,10 +1247,25 @@ public class AgentInstanceUpdateTest {
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var jobBatch = ENGINE.jobs().withType("agent").withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getValue()
             .getAgentInstanceKey();
@@ -916,6 +1273,8 @@ public class AgentInstanceUpdateTest {
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(serviceTaskInstance.getKey())
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
         .withStatus(from)
         .withChangedAttributes(List.of("status"))
         .update();
@@ -926,6 +1285,8 @@ public class AgentInstanceUpdateTest {
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .withStatus(AgentInstanceStatus.INITIALIZING)
             .withChangedAttributes(List.of("status"))
             .expectRejection()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
@@ -61,12 +61,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -117,12 +116,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -180,12 +178,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -238,12 +235,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -314,12 +310,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -369,12 +364,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -451,12 +445,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -523,12 +516,11 @@ public class AgentInstanceUpdateTest {
                 .withType("agent")
                 .getFirst()
                 .getKey();
-        final var jobLease =
-            jobBatch
-                .getValue()
-                .getJobs()
-                .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-                .getLeaseToken();
+        final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+        assertThat(jobIndex)
+            .as("activated job batch contains job with key '%d'", jobKey)
+            .isNotEqualTo(-1);
+        final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
         final var agentInstanceKey =
             ENGINE
                 .agentInstances()
@@ -813,12 +805,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -868,12 +859,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -938,12 +928,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()
@@ -1022,12 +1011,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
 
     final var agentInstanceKey =
         ENGINE
@@ -1092,12 +1080,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
 
     final var agentInstanceKey =
         ENGINE
@@ -1254,12 +1241,11 @@ public class AgentInstanceUpdateTest {
             .withType("agent")
             .getFirst()
             .getKey();
-    final var jobLease =
-        jobBatch
-            .getValue()
-            .getJobs()
-            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
-            .getLeaseToken();
+    final var jobIndex = jobBatch.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("activated job batch contains job with key '%d'", jobKey)
+        .isNotEqualTo(-1);
+    final var jobLease = jobBatch.getValue().getJobs().get(jobIndex).getLeaseToken();
     final var agentInstanceKey =
         ENGINE
             .agentInstances()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -86,16 +86,35 @@ public class MigrateAgentInstanceTest {
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .getFirst();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(AGENT_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+
     final long agentInstanceKey =
         engine
             .agentInstances()
             .withElementInstanceKey(agentTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getKey();
 
-    RecordingExporter.jobRecords(JobIntent.CREATED).withType(AGENT_JOB_TYPE).await();
-    engine.jobs().withType(AGENT_JOB_TYPE).activate();
-    engine.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
+    engine
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(AGENT_JOB_TYPE)
+        .withLeaseToken(jobLease)
+        .complete();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
@@ -159,11 +178,33 @@ public class MigrateAgentInstanceTest {
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .getFirst();
-    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(AGENT_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
 
-    RecordingExporter.jobRecords(JobIntent.CREATED).withType(AGENT_JOB_TYPE).await();
-    engine.jobs().withType(AGENT_JOB_TYPE).activate();
-    engine.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
+    engine
+        .agentInstances()
+        .withElementInstanceKey(agentTaskInstance.getKey())
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
+        .create();
+
+    engine
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(AGENT_JOB_TYPE)
+        .withLeaseToken(jobLease)
+        .complete();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
@@ -275,13 +316,19 @@ public class MigrateAgentInstanceTest {
     // set each agent instance's definition the live way: via a CONFIGURATION history item in
     // CREATE's own history batch, applied inline by AgentInstanceCreateProcessor before it
     // appends AGENT_INSTANCE:CREATED.
-    engine.jobs().withType(AGENT_JOB_TYPE).activate();
+    final var firstJobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
     final var firstJobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(AGENT_JOB_TYPE)
             .getFirst()
             .getKey();
+    final var firstJobLease =
+        firstJobBatch
+            .getValue()
+            .getJobs()
+            .get(firstJobBatch.getValue().getJobKeys().indexOf(firstJobKey))
+            .getLeaseToken();
     final var firstConfigItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-config-a")
@@ -298,17 +345,24 @@ public class MigrateAgentInstanceTest {
             .agentInstances()
             .withElementInstanceKey(firstTaskInstance.getKey())
             .withJobKey(firstJobKey)
+            .withJobLease(firstJobLease)
             .withHistory(List.of(firstConfigItem))
             .create()
             .getKey();
 
-    engine.jobs().withType(otherJobType).activate();
+    final var secondJobBatch = engine.jobs().withType(otherJobType).withLease().activate();
     final var secondJobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(otherJobType)
             .getFirst()
             .getKey();
+    final var secondJobLease =
+        secondJobBatch
+            .getValue()
+            .getJobs()
+            .get(secondJobBatch.getValue().getJobKeys().indexOf(secondJobKey))
+            .getLeaseToken();
     final var secondConfigItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-config-b")
@@ -325,6 +379,7 @@ public class MigrateAgentInstanceTest {
             .agentInstances()
             .withElementInstanceKey(secondTaskInstance.getKey())
             .withJobKey(secondJobKey)
+            .withJobLease(secondJobLease)
             .withHistory(List.of(secondConfigItem))
             .create()
             .getKey();
@@ -444,10 +499,26 @@ public class MigrateAgentInstanceTest {
             .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
             .getFirst()
             .getKey();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(AGENT_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+
     final long agentInstanceKey =
         engine
             .agentInstances()
             .withElementInstanceKey(adHocSubProcessInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getKey();
 
@@ -511,10 +582,26 @@ public class MigrateAgentInstanceTest {
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .getFirst();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(AGENT_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+
     final long agentInstanceKey =
         engine
             .agentInstances()
             .withElementInstanceKey(agentTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getKey();
     final long sourceAgentDefinitionKey =
@@ -586,10 +673,26 @@ public class MigrateAgentInstanceTest {
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .getFirst();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(AGENT_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+
     final long agentInstanceKey =
         engine
             .agentInstances()
             .withElementInstanceKey(agentTaskInstance.getKey())
+            .withJobKey(jobKey)
+            .withJobLease(jobLease)
             .create()
             .getKey();
 
@@ -649,7 +752,26 @@ public class MigrateAgentInstanceTest {
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .getFirst();
-    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(AGENT_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+
+    engine
+        .agentInstances()
+        .withElementInstanceKey(agentTaskInstance.getKey())
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
+        .create();
 
     // when
     final var rejection =
@@ -721,7 +843,26 @@ public class MigrateAgentInstanceTest {
             .withElementId("A")
             .getFirst();
     // create an agent instance and leave its job running so its owning element stays active
-    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(AGENT_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+
+    engine
+        .agentInstances()
+        .withElementInstanceKey(agentTaskInstance.getKey())
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
+        .create();
 
     // when
     final var rejection =
@@ -788,13 +929,35 @@ public class MigrateAgentInstanceTest {
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .getFirst();
-    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(AGENT_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var jobBatch = engine.jobs().withType(AGENT_JOB_TYPE).withLease().activate();
+    final var jobLease =
+        jobBatch
+            .getValue()
+            .getJobs()
+            .get(jobBatch.getValue().getJobKeys().indexOf(jobKey))
+            .getLeaseToken();
+
+    engine
+        .agentInstances()
+        .withElementInstanceKey(agentTaskInstance.getKey())
+        .withJobKey(jobKey)
+        .withJobLease(jobLease)
+        .create();
 
     // complete the agentic job so "A" completes and the process moves on to "B", orphaning the
     // still-active agent instance
-    RecordingExporter.jobRecords(JobIntent.CREATED).withType(AGENT_JOB_TYPE).await();
-    engine.jobs().withType(AGENT_JOB_TYPE).activate();
-    engine.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
+    engine
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(AGENT_JOB_TYPE)
+        .withLeaseToken(jobLease)
+        .complete();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -75,6 +75,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
+          "jobLease": "lease-abc",
           "history": [
             {
               "historyItemId": "item-0",
@@ -148,6 +149,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
+          "jobLease": "lease-abc",
           "history": [
             {
               "historyItemId": "item-0",
@@ -216,6 +218,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
+          "jobLease": "lease-abc",
           "history": [
             {
               "historyItemId": "item-0",
@@ -314,7 +317,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 }
                 """
                     .formatted(JOB_KEY)),
-            "No elementInstanceKey provided."),
+            "No elementInstanceKey provided. No jobLease provided."),
         Arguments.of(
             named(
                 "null elementInstanceKey",
@@ -337,7 +340,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 }
                 """
                     .formatted(JOB_KEY)),
-            "No elementInstanceKey provided."),
+            "No elementInstanceKey provided. No jobLease provided."),
         Arguments.of(
             named(
                 "non-numeric elementInstanceKey",
@@ -362,7 +365,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     .formatted(JOB_KEY)),
             "The provided elementInstanceKey 'not-a-number' is not a valid key."
                 + " Expected a numeric value."
-                + " Did you pass an entity id instead of an entity key?."),
+                + " Did you pass an entity id instead of an entity key?."
+                + " No jobLease provided."),
         Arguments.of(
             named(
                 "zero elementInstanceKey",
@@ -385,7 +389,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 }
                 """
                     .formatted(JOB_KEY)),
-            "The value for elementInstanceKey is '0' but must be > 0."),
+            "The value for elementInstanceKey is '0' but must be > 0. No jobLease provided."),
         Arguments.of(
             named(
                 "negative elementInstanceKey",
@@ -408,7 +412,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 }
                 """
                     .formatted(JOB_KEY)),
-            "The value for elementInstanceKey is '-1' but must be > 0."),
+            "The value for elementInstanceKey is '-1' but must be > 0. No jobLease provided."),
         Arguments.of(
             named(
                 "missing history",
@@ -418,7 +422,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 }
                 """
                     .formatted(ELEMENT_INSTANCE_KEY)),
-            "No jobKey provided. No history provided."),
+            "No jobKey provided. No jobLease provided. No history provided."),
         Arguments.of(
             named(
                 "history without jobKey",
@@ -447,7 +451,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 }
                 """
                     .formatted(ELEMENT_INSTANCE_KEY)),
-            "No jobKey provided."),
+            "No jobKey provided. No jobLease provided."),
         Arguments.of(
             named(
                 "non-numeric jobKey",
@@ -471,7 +475,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 """
                     .formatted(ELEMENT_INSTANCE_KEY)),
             "The provided jobKey 'not-a-number' is not a valid key. Expected a numeric value."
-                + " Did you pass an entity id instead of an entity key?."),
+                + " Did you pass an entity id instead of an entity key?."
+                + " No jobLease provided."),
         Arguments.of(
             named(
                 "history without a CONFIGURATION item establishing the definition",
@@ -491,7 +496,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 }
                 """
                     .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY)),
-            "No CONFIGURATION history item sets 'model'; add a CONFIGURATION history item that"
+            "No jobLease provided."
+                + " No CONFIGURATION history item sets 'model'; add a CONFIGURATION history item that"
                 + " sets it. No CONFIGURATION history item sets 'provider'; add a CONFIGURATION"
                 + " history item that sets it. No CONFIGURATION history item sets"
                 + " 'systemPrompt'; add a CONFIGURATION history item that sets it."));
@@ -508,6 +514,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
         {
           "elementInstanceKey": "%d",
           "jobKey": "%d",
+          "jobLease": "lease-abc",
           "history": [
             {
               "historyItemId": "item-0",
@@ -546,10 +553,12 @@ class AgentInstanceControllerTest extends RestControllerTest {
         """
         {
           "elementInstanceKey": "%d",
+          "jobKey": "%d",
+          "jobLease": "lease-abc",
           "status": "THINKING"
         }
         """
-            .formatted(ELEMENT_INSTANCE_KEY);
+            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
 
     // when / then
     webClient
@@ -589,10 +598,12 @@ class AgentInstanceControllerTest extends RestControllerTest {
     final var requestBody =
         """
         {
-          "elementInstanceKey": "%d"
+          "elementInstanceKey": "%d",
+          "jobKey": "%d",
+          "jobLease": "lease-abc"
         }
         """
-            .formatted(ELEMENT_INSTANCE_KEY);
+            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
 
     // when / then
     webClient
@@ -662,7 +673,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     """
                     { "status": "THINKING" }
                     """)),
-            "No elementInstanceKey provided."),
+            "No elementInstanceKey provided. No jobKey provided. No jobLease provided."),
         Arguments.of(
             named(
                 "null elementInstanceKey",
@@ -671,7 +682,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     """
                     { "elementInstanceKey": null, "status": "THINKING" }
                     """)),
-            "No elementInstanceKey provided."),
+            "No elementInstanceKey provided. No jobKey provided. No jobLease provided."),
         Arguments.of(
             named(
                 "non-numeric elementInstanceKey",
@@ -682,7 +693,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     """)),
             "The provided elementInstanceKey 'not-a-number' is not a valid key."
                 + " Expected a numeric value."
-                + " Did you pass an entity id instead of an entity key?."),
+                + " Did you pass an entity id instead of an entity key?."
+                + " No jobKey provided. No jobLease provided."),
         Arguments.of(
             named(
                 "zero agentInstanceKey",
@@ -692,7 +704,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     { "elementInstanceKey": "%d", "status": "IDLE" }
                     """
                         .formatted(ELEMENT_INSTANCE_KEY))),
-            "The value for agentInstanceKey is '0' but must be > 0."),
+            "The value for agentInstanceKey is '0' but must be > 0."
+                + " No jobKey provided. No jobLease provided."),
         Arguments.of(
             named(
                 "negative agentInstanceKey",
@@ -702,7 +715,8 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     { "elementInstanceKey": "%d", "status": "IDLE" }
                     """
                         .formatted(ELEMENT_INSTANCE_KEY))),
-            "The value for agentInstanceKey is '-1' but must be > 0."));
+            "The value for agentInstanceKey is '-1' but must be > 0."
+                + " No jobKey provided. No jobLease provided."));
   }
 
   @Test
@@ -719,9 +733,9 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(
             """
-            { "elementInstanceKey": "%d", "status": "IDLE" }
+            { "elementInstanceKey": "%d", "jobKey": "%d", "jobLease": "lease-abc", "status": "IDLE" }
             """
-                .formatted(ELEMENT_INSTANCE_KEY))
+                .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))
         .exchange()
         .expectStatus()
         .is5xxServerError();
@@ -815,7 +829,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
     }
 
     @Test
-    void shouldAcceptHistoryBatchWithoutJobLease() {
+    void shouldAcceptHistoryBatchWithJobLease() {
       // given
       final var responseRecord = new AgentInstanceRecord();
       responseRecord.addHistoryItem(
@@ -834,6 +848,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
           {
             "elementInstanceKey": "%d",
             "jobKey": "%d",
+            "jobLease": "lease-abc",
             "history": [
               %s,
               %s
@@ -874,7 +889,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
               assertArg(
                   record -> {
                     assertThat(record.getJobKey()).isEqualTo(JOB_KEY);
-                    assertThat(record.getJobLease()).isEmpty();
+                    assertThat(record.getJobLease()).isEqualTo("lease-abc");
                     assertThat(record.getHistory()).hasSize(2);
                   }),
               any());
@@ -962,10 +977,12 @@ class AgentInstanceControllerTest extends RestControllerTest {
           """
           {
             "elementInstanceKey": "%d",
+            "jobKey": "%d",
+            "jobLease": "lease-abc",
             "history": []
           }
           """
-              .formatted(ELEMENT_INSTANCE_KEY);
+              .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
 
       // when / then
       webClient
@@ -1176,7 +1193,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
     }
 
     @Test
-    void shouldAcceptHistoryBatchWithoutJobLease() {
+    void shouldAcceptHistoryBatchWithJobLease() {
       // given
       final var responseRecord = new AgentInstanceRecord();
       responseRecord.setAgentInstanceKey(AGENT_INSTANCE_KEY);
@@ -1196,6 +1213,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
           {
             "elementInstanceKey": "%d",
             "jobKey": "%d",
+            "jobLease": "lease-abc",
             "history": [
               {
                 "historyItemId": "item-0",
@@ -1248,7 +1266,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
               assertArg(
                   record -> {
                     assertThat(record.getJobKey()).isEqualTo(JOB_KEY);
-                    assertThat(record.getJobLease()).isEmpty();
+                    assertThat(record.getJobLease()).isEqualTo("lease-abc");
                     assertThat(record.getHistory()).hasSize(2);
                   }),
               any());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
@@ -134,6 +134,7 @@ public final class CreateAgentInstanceTest {
             .newActivateJobsCommand()
             .jobType("agent-conflict-job")
             .maxJobsToActivate(1)
+            .withLease(true)
             .send()
             .join()
             .getJobs()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
@@ -129,7 +129,7 @@ public final class CreateAgentInstanceTest {
             .getFirst()
             .getValue()
             .getElementInstanceKey();
-    final long jobKey =
+    final var activatedJob =
         client
             .newActivateJobsCommand()
             .jobType("agent-conflict-job")
@@ -137,8 +137,9 @@ public final class CreateAgentInstanceTest {
             .send()
             .join()
             .getJobs()
-            .getFirst()
-            .getKey();
+            .getFirst();
+    final long jobKey = activatedJob.getKey();
+    final String jobLease = activatedJob.getLeaseToken();
 
     // first CREATE — must succeed and return the new agentInstanceKey.
     final var firstResult =
@@ -146,7 +147,7 @@ public final class CreateAgentInstanceTest {
             .newCreateAgentInstanceCommand()
             .elementInstanceKey(elementInstanceKey)
             .jobKey(jobKey)
-            .jobLease("test-job-lease")
+            .jobLease(jobLease)
             .history(
                 List.of(
                     configurationHistoryItem(
@@ -163,7 +164,7 @@ public final class CreateAgentInstanceTest {
                         .newCreateAgentInstanceCommand()
                         .elementInstanceKey(elementInstanceKey)
                         .jobKey(jobKey)
-                        .jobLease("test-job-lease")
+                        .jobLease(jobLease)
                         .history(
                             List.of(
                                 configurationHistoryItem(


### PR DESCRIPTION
## Description

This closes the last gap in agent-instance job-reference validation: a job key or lease token could be entirely absent from a CREATE or UPDATE command, and the engine would sometimes accept it or reject it with a confusing, unrelated error instead of a clear "this is required" message.

**Goal:** every agent-instance CREATE/UPDATE command must be attributed to a real, currently-leased job — no exceptions, and no silently-swallowed missing fields.

**What this PR provides:**
- HTTP-level validation (`AgentInstanceRequestValidator`) now requires `jobLease` on both CREATE and UPDATE, and requires `jobKey` unconditionally on UPDATE (previously required only for some request shapes).
- Engine-level validation (`AgentHistoryBatchBehavior#validateJobContext`) now unconditionally rejects a job with no lease token (`NOT_FOUND`), regardless of the caller's lease-mismatch-handling mode (`REJECT` for CREATE, `ALLOW_STALE` for UPDATE) — a job without a lease is never referenceable, full stop.
- The same method now rejects a missing `jobKey` (the `-1` "unset" sentinel used across the codebase) outright with `INVALID_ARGUMENT` and a clear message, instead of falling through to a job-state lookup that produced a misleading `NOT_FOUND` ("job was not active") for a key that was never provided in the first place.
- Removed the dead `jobKey == -1` bypass this replaces — it let a request skip job validation entirely as long as it carried no history, which is unreachable now that `jobKey` is required on every CREATE/UPDATE.
- Full fixture ripple: every engine test that creates or updates an agent instance now threads a real, actively-leased job through `withLease()` instead of a bare activation or placeholder job reference (fixture-only churn, no behavior/assertion changes beyond what the two decisions above require).
- Regenerated the `request-validation-test-generator` e2e spec for agent-instance requests to reflect the new required fields.

**Decisions worth flagging for review:**
- The lease token is treated as a fencing mechanism, not an optional courtesy (see ADR 0005-810) — that's why "no lease" is an unconditional rejection independent of `REJECT`/`ALLOW_STALE` mode, rather than being folded into the mismatch-handling logic.
- Test fixtures intentionally read `jobKey` and `jobLease` from two different sources: `jobKey` comes from `RecordingExporter`, filtered by process instance and job type (the shared `@ClassRule ENGINE` leaks job-queue state across test methods, so a `jobBatch` is not safe to index positionally); `jobLease` comes from the `jobBatch` activation response itself, because no per-job `JobIntent.ACTIVATED` record is ever exported during batch activation — only a batch-level `JobBatchIntent.ACTIVATED` event exists, so the client response is the only place a lease token is ever observable. This looked redundant at first glance but isn't.

**Built on top of #62042** (not yet merged): this branch is stacked on it and has been rebased onto its current tip to avoid conflicts. The diff below therefore also contains #62042's own commits until that PR merges — only the 5 commits from `3ea6f7eb495` onward (`test: reject missing jobKey and jobLease on agent-instance create/update` through `feat: reject agent-instance jobs that never held a lease, drop dead jobKey bypass`) belong to this PR.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), or [for documentation changes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes)).

## Related issues

closes #60864
