### PR TITLE
deps: bump camunda-security-library to 1.0.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha67</version.camunda-security-library>
+    <version.camunda-security-library>1.0.0</version.camunda-security-library>
     <version.checkstyle>14.1.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Summary

Bumps `camunda-security-library` from `0.1.0-alpha67` to its first stable release, `1.0.0`.

Notable change in this range: [camunda/camunda-security-library#625](https://github.com/camunda/camunda-security-library/pull/625) replaces Spring Security's generic multi-IdP login page with a Camunda-branded picker, and single-IdP deployments now redirect straight to the provider instead of rendering a one-link "picker". No config-surface or property changes are introduced, and none of the other removed/changed APIs in this range (`DefaultLoginPageGeneratingFilter` override anchor, `JwtCookieAuthenticationFilter`/`JwtCookieTokenPort`) are referenced anywhere in this repo, so this is a plain version bump.

## Testing

- Full-repo `./mvnw install -Dquickly -T1C` and targeted `verify` runs on `security/security-*` and `webapp/server` all green.
- Manually tested locally end-to-end against a local Keycloak (via `.local/docker-compose-dev.yaml`), running `StandaloneCamunda` against the locally-built `1.0.0` jars:
  - **Two OIDC providers configured** (two Keycloak realms, so each has a distinct issuer): `/login` renders the new branded picker with both providers listed, and completing the flow through either one logs in successfully (verified via `/v2/authentication/me`).
  - **One OIDC provider configured**: `/login` redirects straight to the provider (`302` to `/oauth2/authorization/oidc`) with no picker shown, matching the documented single-IdP behavior.

Screenshot of the two-provider picker:

<img width="771" height="612" alt="Screenshot 2026-09-08 at 10 23 15" src="https://github.com/user-attachments/assets/9375939d-4601-4949-9824-ef8accc88c0d" />

## Related issues

- [x] This PR does not need a linked issue