### PR TITLE
feat: expose wait-state enablement in system configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -62,6 +62,7 @@ public class GatewayRestPropertiesOverride {
     }
 
     public void applyTo(final GatewayRestConfiguration override) {
+      override.setWaitStatesEnabled(camunda.getData().getWaitStates().isEnabled());
       populateFromJobMetrics(override);
       populateFromValidators(override);
     }

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestWaitStatesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestWaitStatesTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class ApiRestWaitStatesTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(
+              UnifiedConfiguration.class,
+              UnifiedConfigurationHelper.class,
+              GatewayRestPropertiesOverride.class);
+
+  @Test
+  void shouldEnableWaitStatesByDefault() {
+    // given no wait-state configuration
+    // when/then
+    contextRunner.run(
+        context ->
+            assertThat(context.getBean(GatewayRestProperties.class).isWaitStatesEnabled())
+                .isTrue());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldPropagateConfiguredWaitStatesEnabled(final boolean enabled) {
+    // given
+    final var runner =
+        contextRunner.withPropertyValues("camunda.data.wait-states.enabled=" + enabled);
+
+    // when/then
+    runner.run(
+        context ->
+            assertThat(context.getBean(GatewayRestProperties.class).isWaitStatesEnabled())
+                .isEqualTo(enabled));
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
@@ -15,11 +15,14 @@ import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.MapPropertySource;
@@ -90,6 +93,28 @@ class PhysicalTenantResolverTest {
     // then both declared tenants are present (alongside the synthesized 'default')
     assertThat(indexPrefixOf(resolved.get("tenanta"))).isEqualTo("tenanta");
     assertThat(indexPrefixOf(resolved.get("tenantb"))).isEqualTo("tenantb");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldResolveWaitStateRestConfigurationPerPhysicalTenant(final boolean rootEnabled) {
+    // given
+    setProperties(
+        Map.of(
+            "camunda.data.wait-states.enabled", rootEnabled,
+            "camunda.physical-tenants.tenanta.data.wait-states.enabled", !rootEnabled,
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"),
+        "tenanta");
+
+    // when
+    final var configs =
+        newResolver()
+            .mapValues(config -> new GatewayRestPropertiesOverride.Converter(config).convert());
+
+    // then
+    assertThat(configs.get("default").isWaitStatesEnabled()).isEqualTo(rootEnabled);
+    assertThat(configs.get("tenanta").isWaitStatesEnabled()).isEqualTo(!rootEnabled);
   }
 
   @Test

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/system-configuration.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/system-configuration.ts
@@ -9,7 +9,9 @@
 import type {GetSystemConfigurationResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
 
 function createSystemConfiguration(
-	overrides?: Partial<GetSystemConfigurationResponseBody>,
+	overrides?: Omit<Partial<GetSystemConfigurationResponseBody>, 'deployment'> & {
+		deployment?: Partial<GetSystemConfigurationResponseBody['deployment']>;
+	},
 ): GetSystemConfigurationResponseBody {
 	return {
 		jobMetrics: {
@@ -21,15 +23,17 @@ function createSystemConfiguration(
 			maxUniqueKeys: 100,
 		},
 		components: {active: []},
-		deployment: {
-			isMultiTenancyEnabled: false,
-			maxRequestSize: 0,
-		},
 		authentication: {canLogout: true, isLoginDelegated: false},
 		cloud: {
 			stage: null,
 		},
 		...overrides,
+		deployment: {
+			isMultiTenancyEnabled: false,
+			isWaitStatesEnabled: true,
+			maxRequestSize: 0,
+			...overrides?.deployment,
+		},
 	};
 }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/config/system-configuration.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/config/system-configuration.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getSystemConfigurationResponseBodySchema} from '@camunda/camunda-api-zod-schemas/8.10';
+import {expect} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+
+it('should provide an enabled wait-state fixture by default', () => {
+	const config = getSystemConfigurationResponseBodySchema.parse(createSystemConfiguration());
+
+	expect(config.deployment.isWaitStatesEnabled).toBe(true);
+});
+
+it.for([false, true])('should preserve explicit wait-state enablement of %s', (isWaitStatesEnabled) => {
+	const config = getSystemConfigurationResponseBodySchema.parse(
+		createSystemConfiguration({deployment: {isWaitStatesEnabled}}),
+	);
+
+	expect(config.deployment.isWaitStatesEnabled).toBe(isWaitStatesEnabled);
+	expect(config.deployment.isMultiTenancyEnabled).toBe(false);
+});
+
+it('should preserve existing deployment fixture overrides', () => {
+	const config = getSystemConfigurationResponseBodySchema.parse(
+		createSystemConfiguration({deployment: {isMultiTenancyEnabled: true, maxRequestSize: 4194304}}),
+	);
+
+	expect(config.deployment).toEqual({
+		isMultiTenancyEnabled: true,
+		isWaitStatesEnabled: true,
+		maxRequestSize: 4194304,
+	});
+});
+
+it.for([undefined, null, 'false'])('should reject invalid wait-state enablement of %s without a fallback', (value) => {
+	const config = createSystemConfiguration();
+
+	const result = getSystemConfigurationResponseBodySchema.safeParse({
+		...config,
+		deployment: {...config.deployment, isWaitStatesEnabled: value},
+	});
+
+	expect(result.success).toBe(false);
+});

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/system-configuration.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/system-configuration.ts
@@ -26,6 +26,7 @@ type ComponentsConfiguration = z.infer<typeof componentsConfigurationSchema>;
 
 const deploymentConfigurationSchema = z.object({
 	isMultiTenancyEnabled: z.boolean(),
+	isWaitStatesEnabled: z.boolean(),
 	maxRequestSize: z.number(),
 });
 type DeploymentConfiguration = z.infer<typeof deploymentConfigurationSchema>;

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -123,6 +123,7 @@ paths:
                       active: ["operate", "tasklist"]
                     deployment:
                       isMultiTenancyEnabled: false
+                      isWaitStatesEnabled: true
                       maxRequestSize: 4194304
                     authentication:
                       canLogout: true
@@ -273,17 +274,27 @@ components:
       type: object
       required:
         - isMultiTenancyEnabled
+        - isWaitStatesEnabled
         - maxRequestSize
       properties:
         isMultiTenancyEnabled:
           description: Whether multi-tenancy is enabled.
           type: boolean
           example: false
+        isWaitStatesEnabled:
+          description: |
+            Whether wait-state tracking is enabled for the current physical tenant.
+            Reflects camunda.data.wait-states.enabled, which defaults to true.
+          type: boolean
+          example: true
         maxRequestSize:
           description: The maximum HTTP request size in bytes.
           type: integer
           format: int64
           example: 4194304
+      x-properties-added-in-version:
+        - propertyName: isWaitStatesEnabled
+          addedInVersion: "8.10"
 
     AuthenticationConfigurationResponse:
       description: Configuration for authentication and session management.
@@ -330,4 +341,3 @@ components:
         - dev
         - int
         - prod
-

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -292,9 +292,6 @@ components:
           type: integer
           format: int64
           example: 4194304
-      x-properties-added-in-version:
-        - propertyName: isWaitStatesEnabled
-          addedInVersion: "8.10"
 
     AuthenticationConfigurationResponse:
       description: Configuration for authentication and session management.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -26,11 +26,20 @@ public class GatewayRestConfiguration {
       MAX_CLUSTER_VARIABLE_METADATA_ENTRIES * MAX_CLUSTER_VARIABLE_METADATA_ENTRY_LENGTH;
 
   private final JobMetricsConfiguration jobMetrics = new JobMetricsConfiguration();
+  private boolean waitStatesEnabled = true;
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
   private int maxClusterVariableMetadataSize = DEFAULT_MAX_CLUSTER_VARIABLE_METADATA_SIZE;
 
   public JobMetricsConfiguration getJobMetrics() {
     return jobMetrics;
+  }
+
+  public boolean isWaitStatesEnabled() {
+    return waitStatesEnabled;
+  }
+
+  public void setWaitStatesEnabled(final boolean waitStatesEnabled) {
+    this.waitStatesEnabled = waitStatesEnabled;
   }
 
   /**

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -82,8 +82,8 @@ public class SystemController {
   @CamundaGetMapping(path = "/configuration")
   public ResponseEntity<SystemConfigurationResponse> getSystemConfiguration(
       @PhysicalTenantId final String physicalTenantId) {
-    final var jobMetrics =
-        tenantRestConfigProvider.forPhysicalTenant(physicalTenantId).getJobMetrics();
+    final var tenantRestConfig = tenantRestConfigProvider.forPhysicalTenant(physicalTenantId);
+    final var jobMetrics = tenantRestConfig.getJobMetrics();
     final var jobMetricsResponse =
         JobMetricsConfigurationResponse.Builder.create()
             .enabled(jobMetrics.isEnabled())
@@ -98,7 +98,7 @@ public class SystemController {
         SystemConfigurationResponse.Builder.create()
             .jobMetrics(jobMetricsResponse)
             .components(buildComponentsConfiguration())
-            .deployment(buildDeploymentConfiguration())
+            .deployment(buildDeploymentConfiguration(tenantRestConfig.isWaitStatesEnabled()))
             .authentication(buildAuthenticationConfiguration())
             .cloud(buildCloudConfiguration())
             .build());
@@ -113,7 +113,8 @@ public class SystemController {
         .build();
   }
 
-  private DeploymentConfigurationResponse buildDeploymentConfiguration() {
+  private DeploymentConfigurationResponse buildDeploymentConfiguration(
+      final boolean isWaitStatesEnabled) {
     final boolean isMultiTenancyEnabled =
         cslProperties != null
             && cslProperties.getMultiTenancy() != null
@@ -121,6 +122,7 @@ public class SystemController {
 
     return DeploymentConfigurationResponse.Builder.create()
         .isMultiTenancyEnabled(isMultiTenancyEnabled)
+        .isWaitStatesEnabled(isWaitStatesEnabled)
         .maxRequestSize(maxRequestSizeBytes)
         .build();
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.system;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -38,6 +39,8 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -90,6 +93,7 @@ public class SystemControllerTest extends RestControllerTest {
 
   // WebappConfiguration is provided by SystemControllerTestConfiguration
   @Autowired WebappConfiguration webappConfiguration;
+  @Autowired SystemController systemController;
 
   @BeforeEach
   void setupUsageMetricsServices() {
@@ -454,6 +458,58 @@ public class SystemControllerTest extends RestControllerTest {
             }
             """,
             JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldReturnWaitStatesEnabledByDefault() {
+    // given the default REST configuration
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.deployment.isWaitStatesEnabled")
+        .isEqualTo(true);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldReturnConfiguredWaitStatesEnabled(final boolean enabled) {
+    // given
+    final var config = new GatewayRestConfiguration();
+    config.setWaitStatesEnabled(enabled);
+    when(tenantRestConfigProvider.forPhysicalTenant(any())).thenReturn(config);
+
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.deployment.isWaitStatesEnabled")
+        .isEqualTo(enabled);
+  }
+
+  @Test
+  void shouldReturnWaitStatesConfigurationForEachPhysicalTenant() {
+    // given
+    final var enabledConfig = new GatewayRestConfiguration();
+    final var disabledConfig = new GatewayRestConfiguration();
+    disabledConfig.setWaitStatesEnabled(false);
+    when(tenantRestConfigProvider.forPhysicalTenant("enabled")).thenReturn(enabledConfig);
+    when(tenantRestConfigProvider.forPhysicalTenant("disabled")).thenReturn(disabledConfig);
+
+    // when/then
+    for (final var tenantId : List.of("enabled", "disabled", "enabled")) {
+      final var response = systemController.getSystemConfiguration(tenantId);
+      assertThat(response.getBody().getDeployment().getIsWaitStatesEnabled())
+          .isEqualTo(tenantId.equals("enabled"));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description

Prerequisite for the Process Instance header in #56029: expose the tenant-resolved wait-state flag through the existing system configuration response, with matching OpenAPI/Zod schemas and shared fixtures. Preserves default `true` and explicit `false` without a new endpoint or legacy bootstrap dependency.

## Checklist

- [x] Main-only migration prerequisite; no backport needed.

## Related issues

relates to #56029