### PR TITLE
feat: migrate Operate Process Instance shell

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -62,6 +62,7 @@ public class GatewayRestPropertiesOverride {
     }
 
     public void applyTo(final GatewayRestConfiguration override) {
+      override.setWaitStatesEnabled(camunda.getData().getWaitStates().isEnabled());
       populateFromJobMetrics(override);
       populateFromValidators(override);
     }

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestWaitStatesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestWaitStatesTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class ApiRestWaitStatesTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(
+              UnifiedConfiguration.class,
+              UnifiedConfigurationHelper.class,
+              GatewayRestPropertiesOverride.class);
+
+  @Test
+  void shouldEnableWaitStatesByDefault() {
+    // given no wait-state configuration
+    // when/then
+    contextRunner.run(
+        context ->
+            assertThat(context.getBean(GatewayRestProperties.class).isWaitStatesEnabled())
+                .isTrue());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldPropagateConfiguredWaitStatesEnabled(final boolean enabled) {
+    // given
+    final var runner =
+        contextRunner.withPropertyValues("camunda.data.wait-states.enabled=" + enabled);
+
+    // when/then
+    runner.run(
+        context ->
+            assertThat(context.getBean(GatewayRestProperties.class).isWaitStatesEnabled())
+                .isEqualTo(enabled));
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
@@ -15,11 +15,14 @@ import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.MapPropertySource;
@@ -90,6 +93,28 @@ class PhysicalTenantResolverTest {
     // then both declared tenants are present (alongside the synthesized 'default')
     assertThat(indexPrefixOf(resolved.get("tenanta"))).isEqualTo("tenanta");
     assertThat(indexPrefixOf(resolved.get("tenantb"))).isEqualTo("tenantb");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldResolveWaitStateRestConfigurationPerPhysicalTenant(final boolean rootEnabled) {
+    // given
+    setProperties(
+        Map.of(
+            "camunda.data.wait-states.enabled", rootEnabled,
+            "camunda.physical-tenants.tenanta.data.wait-states.enabled", !rootEnabled,
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"),
+        "tenanta");
+
+    // when
+    final var configs =
+        newResolver()
+            .mapValues(config -> new GatewayRestPropertiesOverride.Converter(config).convert());
+
+    // then
+    assertThat(configs.get("default").isWaitStatesEnabled()).isEqualTo(rootEnabled);
+    assertThat(configs.get("tenanta").isWaitStatesEnabled()).isEqualTo(!rootEnabled);
   }
 
   @Test

--- a/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
@@ -24,7 +24,6 @@ const config: KnipConfig = {
 		// TODO(#55642): remove when BatchOperation detail page is migrated
 		'src/operate/shared/PaginatedSortableTable/**',
 		// TODO(#61095, #55987): remove when Process Instance header / Processes toolbar operations are migrated
-		'src/operate/components/DrainingTag/**',
 	],
 	ignoreDependencies: ['@vitest/browser'],
 	typescript: {

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/system-configuration.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/system-configuration.ts
@@ -9,7 +9,9 @@
 import type {GetSystemConfigurationResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
 
 function createSystemConfiguration(
-	overrides?: Partial<GetSystemConfigurationResponseBody>,
+	overrides?: Omit<Partial<GetSystemConfigurationResponseBody>, 'deployment'> & {
+		deployment?: Partial<GetSystemConfigurationResponseBody['deployment']>;
+	},
 ): GetSystemConfigurationResponseBody {
 	return {
 		jobMetrics: {
@@ -21,15 +23,17 @@ function createSystemConfiguration(
 			maxUniqueKeys: 100,
 		},
 		components: {active: []},
-		deployment: {
-			isMultiTenancyEnabled: false,
-			maxRequestSize: 0,
-		},
 		authentication: {canLogout: true, isLoginDelegated: false},
 		cloud: {
 			stage: null,
 		},
 		...overrides,
+		deployment: {
+			isMultiTenancyEnabled: false,
+			isWaitStatesEnabled: true,
+			maxRequestSize: 0,
+			...overrides?.deployment,
+		},
 	};
 }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -192,7 +192,25 @@ const mockGetProcessInstanceCallHierarchyEndpoint = createEndpointMock({
 	method: endpoints.getProcessInstanceCallHierarchy.method,
 });
 
+const mockGetProcessInstanceEndpoint = createEndpointMock({
+	endpoint: endpoints.getProcessInstance.getUrl({processInstanceKey: ':processInstanceKey'}),
+	method: endpoints.getProcessInstance.method,
+});
+
+const mockGetProcessInstanceWaitStateStatisticsEndpoint = createEndpointMock({
+	endpoint: endpoints.getProcessInstanceWaitStateStatistics.getUrl({processInstanceKey: ':processInstanceKey'}),
+	method: endpoints.getProcessInstanceWaitStateStatistics.method,
+});
+
+const mockQueryProcessInstanceIncidentsEndpoint = createEndpointMock({
+	endpoint: endpoints.queryProcessInstanceIncidents.getUrl({processInstanceKey: ':processInstanceKey'}),
+	method: endpoints.queryProcessInstanceIncidents.method,
+});
+
 export {
+	mockGetProcessInstanceWaitStateStatisticsEndpoint,
+	mockGetProcessInstanceEndpoint,
+	mockQueryProcessInstanceIncidentsEndpoint,
 	mockCurrentUserEndpoint,
 	mockLoginEndpoint,
 	mockLogoutEndpoint,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstance.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstance.test.tsx
@@ -1,0 +1,436 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {afterEach, beforeEach, describe, expect} from 'vitest';
+import {userEvent, page} from 'vitest/browser';
+import {HttpResponse, http, delay} from 'msw';
+import {Button} from '@carbon/react';
+import styled from 'styled-components';
+import {cleanup} from 'vitest-browser-react';
+import {useParams, useSearch} from '@tanstack/react-router';
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {
+	mockCurrentUserEndpoint,
+	mockGetProcessInstanceEndpoint,
+	mockGetProcessInstanceWaitStateStatisticsEndpoint,
+	mockGetProcessInstanceCallHierarchyEndpoint,
+	mockGetProcessDefinitionXmlEndpoint,
+	mockQueryProcessDefinitionsEndpoint,
+	mockQueryProcessInstanceIncidentsEndpoint,
+} from '#/shared-test-modules/mock-handlers';
+import {createProcessInstance} from '#/shared-test-modules/api-mocks/process-instances';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+import {createCallHierarchy} from '#/shared-test-modules/api-mocks/call-hierarchy';
+import {
+	createProcessDefinition,
+	createQueryProcessDefinitionsResponse,
+} from '#/shared-test-modules/api-mocks/process-definitions';
+import {createPaginatedResponse, createProblemDetails} from '#/shared-test-modules/api-mocks/shared';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {ProcessInstance} from './ProcessInstance';
+import {processInstanceSearchSchema} from './processInstanceSearch';
+import {useProcessInstancePage} from './useProcessInstancePage';
+import {processInstanceQuery, waitStateStatisticsQuery} from './processInstance.queries';
+
+const ID = '2251799813685280';
+const PageContainer = styled.div`
+	height: 900px;
+`;
+const XML =
+	'<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="test"><process id="my-process"><callActivity id="call" /></process></definitions>';
+
+function ChildPanel() {
+	const {selection, activeTab, selectElement, selectElementInstance, clearSelection, setActiveTab} =
+		useProcessInstancePage();
+	return (
+		<>
+			<output aria-label="Selection">{JSON.stringify(selection)}</output>
+			<output aria-label="Active tab">{activeTab}</output>
+			<Button onClick={() => selectElement({elementId: 'task'})}>Select element</Button>
+			<Button onClick={() => selectElement({elementId: 'call'})}>Select call</Button>
+			<Button onClick={() => setActiveTab('history')}>History tab</Button>
+			<Button
+				onClick={() =>
+					selectElementInstance({
+						elementId: 'task',
+						elementInstanceKey: '999',
+						isPlaceholder: true,
+						anchorElementId: 'anchor',
+					})
+				}
+			>
+				Select instance
+			</Button>
+			<Button onClick={clearSelection}>Clear selection</Button>
+			<Button onClick={() => setActiveTab('details')}>Details tab</Button>
+		</>
+	);
+}
+
+function TestPage() {
+	const {processInstanceId = ID} = useParams({strict: false});
+	const search = processInstanceSearchSchema.parse(useSearch({strict: false}));
+	return (
+		<PageContainer>
+			<ProcessInstance processInstanceId={processInstanceId} search={search} bottomPanel={<ChildPanel />} />
+		</PageContainer>
+	);
+}
+
+function renderPage(search = '') {
+	return renderWithRouter(TestPage, {
+		path: '/operate/processes/$processInstanceId',
+		initialEntry: `/operate/processes/${ID}${search}`,
+	});
+}
+
+describe('Process Instance shell', () => {
+	beforeEach(async () => {
+		sessionStorage.setItem('clientConfig', JSON.stringify(createSystemConfiguration()));
+		await page.viewport(1600, 1000);
+	});
+	afterEach(async () => {
+		await cleanup();
+		sessionStorage.clear();
+		localStorage.clear();
+		notificationsStore.reset();
+	});
+
+	function supportingMocks(xmlDelay = 0) {
+		return [
+			mockGetProcessInstanceWaitStateStatisticsEndpoint({successResponse: HttpResponse.json({items: []})}),
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(
+					createCurrentUser({tenants: [{tenantId: 'tenant-a', name: 'Tenant A', description: null}]}),
+				),
+			}),
+			mockGetProcessDefinitionXmlEndpoint({successResponse: HttpResponse.text(XML), delay: xmlDelay}),
+			mockQueryProcessDefinitionsEndpoint({
+				successResponse: HttpResponse.json(createQueryProcessDefinitionsResponse()),
+			}),
+			mockGetProcessInstanceCallHierarchyEndpoint({successResponse: HttpResponse.json([])}),
+		];
+	}
+
+	it('should render metadata, tenant-specific version and called-instance links without write actions', async ({
+		worker,
+	}) => {
+		sessionStorage.setItem(
+			'clientConfig',
+			JSON.stringify(createSystemConfiguration({deployment: {isMultiTenancyEnabled: true, maxRequestSize: 1000000}})),
+		);
+		worker.use(
+			...supportingMocks(1500),
+			mockGetProcessInstanceEndpoint({
+				successResponse: HttpResponse.json(
+					createProcessInstance({
+						tenantId: 'tenant-a',
+						processDefinitionVersionTag: 'production',
+						businessId: 'order-42',
+						endDate: '2026-01-16T10:00:00Z',
+						state: 'COMPLETED',
+					}),
+				),
+			}),
+		);
+		const previousTitle = document.title;
+		const screen = await renderPage();
+		await page.viewport(1600, 1000);
+		await expect.element(screen.getByRole('columnheader', {name: 'Called Instances'})).toBeVisible();
+		await expect.element(screen.getByRole('columnheader', {name: 'Version Tag'})).not.toBeInTheDocument();
+		await expect.element(screen.getByText('My Process', {exact: true})).toBeVisible();
+		for (const value of [ID, 'production', 'order-42', 'Tenant A']) {
+			await expect.element(screen.getByRole('cell', {name: value, exact: true})).toBeVisible();
+		}
+		await expect.element(screen.getByRole('columnheader', {name: 'End Date'})).toBeVisible();
+		const version = screen.getByRole('link', {name: /View process.*version 1/});
+		const versionUrl = new URL(version.element().getAttribute('href')!, location.origin);
+		expect(versionUrl.searchParams.get('tenantId')).toBe('tenant-a');
+		expect(versionUrl.searchParams.get('process')).toBe('my-process');
+		expect(versionUrl.searchParams.get('version')).toBe('1');
+		const calledUrl = new URL(
+			screen.getByRole('link', {name: 'View all called instances'}).element().getAttribute('href')!,
+			location.origin,
+		);
+		expect(JSON.parse(calledUrl.searchParams.get('parentProcessInstanceKey')!)).toBe(ID);
+		await expect.element(screen.getByRole('button', {name: 'Cancel Instance'})).not.toBeInTheDocument();
+		expect(document.title).toBe(`Operate: Process Instance ${ID} of My Process`);
+		localStorage.setItem('operate.panelStates', JSON.stringify({isProcessesFiltersCollapsed: true, other: true}));
+		await userEvent.click(screen.getByRole('link', {name: 'View all called instances'}));
+		expect(JSON.parse(localStorage.getItem('operate.panelStates')!)).toEqual({
+			isProcessesFiltersCollapsed: false,
+			other: true,
+		});
+		await expect.poll(() => document.title).toBe(previousTitle);
+	});
+
+	it('should hide absent metadata, use the definition ID fallback and reduce the header on small screens', async ({
+		worker,
+	}) => {
+		await page.viewport(1024, 768);
+		worker.use(
+			...supportingMocks(),
+			mockGetProcessInstanceEndpoint({
+				successResponse: HttpResponse.json({...createProcessInstance(), processDefinitionName: null}),
+			}),
+		);
+		const screen = await renderPage('?elementId=task');
+		await expect.element(screen.getByText('my-process', {exact: true})).toBeVisible();
+		await expect.element(screen.getByLabelText('Active tab')).toHaveTextContent('details');
+		for (const name of ['Tenant', 'Version Tag', 'Business ID', 'Start Date', 'End Date', 'Called Instances']) {
+			await expect.element(screen.getByRole('columnheader', {name, exact: true})).not.toBeInTheDocument();
+		}
+	});
+
+	it('should show suspended state ahead of incidents and reuse draining metadata', async ({worker}) => {
+		worker.use(...supportingMocks());
+		worker.use(
+			mockGetProcessInstanceEndpoint({
+				successResponse: HttpResponse.json(createProcessInstance({state: 'SUSPENDED', hasIncident: true})),
+			}),
+			mockQueryProcessInstanceIncidentsEndpoint({
+				successResponse: HttpResponse.json(
+					createPaginatedResponse({
+						page: {totalItems: 2, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+					}),
+				),
+			}),
+			mockQueryProcessDefinitionsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryProcessDefinitionsResponse({
+						items: [createProcessDefinition({processDefinitionKey: '2251799813685279', state: 'DRAINING'})],
+					}),
+				),
+			}),
+		);
+		const screen = await renderPage();
+		await expect.element(screen.getByText('2 Incidents')).toBeVisible();
+		await expect.element(screen.getByTestId('SUSPENDED-icon')).toBeVisible();
+		await expect.element(screen.getByText('Draining', {exact: true})).toBeVisible();
+		await expect.element(screen.getByLabelText('Active tab')).toHaveTextContent('incidents');
+	});
+
+	it('should show a loading skeleton and recover from a failed request', async ({worker}) => {
+		worker.use(
+			mockGetProcessInstanceEndpoint({
+				successResponse: HttpResponse.json(createProblemDetails({status: 500}), {status: 500}),
+				delay: 1500,
+			}),
+		);
+		const screen = await renderPage();
+		await expect.element(screen.getByRole('columnheader', {name: 'Process Instance Key'})).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Retry', exact: true})).toBeVisible();
+		worker.use(
+			...supportingMocks(),
+			mockGetProcessInstanceEndpoint({successResponse: HttpResponse.json(createProcessInstance())}),
+		);
+		await userEvent.click(screen.getByRole('button', {name: 'Retry', exact: true}));
+		await expect.element(screen.getByText('My Process', {exact: true})).toBeVisible();
+	});
+
+	it.for([403, 500])(
+		'should handle a cached %i response without exposing forbidden or discarding usable data',
+		async (status, {worker}) => {
+			worker.use(
+				...supportingMocks(),
+				mockGetProcessInstanceEndpoint({successResponse: HttpResponse.json(createProcessInstance())}),
+			);
+			const screen = await renderPage();
+			await expect.element(screen.getByText('My Process', {exact: true})).toBeVisible();
+			worker.use(
+				mockGetProcessInstanceEndpoint({
+					successResponse: HttpResponse.json(createProblemDetails({status}), {status}),
+				}),
+			);
+			await screen.queryClient.invalidateQueries({queryKey: processInstanceQuery(ID).queryKey});
+			if (status === 403) {
+				await expect
+					.element(screen.getByText('403 - You do not have permission to view this information'))
+					.toBeVisible();
+				await expect.element(screen.getByText('My Process', {exact: true})).not.toBeInTheDocument();
+			} else {
+				await expect.element(screen.getByText('My Process', {exact: true})).toBeVisible();
+				await expect.element(screen.getByRole('button', {name: 'Retry', exact: true})).not.toBeInTheDocument();
+			}
+		},
+	);
+
+	it('should replace a missing instance with the running Processes list and notify once', async ({worker}) => {
+		worker.use(
+			mockGetProcessInstanceEndpoint({
+				successResponse: HttpResponse.json(createProblemDetails({status: 404}), {status: 404}),
+			}),
+		);
+		const screen = await renderPage();
+		await expect.poll(() => screen.router.state.location.pathname).toBe('/operate/processes');
+		expect(screen.router.state.location.search).toMatchObject({
+			active: true,
+			incidents: true,
+			completed: false,
+			canceled: false,
+		});
+		expect(notificationsStore.notifications.map(({title}) => title)).toEqual([`Instance ${ID} could not be found`]);
+	});
+
+	it('should collapse deep call hierarchies and navigate to hidden ancestors', async ({worker}) => {
+		worker.use(...supportingMocks());
+		worker.use(
+			mockGetProcessInstanceEndpoint({successResponse: HttpResponse.json(createProcessInstance())}),
+			mockGetProcessInstanceCallHierarchyEndpoint({
+				successResponse: HttpResponse.json([
+					...Array.from({length: 6}, (_, index) =>
+						createCallHierarchy({processInstanceKey: String(index + 1), processDefinitionName: `Parent ${index + 1}`}),
+					),
+					createCallHierarchy({processInstanceKey: ID}),
+				]),
+			}),
+		);
+		const screen = await renderPage();
+		await expect.element(screen.getByRole('link', {name: 'Parent 1'})).toHaveAttribute('href', '/operate/processes/1');
+		await expect.element(screen.getByRole('link', {name: 'Parent 6'})).toBeVisible();
+		await userEvent.click(screen.getByRole('button', {name: 'More'}));
+		await userEvent.click(screen.getByRole('menuitem', {name: 'Parent 3'}));
+		await expect.poll(() => screen.router.state.location.pathname).toBe('/operate/processes/3');
+	});
+
+	it('should keep selection and active tab in the URL with replacement selection and back navigation', async ({
+		worker,
+	}) => {
+		worker.use(
+			...supportingMocks(),
+			mockGetProcessInstanceEndpoint({successResponse: HttpResponse.json(createProcessInstance())}),
+		);
+		const screen = await renderPage('?tab=history&elementId=old&elementInstanceKey=123&isMultiInstanceBody=true');
+		await expect.element(screen.getByLabelText('Active tab')).toHaveTextContent('history');
+		await userEvent.click(screen.getByRole('button', {name: 'Select element', exact: true}));
+		expect(screen.router.state.location.search).toEqual({tab: 'history', elementId: 'task'});
+		await userEvent.click(screen.getByRole('button', {name: 'Select instance', exact: true}));
+		expect(screen.router.state.location.search).toMatchObject({
+			elementInstanceKey: '999',
+			isPlaceholder: true,
+			anchorElementId: 'anchor',
+		});
+		await userEvent.click(screen.getByRole('button', {name: 'Clear selection'}));
+		expect(screen.router.state.location.search).toEqual({tab: 'history'});
+		await userEvent.click(screen.getByRole('button', {name: 'Details tab'}));
+		await expect.element(screen.getByLabelText('Active tab')).toHaveTextContent('variables');
+		screen.router.history.back();
+		await expect.element(screen.getByLabelText('Active tab')).toHaveTextContent('history');
+	});
+
+	it.for([
+		[true, 'ACTIVE', false, 1, 'my-process', 'details', 'Waiting'],
+		[true, 'ACTIVE', false, 2, 'my-process', 'details', '2 waiting'],
+		[true, 'ACTIVE', false, 0, 'my-process', 'details', null],
+		[true, 'ACTIVE', false, 2, 'task', 'variables', null],
+		[true, 'ACTIVE', false, 0, 'ERROR', 'variables', null],
+		[false, 'ACTIVE', false, 2, 'my-process', 'variables', null],
+		[true, 'COMPLETED', false, 2, 'my-process', 'variables', null],
+		[true, 'SUSPENDED', false, 2, 'my-process', 'variables', null],
+		[true, 'SUSPENDED', true, 2, 'my-process', 'incidents', '2 waiting'],
+	] as const)(
+		'should preserve wait-state gating and tab precedence (%j)',
+		async ([isWaitStatesEnabled, state, hasIncident, waitingCount, elementId, tab, label], {worker}) => {
+			sessionStorage.setItem(
+				'clientConfig',
+				JSON.stringify(createSystemConfiguration({deployment: {isWaitStatesEnabled}})),
+			);
+			let requests = 0;
+			worker.use(
+				...supportingMocks(),
+				mockGetProcessInstanceEndpoint({
+					successResponse: HttpResponse.json(createProcessInstance({state, hasIncident})),
+				}),
+				mockQueryProcessInstanceIncidentsEndpoint({successResponse: HttpResponse.json(createPaginatedResponse())}),
+			);
+			worker.use(
+				http.get('/v2/process-instances/:key/statistics/wait-states', () => {
+					requests++;
+					return HttpResponse.json({items: [{elementId, waitingCount}]}, {status: elementId === 'ERROR' ? 500 : 200});
+				}),
+			);
+			const screen = await renderPage();
+			await expect.element(screen.getByLabelText('Active tab')).toHaveTextContent(tab);
+			await expect.element(screen.getByText('My Process', {exact: true})).toBeVisible();
+			if (label) {
+				await expect.element(screen.getByText(label, {exact: true})).toBeVisible();
+			} else {
+				await expect.element(screen.getByText(/^(Waiting|\d+ waiting)$/)).not.toBeInTheDocument();
+			}
+			expect(requests).toBe(isWaitStatesEnabled && (state === 'ACTIVE' || hasIncident) ? 1 : 0);
+		},
+	);
+
+	it.for([true, false])(
+		'should defer tabs, poll and clear cached waits on completion or flag disablement (%s)',
+		{timeout: 10000},
+		async (isWaitStatesEnabled, {worker}) => {
+			let requests = 0;
+			worker.use(
+				...supportingMocks(),
+				mockGetProcessInstanceEndpoint({successResponse: HttpResponse.json(createProcessInstance())}),
+			);
+			worker.use(
+				http.get('/v2/process-instances/:key/statistics/wait-states', async () => {
+					if (requests === 0) {
+						await delay(1500);
+					}
+					return HttpResponse.json({items: [{elementId: 'my-process', waitingCount: ++requests}]});
+				}),
+			);
+			const search = isWaitStatesEnabled ? '' : '?tab=details';
+			const screen = await renderPage(search);
+			await expect.element(screen.getByText('My Process', {exact: true})).toBeVisible();
+			expect(screen.getByLabelText('Active tab').element().textContent).toBe(search ? 'details' : '');
+			await expect.element(screen.getByText('Waiting', {exact: true})).toBeVisible();
+			await expect.poll(() => requests, {timeout: 7000}).toBe(2);
+			await expect.element(screen.getByText('2 waiting', {exact: true})).toBeVisible();
+			const instance = createProcessInstance({
+				state: isWaitStatesEnabled ? 'COMPLETED' : 'ACTIVE',
+				businessId: 'updated',
+			});
+			const config = createSystemConfiguration({deployment: {isWaitStatesEnabled}});
+			sessionStorage.setItem('clientConfig', JSON.stringify(config));
+			screen.queryClient.setQueryData(processInstanceQuery(ID).queryKey, instance);
+			await expect.element(screen.getByText('2 waiting', {exact: true})).not.toBeInTheDocument();
+			await expect.element(screen.getByLabelText('Active tab')).toHaveTextContent('variables');
+			expect(waitStateStatisticsQuery(instance).refetchInterval).toBe(false);
+		},
+	);
+
+	it('should validate shareable state without losing numeric identity precision', () => {
+		expect(
+			processInstanceSearchSchema.parse({elementId: 123, elementInstanceKey: '9007199254740993', tab: 'invalid'}),
+		).toEqual({
+			elementId: '123',
+			elementInstanceKey: '9007199254740993',
+			tab: undefined,
+		});
+	});
+
+	it.for([false, true])(
+		'should select the first tab atomically and defer call-activity switching until XML is ready (incidents: %s)',
+		async (hasIncident, {worker}) => {
+			worker.use(
+				...supportingMocks(1500),
+				mockGetProcessInstanceEndpoint({successResponse: HttpResponse.json(createProcessInstance({hasIncident}))}),
+				mockQueryProcessInstanceIncidentsEndpoint({successResponse: HttpResponse.json(createPaginatedResponse())}),
+			);
+			const screen = await renderPage('?tab=variables');
+			await userEvent.click(screen.getByRole('button', {name: 'Select element', exact: true}));
+			const tab = hasIncident ? 'incidents' : 'details';
+			expect(screen.router.state.location.search).toEqual({tab, elementId: 'task'});
+			await userEvent.click(screen.getByRole('button', {name: 'History tab'}));
+			await userEvent.click(screen.getByRole('button', {name: 'Select call'}));
+			await expect.element(screen.getByText('My Process', {exact: true})).toBeVisible();
+			await expect.poll(() => screen.router.state.location.search).toEqual({tab, elementId: 'call'});
+		},
+	);
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstance.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstance.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect} from 'react';
+import {Button} from '@carbon/react';
+import {useQuery} from '@tanstack/react-query';
+import {useNavigate} from '@tanstack/react-router';
+import {useTranslation} from 'react-i18next';
+import {ForbiddenError} from '#/shared/errors';
+import {requestErrorSchema} from '#/shared/http/request';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {VisuallyHiddenH1} from '#/operate/shared/VisuallyHiddenH1/VisuallyHiddenH1';
+import {InstanceDetail} from '#/operate/shared/InstanceDetail/InstanceDetail';
+import {ProcessInstanceHeaderSkeleton} from './ProcessInstanceHeaderSkeleton';
+import {ErrorMessage} from '#/operate/shared/ErrorMessage/ErrorMessage';
+import {EmptyState} from '#/operate/components/EmptyState/EmptyState';
+import permissionDeniedIconUrl from '#/operate/assets/permission-denied.svg';
+import {useCallHierarchy} from '#/operate/shared/Operations/Operations.queries';
+import {processInstanceQuery} from './processInstance.queries';
+import {ProcessInstanceProvider} from './ProcessInstanceProvider';
+import {ProcessInstanceHeader} from './ProcessInstanceHeader';
+import {ProcessInstanceBreadcrumb} from './ProcessInstanceBreadcrumb';
+import type {ProcessInstanceSearch} from './processInstanceSearch';
+import {Container} from './styled';
+import {getProcessDefinitionName} from '#/operate/shared/utils/instance';
+
+type Props = {
+	processInstanceId: string;
+	search: ProcessInstanceSearch;
+	topPanel?: React.ReactNode;
+	bottomPanel?: React.ReactNode;
+	headerOperations?: React.ReactNode;
+};
+
+function ProcessInstance({processInstanceId, search, topPanel, bottomPanel, headerOperations}: Props) {
+	const {t} = useTranslation();
+	const navigate = useNavigate();
+	const {data: instance, error, isPending, refetch, isFetching} = useQuery(processInstanceQuery(processInstanceId));
+	const {data: hierarchy} = useCallHierarchy(processInstanceId, {enabled: instance !== undefined && error === null});
+	const parsedError = requestErrorSchema.safeParse(error);
+	const isNotFound = parsedError.success && parsedError.data.response?.status === 404;
+	useEffect(() => {
+		if (isNotFound) {
+			notificationsStore.displayNotification({
+				kind: 'error',
+				title: t('operate.processInstance.notFound', {processInstanceId}),
+				isDismissable: true,
+			});
+			void navigate({
+				to: '/operate/processes',
+				search: {active: true, incidents: true, completed: false, canceled: false},
+				replace: true,
+			});
+		}
+	}, [isNotFound, processInstanceId, navigate, t]);
+	useEffect(() => {
+		if (instance) {
+			const previousTitle = document.title;
+			document.title = t('operate.processInstance.pageTitle', {
+				processInstanceId,
+				name: getProcessDefinitionName(instance),
+			});
+			return () => {
+				document.title = previousTitle;
+			};
+		}
+		return undefined;
+	}, [instance, processInstanceId, t]);
+	if (error instanceof ForbiddenError) {
+		return (
+			<Container>
+				<EmptyState
+					icon={<img src={permissionDeniedIconUrl} alt="" />}
+					heading={t('operate.processInstance.forbidden.heading')}
+					description={t('operate.processInstance.forbidden.description')}
+					link={{
+						label: t('operate.processInstance.forbidden.learnMore'),
+						href: 'https://docs.camunda.io/docs/self-managed/operate-deployment/operate-authentication/#resource-based-permissions',
+					}}
+				/>
+			</Container>
+		);
+	}
+	if (isNotFound) {
+		return null;
+	}
+	if (error !== null && instance === undefined) {
+		return (
+			<Container>
+				<ErrorMessage />
+				<Button disabled={isFetching} onClick={() => void refetch()}>
+					{t('operate.processInstance.retry')}
+				</Button>
+			</Container>
+		);
+	}
+	if (isPending) {
+		return <ProcessInstancePending />;
+	}
+	return (
+		<ProcessInstanceProvider key={processInstanceId} processInstance={instance} search={search}>
+			<Container>
+				<VisuallyHiddenH1>{t('operate.processInstance.title')}</VisuallyHiddenH1>
+				<InstanceDetail
+					type="process"
+					breadcrumb={
+						hierarchy && hierarchy.length > 0 ? (
+							<ProcessInstanceBreadcrumb callHierarchy={hierarchy.slice(0, -1)} processInstance={instance} />
+						) : undefined
+					}
+					header={<ProcessInstanceHeader operations={headerOperations} />}
+					topPanel={topPanel ?? <div />}
+					bottomPanel={bottomPanel ?? <div />}
+				/>
+			</Container>
+		</ProcessInstanceProvider>
+	);
+}
+
+function ProcessInstancePending() {
+	const {t} = useTranslation();
+	return (
+		<Container>
+			<VisuallyHiddenH1>{t('operate.processInstance.title')}</VisuallyHiddenH1>
+			<InstanceDetail
+				type="process"
+				header={<ProcessInstanceHeaderSkeleton />}
+				topPanel={<div />}
+				bottomPanel={<div />}
+			/>
+		</Container>
+	);
+}
+
+export {ProcessInstance, ProcessInstancePending};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstanceBreadcrumb.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstanceBreadcrumb.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BreadcrumbItem, OverflowMenu, OverflowMenuItem} from '@carbon/react';
+import {useNavigate} from '@tanstack/react-router';
+import {useTranslation} from 'react-i18next';
+import type {CallHierarchy, ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {ProcessInstanceLink, CarbonBreadcrumb} from './styled';
+
+function ProcessInstanceBreadcrumb({
+	callHierarchy,
+	processInstance,
+}: {
+	callHierarchy: CallHierarchy[];
+	processInstance: ProcessInstance;
+}) {
+	const {t} = useTranslation();
+	const navigate = useNavigate();
+	const hasOverflow = callHierarchy.length > 4;
+	const visible = hasOverflow ? callHierarchy.slice(0, 2) : callHierarchy;
+	const overflowing = hasOverflow ? callHierarchy.slice(2, -1) : [];
+	const last = hasOverflow ? callHierarchy.at(-1) : undefined;
+	const linkTitle = ({processDefinitionName: name, processInstanceKey: key}: CallHierarchy) =>
+		t('operate.processInstance.breadcrumb.view', {name, key});
+	const item = (ancestor: CallHierarchy) => (
+		<BreadcrumbItem key={ancestor.processInstanceKey}>
+			<ProcessInstanceLink
+				to="/operate/processes/$processInstanceId"
+				params={{processInstanceId: ancestor.processInstanceKey}}
+				title={linkTitle(ancestor)}
+			>
+				{ancestor.processDefinitionName}
+			</ProcessInstanceLink>
+		</BreadcrumbItem>
+	);
+	return (
+		<CarbonBreadcrumb noTrailingSlash>
+			{visible.map(item)}
+			{overflowing.length > 0 && (
+				<BreadcrumbItem data-floating-menu-container>
+					<OverflowMenu align="bottom" iconDescription={t('operate.processInstance.breadcrumb.more')}>
+						{overflowing.map((ancestor) => (
+							<OverflowMenuItem
+								key={ancestor.processInstanceKey}
+								itemText={ancestor.processDefinitionName}
+								requireTitle
+								title={linkTitle(ancestor)}
+								onClick={() =>
+									void navigate({
+										to: '/operate/processes/$processInstanceId',
+										params: {processInstanceId: ancestor.processInstanceKey},
+									})
+								}
+							/>
+						))}
+					</OverflowMenu>
+				</BreadcrumbItem>
+			)}
+			{last && item(last)}
+			<BreadcrumbItem
+				isCurrentPage
+				title={t('operate.processInstance.breadcrumb.current', {
+					name: processInstance.processDefinitionName,
+					key: processInstance.processInstanceKey,
+				})}
+			>
+				{processInstance.processDefinitionName}
+			</BreadcrumbItem>
+		</CarbonBreadcrumb>
+	);
+}
+
+export {ProcessInstanceBreadcrumb};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstanceHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstanceHeader.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Tag} from '@carbon/react';
+import {useQuery} from '@tanstack/react-query';
+import {useMediaQuery} from '@uidotdev/usehooks';
+import {useTranslation} from 'react-i18next';
+import {queries} from '#/shared/http/queries';
+import {getClientConfig} from '#/shared/config/getClientConfig';
+import {getStateLocally, storeStateLocally} from '#/shared/browser-storage/local-storage';
+import {InstanceHeader, type Column} from '#/operate/shared/InstanceHeader/InstanceHeader';
+import {ProcessInstanceHeaderSkeleton} from './ProcessInstanceHeaderSkeleton';
+import {formatEvaluationDate} from '#/operate/shared/utils/formatEvaluationDate';
+import {DrainingTag} from '#/operate/components/DrainingTag/DrainingTag';
+import {drainingProcessDefinitionsQuery} from '#/operate/pages/Dashboard/InstancesByProcess/instancesByProcess.queries';
+import {useDiagramXml} from '#/operate/pages/Processes/useDiagramXml';
+import {processInstanceIncidentsCountQuery} from './processInstance.queries';
+import {useProcessInstancePage} from './useProcessInstancePage';
+import {ProcessInstanceLink} from './styled';
+import {getProcessDefinitionName, getWaitStateLabel} from '#/operate/shared/utils/instance';
+import {hasCalledProcessInstances} from '#/operate/shared/utils/elements';
+
+function ProcessInstanceHeader({operations}: {operations?: React.ReactNode}) {
+	const {t} = useTranslation();
+	const {processInstance: instance, waitingCount} = useProcessInstancePage();
+	const {
+		processInstanceKey,
+		processDefinitionId,
+		processDefinitionKey,
+		processDefinitionVersion,
+		processDefinitionVersionTag,
+		businessId,
+		tenantId,
+		startDate,
+		endDate,
+		state,
+		hasIncident,
+	} = instance;
+	const name = getProcessDefinitionName(instance);
+	const isReduced = useMediaQuery('(max-width: 1311px)');
+	const isMultiTenancyEnabled = getClientConfig().deployment.isMultiTenancyEnabled;
+	const {data: user} = useQuery(queries.getCurrentUser());
+	const tenant = user?.tenants.find((item) => item.tenantId === tenantId)?.name ?? tenantId;
+	const {data: draining} = useQuery(drainingProcessDefinitionsQuery());
+	const {data: diagram, isPending} = useDiagramXml(processDefinitionKey);
+	const {data: incidentsCount} = useQuery({
+		...processInstanceIncidentsCountQuery(processInstanceKey),
+		enabled: hasIncident,
+	});
+	const versionTitle =
+		t('operate.processInstance.header.versionLink', {name, version: processDefinitionVersion}) +
+		(isMultiTenancyEnabled ? ` - ${tenant}` : '');
+	const columns: (Column & {name: string})[] = [
+		{name: t('operate.processInstance.header.key'), title: processInstanceKey, content: processInstanceKey},
+		{
+			name: t('operate.processInstance.header.version'),
+			hideOverflowingContent: false,
+			content: (
+				<ProcessInstanceLink
+					to="/operate/processes"
+					search={{
+						process: processDefinitionId,
+						version: processDefinitionVersion,
+						active: true,
+						incidents: true,
+						completed: false,
+						canceled: false,
+						...(isMultiTenancyEnabled ? {tenantId} : {}),
+					}}
+					title={versionTitle}
+					aria-label={versionTitle}
+				>
+					{processDefinitionVersion}
+				</ProcessInstanceLink>
+			),
+		},
+		{
+			name: t('operate.processInstance.header.versionTag'),
+			hidden: processDefinitionVersionTag == null,
+			title: t('operate.processInstance.header.versionTagDescription'),
+			content: (
+				<Tag size="sm" type="outline">
+					{processDefinitionVersionTag}
+				</Tag>
+			),
+		},
+		{
+			name: t('operate.processInstance.header.businessId'),
+			hidden: businessId == null,
+			title: businessId ?? undefined,
+			content: businessId,
+		},
+		{name: t('operate.processInstance.header.tenant'), hidden: !isMultiTenancyEnabled, title: tenant, content: tenant},
+		{
+			name: t('operate.processInstance.header.startDate'),
+			hidden: isReduced,
+			title: formatEvaluationDate(startDate),
+			content: formatEvaluationDate(startDate),
+		},
+		{
+			name: t('operate.processInstance.header.endDate'),
+			hidden: endDate === null || isReduced,
+			title: formatEvaluationDate(endDate),
+			content: formatEvaluationDate(endDate),
+		},
+		{
+			name: t('operate.processInstance.header.calledInstances'),
+			hidden: isReduced,
+			hideOverflowingContent: false,
+			content: hasCalledProcessInstances(diagram?.businessObjects) ? (
+				<ProcessInstanceLink
+					to="/operate/processes"
+					search={{
+						parentProcessInstanceKey: processInstanceKey,
+						active: true,
+						incidents: true,
+						completed: true,
+						canceled: true,
+					}}
+					title={t('operate.processInstance.header.viewAllTitle')}
+					aria-label={t('operate.processInstance.header.viewAllTitle')}
+					onClick={() =>
+						storeStateLocally('operate.panelStates', {
+							...getStateLocally('operate.panelStates'),
+							isProcessesFiltersCollapsed: false,
+						})
+					}
+				>
+					{t('operate.processInstance.header.viewAll')}
+				</ProcessInstanceLink>
+			) : (
+				t('operate.processInstance.header.none')
+			),
+		},
+	].filter(({hidden}) => !hidden);
+	if (isPending) {
+		return <ProcessInstanceHeaderSkeleton />;
+	}
+	return (
+		<InstanceHeader
+			instanceName={name}
+			state={state === 'SUSPENDED' ? state : hasIncident ? 'INCIDENT' : state}
+			incidentsCount={hasIncident ? incidentsCount : 0}
+			nameSubtitle={getWaitStateLabel(waitingCount)}
+			headerColumns={columns.map(({name}) => name)}
+			bodyColumns={columns}
+			additionalContent={
+				<>
+					{draining?.byKey.has(processDefinitionKey) && (
+						<DrainingTag
+							label={t('operate.processInstance.header.draining')}
+							description={t('operate.dashboard.drainingDescriptionVersion')}
+							align="bottom-right"
+						/>
+					)}
+					{operations}
+				</>
+			}
+		/>
+	);
+}
+
+export {ProcessInstanceHeader};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstanceHeaderSkeleton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstanceHeaderSkeleton.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {InstanceHeaderSkeleton} from '#/operate/shared/InstanceHeader/InstanceHeaderSkeleton';
+
+function ProcessInstanceHeaderSkeleton() {
+	const {t} = useTranslation();
+	return (
+		<InstanceHeaderSkeleton
+			headerColumns={[
+				{name: t('operate.processInstance.header.key'), skeletonWidth: '136px'},
+				{name: t('operate.processInstance.header.version'), skeletonWidth: '34px'},
+				{name: t('operate.processInstance.header.startDate'), skeletonWidth: '142px'},
+				{name: t('operate.processInstance.header.calledInstances'), skeletonWidth: '142px'},
+			]}
+		/>
+	);
+}
+
+export {ProcessInstanceHeaderSkeleton};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstanceProvider.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/ProcessInstanceProvider.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useNavigate} from '@tanstack/react-router';
+import {useEffect, useRef} from 'react';
+import {useQuery} from '@tanstack/react-query';
+import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {ProcessInstanceSearch, ProcessInstanceSelection} from './processInstanceSearch';
+import {ProcessInstanceContext} from './useProcessInstancePage';
+import {useDiagramXml} from '#/operate/pages/Processes/useDiagramXml';
+import {getProcessLevelWaitState} from '#/operate/shared/utils/instance';
+import {waitStateStatisticsQuery} from './processInstance.queries';
+
+function ProcessInstanceProvider({
+	processInstance,
+	search,
+	children,
+}: {
+	processInstance: ProcessInstance;
+	search: ProcessInstanceSearch;
+	children: React.ReactNode;
+}) {
+	const navigate = useNavigate();
+	const {data: diagram} = useDiagramXml(processInstance.processDefinitionKey);
+	const {tab, ...selection} = search;
+	const processInstanceId = processInstance.processInstanceKey;
+	const {data: waitStates, isLoading} = useQuery(waitStateStatisticsQuery(processInstance));
+	const processWaitState = getProcessLevelWaitState(waitStates, processInstance.processDefinitionId);
+	const hasSelection = !!(selection.elementId || selection.elementInstanceKey);
+	const defaultTab = processInstance.hasIncident
+		? 'incidents'
+		: hasSelection || processWaitState
+			? 'details'
+			: 'variables';
+	const activeTab = tab ?? (isLoading ? undefined : defaultTab);
+	useEffect(() => {
+		if (tab === 'details' && !hasSelection && !processWaitState && !isLoading) {
+			void navigate({
+				to: '/operate/processes/$processInstanceId',
+				params: {processInstanceId},
+				search: (current) => ({...current, tab: 'variables'}),
+				replace: true,
+			});
+		}
+	}, [tab, hasSelection, processWaitState, isLoading, navigate, processInstanceId]);
+	const previousElementId = useRef(selection.elementId);
+	useEffect(() => {
+		const elementId = selection.elementId;
+		if (elementId && !diagram) {
+			previousElementId.current ??= elementId;
+			return;
+		}
+		const isSwitchingToCallActivity =
+			previousElementId.current !== undefined &&
+			elementId !== undefined &&
+			previousElementId.current !== elementId &&
+			diagram?.businessObjects[elementId]?.$type === 'bpmn:CallActivity';
+		previousElementId.current = elementId;
+		if (isSwitchingToCallActivity) {
+			void navigate({
+				to: '/operate/processes/$processInstanceId',
+				params: {processInstanceId},
+				search: (current) => ({...current, tab: processInstance.hasIncident ? 'incidents' : 'details'}),
+				replace: true,
+			});
+		}
+	}, [diagram, selection.elementId, navigate, processInstanceId, processInstance.hasIncident]);
+	const select = (next: ProcessInstanceSelection) => {
+		const isFirstSelection =
+			!(selection.elementId || selection.elementInstanceKey) && !!(next.elementId || next.elementInstanceKey);
+		void navigate({
+			to: '/operate/processes/$processInstanceId',
+			params: {processInstanceId},
+			search: {
+				tab: isFirstSelection ? (processInstance.hasIncident ? 'incidents' : 'details') : tab,
+				...next,
+			},
+			replace: true,
+		});
+	};
+	return (
+		<ProcessInstanceContext
+			value={{
+				processInstanceId,
+				processDefinitionKey: processInstance.processDefinitionKey,
+				processInstance,
+				search,
+				selection,
+				activeTab,
+				waitingCount: processWaitState?.waitingCount ?? 0,
+				selectElement: select,
+				selectElementInstance: select,
+				clearSelection: () => select({}),
+				setActiveTab: (tab) => {
+					void navigate({
+						to: '/operate/processes/$processInstanceId',
+						params: {processInstanceId},
+						search: {...search, tab},
+					});
+				},
+			}}
+		>
+			{children}
+		</ProcessInstanceContext>
+	);
+}
+
+export {ProcessInstanceProvider};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/processInstance.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/processInstance.queries.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {queryOptions} from '@tanstack/react-query';
+import type {
+	ProcessInstance,
+	QueryProcessInstanceIncidentsResponseBody,
+	GetProcessInstanceWaitStateStatisticsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {endpoints} from '#/shared/http/endpoints';
+import {request} from '#/shared/http/request';
+import {mapQueryError} from '#/shared/http/mapQueryError';
+import {getClientConfig} from '#/shared/config/getClientConfig';
+import {isInstanceRunning} from '#/operate/shared/utils/instance';
+
+function processInstanceQuery(processInstanceKey: string) {
+	return queryOptions({
+		queryKey: ['processInstance', processInstanceKey] as const,
+		queryFn: async (): Promise<ProcessInstance> => {
+			const {response, error} = await request(endpoints.getProcessInstance({processInstanceKey}));
+			if (error !== null) {
+				throw mapQueryError(error);
+			}
+			return response.json();
+		},
+		staleTime: 500,
+		refetchInterval: ({state: {data}}) => (data && isInstanceRunning(data) ? 5000 : false),
+	});
+}
+
+function processInstanceIncidentsCountQuery(processInstanceKey: string) {
+	return queryOptions({
+		queryKey: ['processInstanceIncidentsCount', processInstanceKey] as const,
+		queryFn: async () => {
+			const {response, error} = await request(
+				endpoints.queryProcessInstanceIncidents(
+					{processInstanceKey},
+					{
+						filter: {state: 'ACTIVE'},
+						page: {limit: 0},
+					},
+				),
+			);
+			if (error !== null) {
+				throw mapQueryError(error);
+			}
+			const data: QueryProcessInstanceIncidentsResponseBody = await response.json();
+			return data.page.totalItems;
+		},
+		staleTime: 5000,
+		refetchInterval: 5000,
+	});
+}
+
+function waitStateStatisticsQuery(instance: ProcessInstance) {
+	const processInstanceKey = instance.processInstanceKey;
+	const enabled = getClientConfig().deployment.isWaitStatesEnabled && isInstanceRunning(instance);
+	return queryOptions({
+		queryKey: ['processInstanceWaitStates', processInstanceKey],
+		queryFn: async ({signal}): Promise<GetProcessInstanceWaitStateStatisticsResponseBody> => {
+			const {response, error} = await request(
+				new Request(endpoints.getProcessInstanceWaitStateStatistics({processInstanceKey}), {signal}),
+			);
+			if (error !== null) {
+				throw mapQueryError(error);
+			}
+			return response.json();
+		},
+		enabled,
+		refetchInterval: enabled ? 5000 : false,
+		select: (data) => (enabled ? data.items : []),
+	});
+}
+
+export {processInstanceQuery, processInstanceIncidentsCountQuery, waitStateStatisticsQuery};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/processInstanceSearch.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/processInstanceSearch.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+
+const processInstanceSelectionSchema = z.object({
+	elementId: z.coerce.string().optional(),
+	elementInstanceKey: z.coerce.string().optional(),
+	isMultiInstanceBody: z.boolean().optional(),
+	isPlaceholder: z.boolean().optional(),
+	anchorElementId: z.coerce.string().optional(),
+});
+const processInstanceSearchSchema = processInstanceSelectionSchema.extend({
+	tab: z
+		.enum([
+			'variables',
+			'incidents',
+			'details',
+			'history',
+			'input-mappings',
+			'output-mappings',
+			'listeners',
+			'operations-log',
+		])
+		.optional()
+		.catch(undefined),
+});
+
+type ProcessInstanceSearch = z.infer<typeof processInstanceSearchSchema>;
+type ProcessInstanceSelection = z.infer<typeof processInstanceSelectionSchema>;
+type ProcessInstanceTab = NonNullable<ProcessInstanceSearch['tab']>;
+
+export {
+	processInstanceSearchSchema,
+	type ProcessInstanceSearch,
+	type ProcessInstanceSelection,
+	type ProcessInstanceTab,
+};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/styled.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {Link, Breadcrumb} from '@carbon/react';
+import {createLink} from '@tanstack/react-router';
+
+const ProcessInstanceLink = createLink(Link);
+const CarbonBreadcrumb = styled(Breadcrumb)`
+	display: flex;
+	align-items: center;
+	background-color: var(--cds-layer-01);
+	border-bottom: 1px solid var(--cds-border-subtle-01);
+	padding-left: var(--cds-spacing-05);
+`;
+
+const Container = styled.main.attrs({id: 'main-content', tabIndex: -1})`
+	height: 100%;
+	position: relative;
+	padding-top: var(--cds-spacing-09);
+`;
+
+export {Container, ProcessInstanceLink, CarbonBreadcrumb};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/useProcessInstancePage.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/ProcessInstance/useProcessInstancePage.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createContext, useContext} from 'react';
+import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {ProcessInstanceSearch, ProcessInstanceSelection, ProcessInstanceTab} from './processInstanceSearch';
+
+type ProcessInstancePageContext = {
+	processInstanceId: string;
+	processDefinitionKey: string;
+	processInstance: ProcessInstance;
+	search: ProcessInstanceSearch;
+	selection: ProcessInstanceSelection;
+	activeTab: ProcessInstanceTab | undefined;
+	waitingCount: number;
+	selectElement: (selection: Pick<ProcessInstanceSelection, 'elementId' | 'isMultiInstanceBody'>) => void;
+	selectElementInstance: (selection: ProcessInstanceSelection) => void;
+	clearSelection: () => void;
+	setActiveTab: (tab: ProcessInstanceTab) => void;
+};
+const ProcessInstanceContext = createContext<ProcessInstancePageContext | null>(null);
+
+function useProcessInstancePage() {
+	const context = useContext(ProcessInstanceContext);
+	if (context === null) {
+		throw new Error('ProcessInstanceProvider is required');
+	}
+	return context;
+}
+
+export {ProcessInstanceContext, useProcessInstancePage};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/getProcessDefinitionName.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/getProcessDefinitionName.ts
@@ -6,10 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {ProcessDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
-
-function getProcessDefinitionName(definition: Pick<ProcessDefinition, 'name' | 'processDefinitionId'>) {
-	return definition.name ?? definition.processDefinitionId;
-}
+import {getProcessDefinitionName} from '#/operate/shared/utils/instance';
 
 export {getProcessDefinitionName};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeader.tsx
@@ -73,7 +73,9 @@ const InstanceHeader: React.FC<InstanceHeaderProps> = ({
 				<thead>
 					<tr>
 						{headerColumns.map((column, index) => (
-							<Th key={index}>{column}</Th>
+							<Th key={index} scope="col">
+								{column}
+							</Th>
 						))}
 					</tr>
 				</thead>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeaderSkeleton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeaderSkeleton.tsx
@@ -23,7 +23,9 @@ const InstanceHeaderSkeleton: React.FC<Props> = ({headerColumns}) => {
 				<thead>
 					<tr>
 						{headerColumns.map(({name}, index) => (
-							<Th key={index}>{name}</Th>
+							<Th key={index} scope="col">
+								{name}
+							</Th>
 						))}
 					</tr>
 				</thead>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/elements.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/elements.ts
@@ -15,6 +15,10 @@ function hasType({businessObject, types}: {businessObject: BusinessObject; types
 	return types.includes(businessObject.$type);
 }
 
+function hasCalledProcessInstances(businessObjects: BusinessObjects = {}) {
+	return Object.values(businessObjects).some((object) => object.$type === 'bpmn:CallActivity');
+}
+
 function isFlowNode(businessObject: BusinessObject) {
 	return businessObject.$instanceOf?.('bpmn:FlowNode') ?? false;
 }
@@ -69,6 +73,7 @@ function getSubprocessOverlayFromIncidentElements(
 
 export {
 	hasType,
+	hasCalledProcessInstances,
 	isFlowNode,
 	isProcessOrSubProcessEndEvent,
 	getFlowNodes,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/instance.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/instance.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {ProcessDefinition, ProcessInstance, WaitStateStatistic} from '@camunda/camunda-api-zod-schemas/8.10';
+import {t} from 'i18next';
+
+function getProcessDefinitionName(
+	definition:
+		| Pick<ProcessDefinition, 'name' | 'processDefinitionId'>
+		| Pick<ProcessInstance, 'processDefinitionName' | 'processDefinitionId'>,
+) {
+	const name = 'name' in definition ? definition.name : definition.processDefinitionName;
+	return name ?? definition.processDefinitionId;
+}
+
+const isInstanceRunning = (instance: ProcessInstance) => instance.state === 'ACTIVE' || instance.hasIncident;
+
+function getProcessLevelWaitState(statistics: WaitStateStatistic[] | undefined, processDefinitionId: string) {
+	return statistics?.find(({elementId}) => elementId === processDefinitionId);
+}
+
+function getWaitStateLabel(count: number) {
+	return count > 0 ? t('operate.shared.instanceHeader.waiting', {count}) : undefined;
+}
+
+export {getProcessDefinitionName, isInstanceRunning, getProcessLevelWaitState, getWaitStateLabel};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
@@ -40,6 +40,7 @@ import { Route as ShadcnAuthTasklistTasksRouteRouteImport } from './routes/shadc
 import { Route as ShadcnAuthTasklistProcessesRouteRouteImport } from './routes/shadcn/_auth/tasklist/processes/route'
 import { Route as CarbonAuthOperateDecisionsIndexRouteImport } from './routes/_carbon/_auth/operate/decisions/index'
 import { Route as CarbonAuthOperateDecisionsDecisionInstanceIdRouteImport } from './routes/_carbon/_auth/operate/decisions/$decisionInstanceId'
+import { Route as CarbonAuthOperateProcessesProcessInstanceIdRouteImport } from './routes/_carbon/_auth/operate/processes_.$processInstanceId'
 import { Route as CarbonAuthTasklistTasksIndexRouteImport } from './routes/_carbon/_auth/tasklist/_tasks/index'
 import { Route as CarbonAuthTasklistTasksUserTaskKeyRouteRouteImport } from './routes/_carbon/_auth/tasklist/_tasks/$userTaskKey/route'
 import { Route as ShadcnAuthTasklistTasksIndexRouteImport } from './routes/shadcn/_auth/tasklist/_tasks/index'
@@ -215,6 +216,12 @@ const CarbonAuthOperateDecisionsDecisionInstanceIdRoute =
     path: '/$decisionInstanceId',
     getParentRoute: () => CarbonAuthOperateDecisionsRoute,
   } as any)
+const CarbonAuthOperateProcessesProcessInstanceIdRoute =
+  CarbonAuthOperateProcessesProcessInstanceIdRouteImport.update({
+    id: '/processes_/$processInstanceId',
+    path: '/processes/$processInstanceId',
+    getParentRoute: () => CarbonAuthOperateRouteRoute,
+  } as any)
 const CarbonAuthTasklistTasksIndexRoute =
   CarbonAuthTasklistTasksIndexRouteImport.update({
     id: '/',
@@ -328,6 +335,7 @@ export interface FileRoutesByFullPath {
   '/tasklist/$userTaskKey': typeof CarbonAuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   '/shadcn/tasklist/$userTaskKey': typeof ShadcnAuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   '/operate/decisions/$decisionInstanceId': typeof CarbonAuthOperateDecisionsDecisionInstanceIdRoute
+  '/operate/processes/$processInstanceId': typeof CarbonAuthOperateProcessesProcessInstanceIdRoute
   '/operate/decisions/': typeof CarbonAuthOperateDecisionsIndexRoute
   '/tasklist/': typeof CarbonAuthTasklistTasksIndexRoute
   '/shadcn/tasklist/': typeof ShadcnAuthTasklistTasksIndexRoute
@@ -364,6 +372,7 @@ export interface FileRoutesByTo {
   '/admin': typeof CarbonAuthAdminIndexRoute
   '/operate': typeof CarbonAuthOperateIndexRoute
   '/operate/decisions/$decisionInstanceId': typeof CarbonAuthOperateDecisionsDecisionInstanceIdRoute
+  '/operate/processes/$processInstanceId': typeof CarbonAuthOperateProcessesProcessInstanceIdRoute
   '/operate/decisions': typeof CarbonAuthOperateDecisionsIndexRoute
   '/tasklist/$userTaskKey/history': typeof CarbonAuthTasklistTasksUserTaskKeyHistoryRouteRouteWithChildren
   '/shadcn/tasklist/$userTaskKey/history': typeof ShadcnAuthTasklistTasksUserTaskKeyHistoryRouteRouteWithChildren
@@ -410,6 +419,7 @@ export interface FileRoutesById {
   '/_carbon/_auth/tasklist/_tasks/$userTaskKey': typeof CarbonAuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   '/shadcn/_auth/tasklist/_tasks/$userTaskKey': typeof ShadcnAuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   '/_carbon/_auth/operate/decisions/$decisionInstanceId': typeof CarbonAuthOperateDecisionsDecisionInstanceIdRoute
+  '/_carbon/_auth/operate/processes_/$processInstanceId': typeof CarbonAuthOperateProcessesProcessInstanceIdRoute
   '/_carbon/_auth/operate/decisions/': typeof CarbonAuthOperateDecisionsIndexRoute
   '/_carbon/_auth/tasklist/_tasks/': typeof CarbonAuthTasklistTasksIndexRoute
   '/shadcn/_auth/tasklist/_tasks/': typeof ShadcnAuthTasklistTasksIndexRoute
@@ -454,6 +464,7 @@ export interface FileRouteTypes {
     | '/tasklist/$userTaskKey'
     | '/shadcn/tasklist/$userTaskKey'
     | '/operate/decisions/$decisionInstanceId'
+    | '/operate/processes/$processInstanceId'
     | '/operate/decisions/'
     | '/tasklist/'
     | '/shadcn/tasklist/'
@@ -490,6 +501,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/operate'
     | '/operate/decisions/$decisionInstanceId'
+    | '/operate/processes/$processInstanceId'
     | '/operate/decisions'
     | '/tasklist/$userTaskKey/history'
     | '/shadcn/tasklist/$userTaskKey/history'
@@ -535,6 +547,7 @@ export interface FileRouteTypes {
     | '/_carbon/_auth/tasklist/_tasks/$userTaskKey'
     | '/shadcn/_auth/tasklist/_tasks/$userTaskKey'
     | '/_carbon/_auth/operate/decisions/$decisionInstanceId'
+    | '/_carbon/_auth/operate/processes_/$processInstanceId'
     | '/_carbon/_auth/operate/decisions/'
     | '/_carbon/_auth/tasklist/_tasks/'
     | '/shadcn/_auth/tasklist/_tasks/'
@@ -774,6 +787,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CarbonAuthOperateDecisionsDecisionInstanceIdRouteImport
       parentRoute: typeof CarbonAuthOperateDecisionsRoute
     }
+    '/_carbon/_auth/operate/processes_/$processInstanceId': {
+      id: '/_carbon/_auth/operate/processes_/$processInstanceId'
+      path: '/processes/$processInstanceId'
+      fullPath: '/operate/processes/$processInstanceId'
+      preLoaderRoute: typeof CarbonAuthOperateProcessesProcessInstanceIdRouteImport
+      parentRoute: typeof CarbonAuthOperateRouteRoute
+    }
     '/_carbon/_auth/tasklist/_tasks/': {
       id: '/_carbon/_auth/tasklist/_tasks/'
       path: '/'
@@ -912,6 +932,7 @@ interface CarbonAuthOperateRouteRouteChildren {
   CarbonAuthOperateOperationsLogRoute: typeof CarbonAuthOperateOperationsLogRoute
   CarbonAuthOperateProcessesRoute: typeof CarbonAuthOperateProcessesRoute
   CarbonAuthOperateIndexRoute: typeof CarbonAuthOperateIndexRoute
+  CarbonAuthOperateProcessesProcessInstanceIdRoute: typeof CarbonAuthOperateProcessesProcessInstanceIdRoute
 }
 
 const CarbonAuthOperateRouteRouteChildren: CarbonAuthOperateRouteRouteChildren =
@@ -924,6 +945,8 @@ const CarbonAuthOperateRouteRouteChildren: CarbonAuthOperateRouteRouteChildren =
     CarbonAuthOperateOperationsLogRoute: CarbonAuthOperateOperationsLogRoute,
     CarbonAuthOperateProcessesRoute: CarbonAuthOperateProcessesRoute,
     CarbonAuthOperateIndexRoute: CarbonAuthOperateIndexRoute,
+    CarbonAuthOperateProcessesProcessInstanceIdRoute:
+      CarbonAuthOperateProcessesProcessInstanceIdRoute,
   }
 
 const CarbonAuthOperateRouteRouteWithChildren =

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_carbon/_auth/operate/processes_.$processInstanceId.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_carbon/_auth/operate/processes_.$processInstanceId.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createFileRoute} from '@tanstack/react-router';
+import {ProcessInstance, ProcessInstancePending} from '#/operate/pages/ProcessInstance/ProcessInstance';
+import {processInstanceQuery} from '#/operate/pages/ProcessInstance/processInstance.queries';
+import {processInstanceSearchSchema} from '#/operate/pages/ProcessInstance/processInstanceSearch';
+
+const Route = createFileRoute('/_carbon/_auth/operate/processes_/$processInstanceId')({
+	validateSearch: processInstanceSearchSchema,
+	loader: ({context: {queryClient}, params: {processInstanceId}}) => {
+		void queryClient.prefetchQuery(processInstanceQuery(processInstanceId));
+	},
+	pendingComponent: ProcessInstancePending,
+	component: function ProcessInstanceRoute() {
+		const {processInstanceId} = Route.useParams();
+		return <ProcessInstance processInstanceId={processInstanceId} search={Route.useSearch()} />;
+	},
+});
+
+export {Route};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/config/system-configuration.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/config/system-configuration.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getSystemConfigurationResponseBodySchema} from '@camunda/camunda-api-zod-schemas/8.10';
+import {expect} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+
+it('should provide an enabled wait-state fixture by default', () => {
+	const config = getSystemConfigurationResponseBodySchema.parse(createSystemConfiguration());
+
+	expect(config.deployment.isWaitStatesEnabled).toBe(true);
+});
+
+it.for([false, true])('should preserve explicit wait-state enablement of %s', (isWaitStatesEnabled) => {
+	const config = getSystemConfigurationResponseBodySchema.parse(
+		createSystemConfiguration({deployment: {isWaitStatesEnabled}}),
+	);
+
+	expect(config.deployment.isWaitStatesEnabled).toBe(isWaitStatesEnabled);
+	expect(config.deployment.isMultiTenancyEnabled).toBe(false);
+});
+
+it('should preserve existing deployment fixture overrides', () => {
+	const config = getSystemConfigurationResponseBodySchema.parse(
+		createSystemConfiguration({deployment: {isMultiTenancyEnabled: true, maxRequestSize: 4194304}}),
+	);
+
+	expect(config.deployment).toEqual({
+		isMultiTenancyEnabled: true,
+		isWaitStatesEnabled: true,
+		maxRequestSize: 4194304,
+	});
+});
+
+it.for([undefined, null, 'false'])('should reject invalid wait-state enablement of %s without a fallback', (value) => {
+	const config = createSystemConfiguration();
+
+	const result = getSystemConfigurationResponseBodySchema.safeParse({
+		...config,
+		deployment: {...config.deployment, isWaitStatesEnabled: value},
+	});
+
+	expect(result.success).toBe(false);
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -416,6 +416,29 @@ const endpoints = {
 			headers: {'Content-Type': 'application/json'},
 		}),
 
+	getProcessInstance: ({processInstanceKey}: Pick<ProcessInstance, 'processInstanceKey'>) =>
+		new Request(getFullURL(unifiedAPIEndpoints.getProcessInstance.getUrl({processInstanceKey})), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.getProcessInstance.method,
+		}),
+
+	getProcessInstanceWaitStateStatistics: ({processInstanceKey}: Pick<ProcessInstance, 'processInstanceKey'>) =>
+		new Request(getFullURL(unifiedAPIEndpoints.getProcessInstanceWaitStateStatistics.getUrl({processInstanceKey})), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.getProcessInstanceWaitStateStatistics.method,
+		}),
+
+	queryProcessInstanceIncidents: (
+		{processInstanceKey}: Pick<ProcessInstance, 'processInstanceKey'>,
+		body: import('@camunda/camunda-api-zod-schemas/8.10').QueryProcessInstanceIncidentsRequestBody,
+	) =>
+		new Request(getFullURL(unifiedAPIEndpoints.queryProcessInstanceIncidents.getUrl({processInstanceKey})), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.queryProcessInstanceIncidents.method,
+			body: JSON.stringify(body),
+			headers: {'Content-Type': 'application/json'},
+		}),
+
 	getProcessInstanceCallHierarchy: ({processInstanceKey}: Pick<ProcessInstance, 'processInstanceKey'>) =>
 		new Request(getFullURL(unifiedAPIEndpoints.getProcessInstanceCallHierarchy.getUrl({processInstanceKey})), {
 			...BASE_REQUEST_OPTIONS,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -420,12 +420,14 @@ const endpoints = {
 		new Request(getFullURL(unifiedAPIEndpoints.getProcessInstance.getUrl({processInstanceKey})), {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.getProcessInstance.method,
+			headers: {'Content-Type': 'application/json'},
 		}),
 
 	getProcessInstanceWaitStateStatistics: ({processInstanceKey}: Pick<ProcessInstance, 'processInstanceKey'>) =>
 		new Request(getFullURL(unifiedAPIEndpoints.getProcessInstanceWaitStateStatistics.getUrl({processInstanceKey})), {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.getProcessInstanceWaitStateStatistics.method,
+			headers: {'Content-Type': 'application/json'},
 		}),
 
 	queryProcessInstanceIncidents: (

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -595,6 +595,38 @@
 					"forbiddenSubtitle": "Bitte kontaktieren Sie Ihren Administrator, wenn Sie Zugriff benötigen."
 				}
 			},
+			"processInstance": {
+				"title": "Operate-Prozessinstanz",
+				"pageTitle": "Operate: Prozessinstanz {{processInstanceId}} von {{name}}",
+				"notFound": "Instanz {{processInstanceId}} konnte nicht gefunden werden",
+				"retry": "Erneut versuchen",
+				"forbidden": {
+					"heading": "403 – Sie haben keine Berechtigung, diese Informationen anzuzeigen",
+					"description": "Wenden Sie sich an Ihren Administrator, um Zugriff zu erhalten.",
+					"learnMore": "Mehr über Berechtigungen erfahren"
+				},
+				"breadcrumb": {
+					"view": "Prozess {{name}} – Instanz {{key}} anzeigen",
+					"current": "Prozess {{name}} – Instanz {{key}}",
+					"more": "Mehr"
+				},
+				"header": {
+					"key": "Prozessinstanzschlüssel",
+					"version": "Version",
+					"versionTag": "Versions-Tag",
+					"versionTagDescription": "Benutzerdefinierte Bezeichnung zur Identifizierung einer Definition.",
+					"businessId": "Geschäfts-ID",
+					"tenant": "Mandant",
+					"startDate": "Startdatum",
+					"endDate": "Enddatum",
+					"calledInstances": "Aufgerufene Instanzen",
+					"versionLink": "Instanzen des Prozesses „{{name}} Version {{version}}“ anzeigen",
+					"viewAll": "Alle anzeigen",
+					"viewAllTitle": "Alle aufgerufenen Instanzen anzeigen",
+					"none": "Keine",
+					"draining": "Wird geleert"
+				}
+			},
 			"decisionInstance": {
 				"title": "Operate Entscheidungsinstanz",
 				"pageTitle": "Operate: Entscheidungsinstanz {{decisionInstanceId}} von {{name}}",
@@ -781,6 +813,8 @@
 					"selectOperator": "Operator auswählen"
 				},
 				"instanceHeader": {
+					"waiting_one": "Wartend",
+					"waiting_other": "{{count}} wartend",
 					"incidentsCount_one": "{{count}} Vorfall",
 					"incidentsCount_other": "{{count}} Vorfälle"
 				},

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -609,6 +609,38 @@
 					"forbiddenSubtitle": "Please contact the administrator if you need access."
 				}
 			},
+			"processInstance": {
+				"title": "Operate Process Instance",
+				"pageTitle": "Operate: Process Instance {{processInstanceId}} of {{name}}",
+				"notFound": "Instance {{processInstanceId}} could not be found",
+				"retry": "Retry",
+				"forbidden": {
+					"heading": "403 - You do not have permission to view this information",
+					"description": "Contact your administrator to get access.",
+					"learnMore": "Learn more about permissions"
+				},
+				"breadcrumb": {
+					"view": "View Process {{name}} - Instance {{key}}",
+					"current": "Process {{name}} - Instance {{key}}",
+					"more": "More"
+				},
+				"header": {
+					"key": "Process Instance Key",
+					"version": "Version",
+					"versionTag": "Version Tag",
+					"versionTagDescription": "User-defined label identifying a definition.",
+					"businessId": "Business ID",
+					"tenant": "Tenant",
+					"startDate": "Start Date",
+					"endDate": "End Date",
+					"calledInstances": "Called Instances",
+					"versionLink": "View process \"{{name}} version {{version}}\" instances",
+					"viewAll": "View All",
+					"viewAllTitle": "View all called instances",
+					"none": "None",
+					"draining": "Draining"
+				}
+			},
 			"decisionInstance": {
 				"title": "Operate Decision Instance",
 				"pageTitle": "Operate: Decision Instance {{decisionInstanceId}} of {{name}}",
@@ -795,6 +827,8 @@
 					"selectOperator": "Select operator"
 				},
 				"instanceHeader": {
+					"waiting_one": "Waiting",
+					"waiting_other": "{{count}} waiting",
 					"incidentsCount_one": "{{count}} incident",
 					"incidentsCount_other": "{{count}} incidents"
 				},

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -595,6 +595,38 @@
 					"forbiddenSubtitle": "Póngase en contacto con su administrador si necesita acceso."
 				}
 			},
+			"processInstance": {
+				"title": "Instancia de proceso de Operate",
+				"pageTitle": "Operate: instancia de proceso {{processInstanceId}} de {{name}}",
+				"notFound": "No se pudo encontrar la instancia {{processInstanceId}}",
+				"retry": "Reintentar",
+				"forbidden": {
+					"heading": "403: No tiene permiso para ver esta información",
+					"description": "Póngase en contacto con su administrador para obtener acceso.",
+					"learnMore": "Más información sobre los permisos"
+				},
+				"breadcrumb": {
+					"view": "Ver proceso {{name}}: instancia {{key}}",
+					"current": "Proceso {{name}}: instancia {{key}}",
+					"more": "Más"
+				},
+				"header": {
+					"key": "Clave de instancia de proceso",
+					"version": "Versión",
+					"versionTag": "Etiqueta de versión",
+					"versionTagDescription": "Etiqueta definida por el usuario que identifica una definición.",
+					"businessId": "ID de negocio",
+					"tenant": "Inquilino",
+					"startDate": "Fecha de inicio",
+					"endDate": "Fecha de finalización",
+					"calledInstances": "Instancias llamadas",
+					"versionLink": "Ver instancias del proceso «{{name}} versión {{version}}»",
+					"viewAll": "Ver todas",
+					"viewAllTitle": "Ver todas las instancias llamadas",
+					"none": "Ninguna",
+					"draining": "En vaciado"
+				}
+			},
 			"decisionInstance": {
 				"title": "Instancia de decisión de Operate",
 				"pageTitle": "Operate: Instancia de decisión {{decisionInstanceId}} de {{name}}",
@@ -781,6 +813,8 @@
 					"selectOperator": "Seleccionar operador"
 				},
 				"instanceHeader": {
+					"waiting_one": "En espera",
+					"waiting_other": "{{count}} en espera",
 					"incidentsCount_one": "{{count}} incidente",
 					"incidentsCount_other": "{{count}} incidentes"
 				},

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -598,6 +598,38 @@
 					"forbiddenSubtitle": "Veuillez contacter votre administrateur si vous avez besoin d'un accès."
 				}
 			},
+			"processInstance": {
+				"title": "Instance de processus Operate",
+				"pageTitle": "Operate : instance de processus {{processInstanceId}} de {{name}}",
+				"notFound": "L'instance {{processInstanceId}} est introuvable",
+				"retry": "Réessayer",
+				"forbidden": {
+					"heading": "403 – Vous n'avez pas l'autorisation de consulter ces informations",
+					"description": "Contactez votre administrateur pour obtenir l'accès.",
+					"learnMore": "En savoir plus sur les autorisations"
+				},
+				"breadcrumb": {
+					"view": "Afficher le processus {{name}} – Instance {{key}}",
+					"current": "Processus {{name}} – Instance {{key}}",
+					"more": "Plus"
+				},
+				"header": {
+					"key": "Clé de l'instance de processus",
+					"version": "Version",
+					"versionTag": "Étiquette de version",
+					"versionTagDescription": "Libellé défini par l'utilisateur identifiant une définition.",
+					"businessId": "Identifiant métier",
+					"tenant": "Locataire",
+					"startDate": "Date de début",
+					"endDate": "Date de fin",
+					"calledInstances": "Instances appelées",
+					"versionLink": "Afficher les instances du processus « {{name}} version {{version}} »",
+					"viewAll": "Tout afficher",
+					"viewAllTitle": "Afficher toutes les instances appelées",
+					"none": "Aucune",
+					"draining": "En cours de vidage"
+				}
+			},
 			"decisionInstance": {
 				"title": "Instance de décision Operate",
 				"pageTitle": "Operate : Instance de décision {{decisionInstanceId}} de {{name}}",
@@ -784,6 +816,8 @@
 					"selectOperator": "Sélectionner un opérateur"
 				},
 				"instanceHeader": {
+					"waiting_one": "En attente",
+					"waiting_other": "{{count}} en attente",
 					"incidentsCount_one": "{{count}} incident",
 					"incidentsCount_other": "{{count}} incidents"
 				},

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/operate/operate-process-instance.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/operate/operate-process-instance.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '#/pw-modules/test-extend';
+import {HttpResponse} from 'msw';
+import {
+	mockCurrentUserEndpoint,
+	mockSystemConfigurationEndpoint,
+	mockLicenseEndpoint,
+	mockGetProcessInstanceEndpoint,
+	mockGetProcessInstanceWaitStateStatisticsEndpoint,
+	mockGetProcessInstanceCallHierarchyEndpoint,
+	mockGetProcessDefinitionXmlEndpoint,
+	mockQueryProcessDefinitionsEndpoint,
+	mockQueryProcessInstancesEndpoint,
+} from '#/shared-test-modules/mock-handlers';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {createLicense} from '#/shared-test-modules/api-mocks/license';
+import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+import {
+	createProcessInstance,
+	createQueryProcessInstancesResponse,
+} from '#/shared-test-modules/api-mocks/process-instances';
+import {createQueryProcessDefinitionsResponse} from '#/shared-test-modules/api-mocks/process-definitions';
+
+test('should open an instance from Processes, retain a deep link on reload and return to its version', async ({
+	page,
+	network,
+	operateProcessesPage,
+	makeAxeBuilder,
+}) => {
+	const instance = createProcessInstance();
+	network.use(
+		mockGetProcessInstanceWaitStateStatisticsEndpoint({successResponse: HttpResponse.json({items: []})}),
+		mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}),
+		mockSystemConfigurationEndpoint({
+			successResponse: HttpResponse.json(createSystemConfiguration({components: {active: ['operate']}})),
+		}),
+		mockLicenseEndpoint({successResponse: HttpResponse.json(createLicense())}),
+		mockGetProcessInstanceEndpoint({successResponse: HttpResponse.json(instance)}),
+		mockGetProcessInstanceCallHierarchyEndpoint({successResponse: HttpResponse.json([])}),
+		mockGetProcessDefinitionXmlEndpoint({
+			successResponse: HttpResponse.text(
+				'<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="test"><process id="my-process" /></definitions>',
+			),
+		}),
+		mockQueryProcessDefinitionsEndpoint({successResponse: HttpResponse.json(createQueryProcessDefinitionsResponse())}),
+		mockQueryProcessInstancesEndpoint({
+			successResponse: HttpResponse.json(createQueryProcessInstancesResponse({items: [instance]})),
+		}),
+	);
+	await operateProcessesPage.goto();
+	await operateProcessesPage.instanceLink(instance.processInstanceKey).click();
+	await expect(page).toHaveURL(new RegExp(`/operate/processes/${instance.processInstanceKey}$`));
+	await expect(page.getByRole('heading', {name: 'Operate Process Instance', exact: true})).toBeAttached();
+	await expect(page.getByRole('cell', {name: instance.processInstanceKey, exact: true})).toBeVisible();
+	await expect(page).toHaveTitle(`Operate: Process Instance ${instance.processInstanceKey} of My Process`);
+	await page.reload();
+	await expect(page.getByText('My Process', {exact: true})).toBeVisible();
+	expect((await makeAxeBuilder().analyze()).violations).toEqual([]);
+	await page.getByRole('link', {name: /View process.*version 1/}).click();
+	await expect(operateProcessesPage.filtersPanel).toBeVisible();
+	expect(new URL(page.url()).searchParams.get('process')).toBe('my-process');
+	expect(new URL(page.url()).searchParams.get('version')).toBe('1');
+});

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/system-configuration.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/system-configuration.ts
@@ -26,6 +26,7 @@ type ComponentsConfiguration = z.infer<typeof componentsConfigurationSchema>;
 
 const deploymentConfigurationSchema = z.object({
 	isMultiTenancyEnabled: z.boolean(),
+	isWaitStatesEnabled: z.boolean(),
 	maxRequestSize: z.number(),
 });
 type DeploymentConfiguration = z.infer<typeof deploymentConfigurationSchema>;

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -123,6 +123,7 @@ paths:
                       active: ["operate", "tasklist"]
                     deployment:
                       isMultiTenancyEnabled: false
+                      isWaitStatesEnabled: true
                       maxRequestSize: 4194304
                     authentication:
                       canLogout: true
@@ -273,17 +274,27 @@ components:
       type: object
       required:
         - isMultiTenancyEnabled
+        - isWaitStatesEnabled
         - maxRequestSize
       properties:
         isMultiTenancyEnabled:
           description: Whether multi-tenancy is enabled.
           type: boolean
           example: false
+        isWaitStatesEnabled:
+          description: |
+            Whether wait-state tracking is enabled for the current physical tenant.
+            Reflects camunda.data.wait-states.enabled, which defaults to true.
+          type: boolean
+          example: true
         maxRequestSize:
           description: The maximum HTTP request size in bytes.
           type: integer
           format: int64
           example: 4194304
+      x-properties-added-in-version:
+        - propertyName: isWaitStatesEnabled
+          addedInVersion: "8.10"
 
     AuthenticationConfigurationResponse:
       description: Configuration for authentication and session management.
@@ -330,4 +341,3 @@ components:
         - dev
         - int
         - prod
-

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -292,9 +292,6 @@ components:
           type: integer
           format: int64
           example: 4194304
-      x-properties-added-in-version:
-        - propertyName: isWaitStatesEnabled
-          addedInVersion: "8.10"
 
     AuthenticationConfigurationResponse:
       description: Configuration for authentication and session management.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -26,11 +26,20 @@ public class GatewayRestConfiguration {
       MAX_CLUSTER_VARIABLE_METADATA_ENTRIES * MAX_CLUSTER_VARIABLE_METADATA_ENTRY_LENGTH;
 
   private final JobMetricsConfiguration jobMetrics = new JobMetricsConfiguration();
+  private boolean waitStatesEnabled = true;
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
   private int maxClusterVariableMetadataSize = DEFAULT_MAX_CLUSTER_VARIABLE_METADATA_SIZE;
 
   public JobMetricsConfiguration getJobMetrics() {
     return jobMetrics;
+  }
+
+  public boolean isWaitStatesEnabled() {
+    return waitStatesEnabled;
+  }
+
+  public void setWaitStatesEnabled(final boolean waitStatesEnabled) {
+    this.waitStatesEnabled = waitStatesEnabled;
   }
 
   /**

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -82,8 +82,8 @@ public class SystemController {
   @CamundaGetMapping(path = "/configuration")
   public ResponseEntity<SystemConfigurationResponse> getSystemConfiguration(
       @PhysicalTenantId final String physicalTenantId) {
-    final var jobMetrics =
-        tenantRestConfigProvider.forPhysicalTenant(physicalTenantId).getJobMetrics();
+    final var tenantRestConfig = tenantRestConfigProvider.forPhysicalTenant(physicalTenantId);
+    final var jobMetrics = tenantRestConfig.getJobMetrics();
     final var jobMetricsResponse =
         JobMetricsConfigurationResponse.Builder.create()
             .enabled(jobMetrics.isEnabled())
@@ -98,7 +98,7 @@ public class SystemController {
         SystemConfigurationResponse.Builder.create()
             .jobMetrics(jobMetricsResponse)
             .components(buildComponentsConfiguration())
-            .deployment(buildDeploymentConfiguration())
+            .deployment(buildDeploymentConfiguration(tenantRestConfig.isWaitStatesEnabled()))
             .authentication(buildAuthenticationConfiguration())
             .cloud(buildCloudConfiguration())
             .build());
@@ -113,7 +113,8 @@ public class SystemController {
         .build();
   }
 
-  private DeploymentConfigurationResponse buildDeploymentConfiguration() {
+  private DeploymentConfigurationResponse buildDeploymentConfiguration(
+      final boolean isWaitStatesEnabled) {
     final boolean isMultiTenancyEnabled =
         cslProperties != null
             && cslProperties.getMultiTenancy() != null
@@ -121,6 +122,7 @@ public class SystemController {
 
     return DeploymentConfigurationResponse.Builder.create()
         .isMultiTenancyEnabled(isMultiTenancyEnabled)
+        .isWaitStatesEnabled(isWaitStatesEnabled)
         .maxRequestSize(maxRequestSizeBytes)
         .build();
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.system;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -38,6 +39,8 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -90,6 +93,7 @@ public class SystemControllerTest extends RestControllerTest {
 
   // WebappConfiguration is provided by SystemControllerTestConfiguration
   @Autowired WebappConfiguration webappConfiguration;
+  @Autowired SystemController systemController;
 
   @BeforeEach
   void setupUsageMetricsServices() {
@@ -454,6 +458,58 @@ public class SystemControllerTest extends RestControllerTest {
             }
             """,
             JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldReturnWaitStatesEnabledByDefault() {
+    // given the default REST configuration
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.deployment.isWaitStatesEnabled")
+        .isEqualTo(true);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldReturnConfiguredWaitStatesEnabled(final boolean enabled) {
+    // given
+    final var config = new GatewayRestConfiguration();
+    config.setWaitStatesEnabled(enabled);
+    when(tenantRestConfigProvider.forPhysicalTenant(any())).thenReturn(config);
+
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.deployment.isWaitStatesEnabled")
+        .isEqualTo(enabled);
+  }
+
+  @Test
+  void shouldReturnWaitStatesConfigurationForEachPhysicalTenant() {
+    // given
+    final var enabledConfig = new GatewayRestConfiguration();
+    final var disabledConfig = new GatewayRestConfiguration();
+    disabledConfig.setWaitStatesEnabled(false);
+    when(tenantRestConfigProvider.forPhysicalTenant("enabled")).thenReturn(enabledConfig);
+    when(tenantRestConfigProvider.forPhysicalTenant("disabled")).thenReturn(disabledConfig);
+
+    // when/then
+    for (final var tenantId : List.of("enabled", "disabled", "enabled")) {
+      final var response = systemController.getSystemConfiguration(tenantId);
+      assertThat(response.getBody().getDeployment().getIsWaitStatesEnabled())
+          .isEqualTo(tenantId.equals("enabled"));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description

Make process-instance links resolve to the Operate detail shell with breadcrumbs, metadata and panel context. Preserve configured waiting-state behavior and provide explicit initial-load retry.

Stacked on #62378; onboarding follows separately. Suspended filtering remains #61094. Baseline diagnostics still block warning-clean sign-off.

## Checklist

<!--- Please delete options that are not relevant. -->

## Related issues

relates to #56029