### PR TITLE
Scope agent history assertion to own process instance

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -2566,14 +2566,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var createdForItem =
         RecordingExporter.records()
             .limit(r -> r.getKey() == clockResetKey)
-            .withValueType(ValueType.AGENT_HISTORY)
+            .agentHistoryRecords()
             .withIntent(AgentHistoryIntent.CREATED)
-            .filter(
-                r -> {
-                  final var value = (AgentHistoryRecordValue) r.getValue();
-                  return value.getAgentInstanceKey() == agentInstanceKey
-                      && value.getHistoryItemId().equals("item-user");
-                })
+            .withAgentInstanceKey(agentInstanceKey)
+            .withHistoryItemId("item-user")
             .toList();
     assertThat(createdForItem).hasSize(1);
   }
@@ -3111,10 +3107,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var createdEvents =
         RecordingExporter.records()
             .limit(r -> r.getKey() == clockResetKey)
-            .withValueType(ValueType.AGENT_HISTORY)
+            .agentHistoryRecords()
             .withIntent(AgentHistoryIntent.CREATED)
-            .filter(
-                r -> ((AgentHistoryRecordValue) r.getValue()).getHistoryItemId().equals("dup-id"))
+            .withHistoryItemId("dup-id")
             .toList();
     assertThat(createdEvents).isEmpty();
   }
@@ -3877,10 +3872,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var createdForItem =
         RecordingExporter.records()
             .limit(r -> r.getKey() == clockResetKey)
-            .withValueType(ValueType.AGENT_HISTORY)
+            .agentHistoryRecords()
             .withIntent(AgentHistoryIntent.CREATED)
-            .filter(
-                r -> ((AgentHistoryRecordValue) r.getValue()).getHistoryItemId().equals("item-x"))
+            .withHistoryItemId("item-x")
             .toList();
     assertThat(createdForItem).as("no second CREATED event was appended for item-x").hasSize(1);
   }
@@ -4295,13 +4289,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var createdForDiscardedItem =
         RecordingExporter.records()
             .limit(r -> r.getKey() == clockResetKey)
-            .withValueType(ValueType.AGENT_HISTORY)
+            .agentHistoryRecords()
             .withIntent(AgentHistoryIntent.CREATED)
-            .filter(
-                r ->
-                    ((AgentHistoryRecordValue) r.getValue())
-                        .getHistoryItemId()
-                        .equals("item-discarded"))
+            .withHistoryItemId("item-discarded")
             .toList();
     assertThat(createdForDiscardedItem)
         .as(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -2569,8 +2569,11 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withValueType(ValueType.AGENT_HISTORY)
             .withIntent(AgentHistoryIntent.CREATED)
             .filter(
-                r ->
-                    ((AgentHistoryRecordValue) r.getValue()).getHistoryItemId().equals("item-user"))
+                r -> {
+                  final var value = (AgentHistoryRecordValue) r.getValue();
+                  return value.getAgentInstanceKey() == agentInstanceKey
+                      && value.getHistoryItemId().equals("item-user");
+                })
             .toList();
     assertThat(createdForItem).hasSize(1);
   }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AgentHistoryRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AgentHistoryRecordStream.java
@@ -40,4 +40,8 @@ public final class AgentHistoryRecordStream
   public AgentHistoryRecordStream withRole(final AgentHistoryRole role) {
     return valueFilter(v -> v.getRole() == role);
   }
+
+  public AgentHistoryRecordStream withHistoryItemId(final String historyItemId) {
+    return valueFilter(v -> v.getHistoryItemId().equals(historyItemId));
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -215,4 +215,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new ScaleRecordStream(
         filter(r -> r.getValueType() == ValueType.SCALE).map(Record.class::cast));
   }
+
+  public AgentHistoryRecordStream agentHistoryRecords() {
+    return new AgentHistoryRecordStream(
+        filter(r -> r.getValueType() == ValueType.AGENT_HISTORY).map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

`AgentInstanceHistoryBatchProcessingTest#shouldMarkResentItemAsDuplicateWithinSameJobActivation` queried `RecordingExporter` for an `AGENT_HISTORY:CREATED` record filtered only by the literal `historyItemId` `"item-user"`. The test class shares one broker across all methods (`@ClassRule EngineRule.singlePartition()`), so the exporter's record log accumulates across the whole class instead of resetting per test. Several sibling methods reuse the same `"item-user"` literal, so the unbounded filter occasionally picked up another test's record too, causing an intermittent `Expected size: 1 but was: 2` failure (seen 19x in one day's CI flaky-test report, e.g. run 34145446940).

Fix scopes the filter to the test's own `agentInstanceKey` in addition to the `historyItemId`, so it can no longer match another test's record regardless of run order or timing. Kept the fix to the query-scoping approach (2 lines of logic) rather than renaming identifiers across the whole class, per the smaller-diff option.

## Related issues

closes #62371
