### PR TITLE
fix: distinguish deleted process definitions in Operate

### DIFF
--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.test.tsx
@@ -506,7 +506,7 @@ describe('<ProcessOperations />', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should hide delete button when definition is deleted', async () => {
+  it('should show deleted tag instead of delete button when definition is deleted', async () => {
     mockSearchProcessDefinitions().withSuccess({
       items: [
         {
@@ -535,13 +535,12 @@ describe('<ProcessOperations />', () => {
       {wrapper: Wrapper},
     );
 
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('button', {
-          name: /^delete process definition/i,
-        }),
-      ).not.toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('deleted-tag')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: /^delete process definition/i,
+      }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByTestId('draining-tag')).not.toBeInTheDocument();
   });
 

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.test.tsx
@@ -407,6 +407,45 @@ describe('<ProcessOperations />', () => {
     );
   });
 
+  it('should keep the delete button disabled while the definition state is still loading', async () => {
+    mockApplyProcessDefinitionOperation().withSuccess(mockOperation);
+    mockSearchProcessDefinitions().withDelay({
+      items: [
+        {
+          name: 'myProcess',
+          processDefinitionId: 'myProcess',
+          processDefinitionKey: '2251799813687094',
+          version: 2,
+          tenantId: '<default>',
+          hasStartForm: false,
+          state: 'DELETED',
+        },
+      ],
+      page: {totalItems: 1},
+    });
+    mockFetchProcessInstances().withSuccess({
+      processInstances: [],
+      totalCount: 0,
+    });
+
+    render(
+      <ProcessOperations
+        processDefinitionId="2251799813687094"
+        processName="myProcess"
+        processVersion="2"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /^delete process definition "myProcess - version 2"$/i,
+      }),
+    ).toBeDisabled();
+
+    expect(await screen.findByTestId('deleted-tag')).toBeInTheDocument();
+  });
+
   it('should disable delete button when there are running instances', async () => {
     mockApplyProcessDefinitionOperation().withSuccess(mockOperation);
     mockFetchProcessInstances().withSuccess({
@@ -465,6 +504,45 @@ describe('<ProcessOperations />', () => {
         name: /^delete process definition/i,
       }),
     ).not.toBeInTheDocument();
+  });
+
+  it('should hide delete button when definition is deleted', async () => {
+    mockSearchProcessDefinitions().withSuccess({
+      items: [
+        {
+          name: 'myProcess',
+          processDefinitionId: 'myProcess',
+          processDefinitionKey: '2251799813687094',
+          version: 2,
+          tenantId: '<default>',
+          hasStartForm: false,
+          state: 'DELETED',
+        },
+      ],
+      page: {totalItems: 1},
+    });
+    mockFetchProcessInstances().withSuccess({
+      processInstances: [],
+      totalCount: 0,
+    });
+
+    render(
+      <ProcessOperations
+        processDefinitionId="2251799813687094"
+        processName="myProcess"
+        processVersion="2"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', {
+          name: /^delete process definition/i,
+        }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('draining-tag')).not.toBeInTheDocument();
   });
 
   it('should enable delete button when process instances could not be fetched', async () => {

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
@@ -12,6 +12,7 @@ import {OperationItems} from 'modules/components/OperationItems';
 import {DeleteButtonContainer} from 'modules/components/DeleteDefinition/styled';
 import {InlineLoading, Link, ListItem, Stack} from '@carbon/react';
 import {DrainingTag} from 'modules/components/DrainingTag';
+import {DeletedTag} from 'modules/components/DeletedTag';
 import {DeleteDefinitionModal} from 'modules/components/DeleteDefinitionModal';
 import {operationsStore} from 'modules/stores/operations';
 import {panelStatesStore} from 'modules/stores/panelStates';
@@ -64,6 +65,7 @@ const ProcessOperations: React.FC<Props> = observer(
               align="top-left"
             />
           )}
+          {isDeleted && <DeletedTag align="top-left" />}
           {!isDraining && !isDeleted && (
             <OperationItems>
               <DangerButton

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
@@ -62,10 +62,10 @@ const ProcessOperations: React.FC<Props> = observer(
           {isDraining && (
             <DrainingTag
               description={DRAINING_MESSAGES.version}
-              align="top-left"
+              align="bottom-right"
             />
           )}
-          {isDeleted && <DeletedTag align="top-left" />}
+          {isDeleted && <DeletedTag />}
           {!isDraining && !isDeleted && (
             <OperationItems>
               <DangerButton

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
@@ -21,7 +21,7 @@ import {notificationsStore} from 'modules/stores/notifications';
 import {tracking} from 'modules/tracking';
 import {observer} from 'mobx-react';
 import {processInstancesStore} from 'modules/stores/processInstances';
-import {useDrainingProcessDefinitions} from 'modules/queries/processDefinitions/useDrainingProcessDefinitions';
+import {useProcessDefinitionState} from 'modules/queries/processDefinitions/useProcessDefinitionState';
 import {DRAINING_MESSAGES} from 'modules/utils/draining';
 
 type Props = {
@@ -38,8 +38,10 @@ const ProcessOperations: React.FC<Props> = observer(
     const [isOperationRunning, setIsOperationRunning] = useState(false);
     const {runningInstancesCount} = processInstancesStore.state;
 
-    const {data: draining} = useDrainingProcessDefinitions();
-    const isDraining = !!draining?.byKey.has(processDefinitionId);
+    const {data: processDefinitionState, isPending: isStatePending} =
+      useProcessDefinitionState(processDefinitionId);
+    const isDraining = processDefinitionState === 'DRAINING';
+    const isDeleted = processDefinitionState === 'DELETED';
 
     useEffect(() => {
       processInstancesStore.fetchRunningInstancesCount();
@@ -56,12 +58,13 @@ const ProcessOperations: React.FC<Props> = observer(
           {isOperationRunning && (
             <InlineLoading data-testid="delete-operation-spinner" />
           )}
-          {isDraining ? (
+          {isDraining && (
             <DrainingTag
               description={DRAINING_MESSAGES.version}
               align="top-left"
             />
-          ) : (
+          )}
+          {!isDraining && !isDeleted && (
             <OperationItems>
               <DangerButton
                 title={
@@ -70,7 +73,11 @@ const ProcessOperations: React.FC<Props> = observer(
                     : `Delete Process Definition "${processName} - Version ${processVersion}"`
                 }
                 type="DELETE"
-                disabled={isOperationRunning || runningInstancesCount !== 0}
+                disabled={
+                  isOperationRunning ||
+                  isStatePending ||
+                  runningInstancesCount !== 0
+                }
                 onClick={() => {
                   tracking.track({
                     eventName: 'definition-deletion-button',

--- a/operate/client/src/modules/components/DeletedTag/index.test.tsx
+++ b/operate/client/src/modules/components/DeletedTag/index.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {DeletedTag} from './index';
+
+describe('<DeletedTag />', () => {
+  it('should render the deleted tag', () => {
+    render(<DeletedTag />);
+
+    expect(screen.getByTestId('deleted-tag')).toBeInTheDocument();
+    expect(screen.getByText('Deleted')).toBeInTheDocument();
+  });
+
+  it('should explain the deleted state on keyboard focus', async () => {
+    const {user} = render(<DeletedTag />);
+
+    await user.tab();
+
+    expect(screen.getByTestId('deleted-tag')).toHaveFocus();
+    expect(
+      await screen.findByText(
+        'This process definition has been deleted. Its record remains available until its history is permanently deleted.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/modules/components/DeletedTag/index.test.tsx
+++ b/operate/client/src/modules/components/DeletedTag/index.test.tsx
@@ -16,17 +16,4 @@ describe('<DeletedTag />', () => {
     expect(screen.getByTestId('deleted-tag')).toBeInTheDocument();
     expect(screen.getByText('Deleted')).toBeInTheDocument();
   });
-
-  it('should explain the deleted state on keyboard focus', async () => {
-    const {user} = render(<DeletedTag />);
-
-    await user.tab();
-
-    expect(screen.getByTestId('deleted-tag')).toHaveFocus();
-    expect(
-      await screen.findByText(
-        'This process definition has been deleted. Its record remains available until its history is permanently deleted.',
-      ),
-    ).toBeInTheDocument();
-  });
 });

--- a/operate/client/src/modules/components/DeletedTag/index.tsx
+++ b/operate/client/src/modules/components/DeletedTag/index.tsx
@@ -6,22 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Tag, Tooltip} from '@carbon/react';
+import {Tag} from '@carbon/react';
 
-type Props = {
-  align?: React.ComponentProps<typeof Tooltip>['align'];
-};
-
-const DeletedTag: React.FC<Props> = ({align = 'top'}) => (
-  <Tooltip
-    label="This process definition has been deleted. Its record remains available until its history is permanently deleted."
-    align={align}
-    autoAlign
-  >
-    <Tag size="sm" type="red" data-testid="deleted-tag" tabIndex={0}>
-      Deleted
-    </Tag>
-  </Tooltip>
+const DeletedTag: React.FC = () => (
+  <Tag size="sm" type="red" data-testid="deleted-tag">
+    Deleted
+  </Tag>
 );
 
 export {DeletedTag};

--- a/operate/client/src/modules/components/DeletedTag/index.tsx
+++ b/operate/client/src/modules/components/DeletedTag/index.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Tag, Tooltip} from '@carbon/react';
+
+type Props = {
+  align?: React.ComponentProps<typeof Tooltip>['align'];
+};
+
+const DeletedTag: React.FC<Props> = ({align = 'top'}) => (
+  <Tooltip
+    label="This process definition has been deleted. Its record remains available until its history is permanently deleted."
+    align={align}
+    autoAlign
+  >
+    <Tag size="sm" type="red" data-testid="deleted-tag" tabIndex={0}>
+      Deleted
+    </Tag>
+  </Tooltip>
+);
+
+export {DeletedTag};

--- a/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionState.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionState.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {QueryProcessDefinitionsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import {useProcessDefinitionsSearch} from './useProcessDefinitionsSearch';
+
+const STATE_REFETCH_INTERVAL = 5000;
+
+type ProcessDefinitionState =
+  QueryProcessDefinitionsResponseBody['items'][number]['state'];
+
+// Filters on the exact key so the query stays a single-item lookup instead
+// of scanning every process definition ever created.
+function useProcessDefinitionState(processDefinitionKey: string | undefined) {
+  return useProcessDefinitionsSearch<ProcessDefinitionState | undefined>({
+    enabled: processDefinitionKey !== undefined,
+    staleTime: STATE_REFETCH_INTERVAL,
+    refetchInterval: STATE_REFETCH_INTERVAL,
+    payload: {
+      filter: {
+        processDefinitionKey,
+      },
+    },
+    select: (items) => items[0]?.state,
+  });
+}
+
+export {useProcessDefinitionState};


### PR DESCRIPTION
## Description

Manual backport of https://github.com/camunda/camunda/pull/61855 without the dropdown logic.

## Related issues

related to https://github.com/camunda/camunda/issues/61504

