### PR TITLE
docs: document load-test tooling language standard

### DIFF
--- a/.github/instructions/load-tests.instructions.md
+++ b/.github/instructions/load-tests.instructions.md
@@ -59,6 +59,15 @@ When reviewing changes to load tests, workflows, or load test infrastructure:
    A plain `make -n <target>` dry run — or the golden file tests, which never set this variable on
    the command line — will not catch this class of regression.
 
+## Choosing a language for new tooling
+
+When adding or extending a load-test script (metrics, reporting, profiling, ops helpers), follow
+the language standard in
+[`load-tests/docs/scripts/README.md`](https://github.com/camunda/camunda/blob/main/load-tests/docs/scripts/README.md#choosing-a-language-for-new-tooling):
+Python is the default for non-trivial operational/reporting scripts; shell is for thin wrappers and
+glue only; Go is for a maintained binary, stronger compile-time guarantees, parallelism/performance
+work, or a real multi-command CLI.
+
 ## What gets backported
 
 **Never backport** (update the versioned folder on `main` instead):

--- a/load-tests/docs/scripts/README.md
+++ b/load-tests/docs/scripts/README.md
@@ -2,6 +2,30 @@
 
 This folder contains several scripts we wrote to test or debug things.
 
+## Choosing a language for new tooling
+
+- **Shell**: thin wrappers and glue only: minimal branching, no assembly of structured data.
+  Fine for orchestrating existing CLIs (`kubectl`, `curl`, `jq`).
+- **Python**: the default for non-trivial operational/reporting scripts: anything that reads or
+  writes JSON/YAML/CSV/TSV, talks to HTTP APIs, validates input, or needs meaningful unit tests.
+  Prefer stdlib (`argparse`, `json`, `csv`, `datetime`, `urllib`) before adding dependencies. Keep
+  a thin shell wrapper around it when command compatibility with an existing script matters.
+- **Go**: for a maintained distributable binary, stronger compile-time guarantees, parallelism or
+  performance work, or a tool that naturally fits into an existing Go module.
+- **Cross-cutting**: use structured encoders instead of string-building; every non-trivial tool
+  needs targeted tests and a README section here (usage, examples, dependencies, exact test
+  command).
+
+This standard came out of comparing three implementations of the same load-test reporting script:
+[#61425](https://github.com/camunda/camunda/pull/61425) (shell), [#62289](https://github.com/camunda/camunda/pull/62289) (Python), and
+[#62361](https://github.com/camunda/camunda/pull/62361) (Go). Python is the default going forward for
+this class of tooling; Go remains an option once a tool becomes a maintained multi-command CLI or
+binary.
+
+Decided 2026-09-08, see the [team discussion](https://camunda.slack.com/archives/C0A22S6M4TF/p1788862132853069?thread_ts=1788811533.488189&cid=C0A22S6M4TF)
+for the full reasoning. Revisit this decision if the tooling grows more complex sub-commands or
+shared logic than a single script justifies.
+
 ## Profile.sh
 
 **Usage:**


### PR DESCRIPTION
## Description

Adds a "Choosing a language for new tooling" section to `load-tests/docs/scripts/README.md` documenting when to use shell, Python, or Go for load-test tooling scripts, plus a short pointer rule in `.github/instructions/load-tests.instructions.md` so AI agents apply the standard automatically when touching `load-tests/**`.

The standard came out of comparing three implementations of the same load-test reporting script: #61425 (shell), #62289 (Python), #62361 (Go). [Decision](https://camunda.slack.com/archives/C0A22S6M4TF/p1788862132853069?thread_ts=1788811533.488189&cid=C0A22S6M4TF): Python is the default going forward for non-trivial load-test tooling; Go remains an option once a tool becomes a maintained multi-command CLI or binary.

Docs-only change, no code. Documented decision [here](https://github.com/camunda/team-reliability-testing/tree/main/decisions) as well.


## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #62389
