### PR TITLE
ci: include stable/8.10 & stable/8.7 branch in the template mapping

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -58,7 +58,9 @@ jobs:
                 done \
               | jq -s '
                   map(
-                    if .branch == "stable/8.8" then
+                    if .branch == "stable/8.7" then
+                      .generation_template = "Camunda 8.7-SNAPSHOT"
+                    elif .branch == "stable/8.8" then
                       .generation_template = "Camunda 8.8-SNAPSHOT"
                     elif .branch == "stable/8.9" then
                       .generation_template = "Camunda 8.9-SNAPSHOT"

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -62,6 +62,8 @@ jobs:
                       .generation_template = "Camunda 8.8-SNAPSHOT"
                     elif .branch == "stable/8.9" then
                       .generation_template = "Camunda 8.9-SNAPSHOT"
+                    elif .branch == "stable/8.10" then
+                      .generation_template = "Camunda 8.10-SNAPSHOT"
                     else
                       .
                     end


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Set `Camunda 8.10-SNAPSHOT` to the `stable/8.10` branch Zeebe Daily QA execution.
  - The branch was cutoff and the process attempts to derive a `Camunda 8.10+gen1` template. Resulting in failures. 
- Set `Camunda 8.7-SNAPSHOT` to the `stable/8.7` branch Zeebe Daily QA execution.
  - The bench tests were running for a while targetting the 8.7+gen1 generation

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

