### PR TITLE
feat: allow schema-manager retry to be configured for Elasticsearch and OpenSearch

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -105,6 +105,9 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   @NestedConfigurationProperty private Bulk bulk = new Bulk(databaseName());
 
   @NestedConfigurationProperty
+  private SchemaManagerRetry retry = new SchemaManagerRetry(databaseName());
+
+  @NestedConfigurationProperty
   private DocumentBasedSecondaryStorageBackup backup =
       new DocumentBasedSecondaryStorageBackup(databaseName());
 
@@ -266,6 +269,14 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public void setBulk(final Bulk bulk) {
     this.bulk = bulk;
+  }
+
+  public SchemaManagerRetry getRetry() {
+    return retry;
+  }
+
+  public void setRetry(final SchemaManagerRetry retry) {
+    this.retry = retry;
   }
 
   public SecondaryStorageSecurity getSecurity() {

--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -98,6 +98,10 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   @NestedConfigurationProperty
   private RdbmsConnectionPool connectionPool = new RdbmsConnectionPool();
 
+  @NestedConfigurationProperty
+  private SchemaManagerRetry retry =
+      new SchemaManagerRetry(databaseName()).withoutLegacyProperties();
+
   /**
    * The database vendor id. It is used to determine the dialect to use for the database. If not
    * set, the dialect is determined automatically.
@@ -200,6 +204,14 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   @Override
   public String databaseName() {
     return "rdbms";
+  }
+
+  public SchemaManagerRetry getRetry() {
+    return retry;
+  }
+
+  public void setRetry(final SchemaManagerRetry retry) {
+    this.retry = retry;
   }
 
   public RdbmsMetrics getMetrics() {

--- a/configuration/src/main/java/io/camunda/configuration/SchemaManagerRetry.java
+++ b/configuration/src/main/java/io/camunda/configuration/SchemaManagerRetry.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.search.schema.config.SchemaManagerConfiguration.SchemaManagerRetryConfiguration;
+import java.time.Duration;
+import java.util.Set;
+
+public class SchemaManagerRetry {
+
+  private static final String LEGACY_PREFIX = "camunda.database.schema-manager.retry";
+
+  private final String prefix;
+
+  private int maxRetries = SchemaManagerRetryConfiguration.DEFAULT_MAX_RETRIES;
+  private Duration minRetryDelay = SchemaManagerRetryConfiguration.DEFAULT_MIN_RETRY_DELAY;
+  private Duration maxRetryDelay = SchemaManagerRetryConfiguration.DEFAULT_MAX_RETRY_DELAY;
+
+  public SchemaManagerRetry(final String databaseName) {
+    prefix = "camunda.data.secondary-storage.%s.retry".formatted(databaseName);
+  }
+
+  public int getMaxRetries() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        prefix + ".max-retries",
+        maxRetries,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_PREFIX + ".maxRetries"));
+  }
+
+  public void setMaxRetries(final int maxRetries) {
+    this.maxRetries = maxRetries;
+  }
+
+  public Duration getMinRetryDelay() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        prefix + ".min-retry-delay",
+        minRetryDelay,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_PREFIX + ".minRetryDelay"));
+  }
+
+  public void setMinRetryDelay(final Duration minRetryDelay) {
+    this.minRetryDelay = minRetryDelay;
+  }
+
+  public Duration getMaxRetryDelay() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        prefix + ".max-retry-delay",
+        maxRetryDelay,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_PREFIX + ".maxRetryDelay"));
+  }
+
+  public void setMaxRetryDelay(final Duration maxRetryDelay) {
+    this.maxRetryDelay = maxRetryDelay;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/SchemaManagerRetry.java
+++ b/configuration/src/main/java/io/camunda/configuration/SchemaManagerRetry.java
@@ -11,12 +11,16 @@ import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilit
 import io.camunda.search.schema.config.SchemaManagerConfiguration.SchemaManagerRetryConfiguration;
 import java.time.Duration;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 public class SchemaManagerRetry {
 
   private static final String LEGACY_PREFIX = "camunda.database.schema-manager.retry";
 
   private final String prefix;
+
+  /** Null for a storage whose retry settings never had a legacy property to migrate from. */
+  private @Nullable String legacyPrefix = LEGACY_PREFIX;
 
   private int maxRetries = SchemaManagerRetryConfiguration.DEFAULT_MAX_RETRIES;
   private Duration minRetryDelay = SchemaManagerRetryConfiguration.DEFAULT_MIN_RETRY_DELAY;
@@ -26,13 +30,22 @@ public class SchemaManagerRetry {
     prefix = "camunda.data.secondary-storage.%s.retry".formatted(databaseName);
   }
 
+  SchemaManagerRetry withoutLegacyProperties() {
+    legacyPrefix = null;
+    return this;
+  }
+
+  private Set<String> legacyProperties(final String suffix) {
+    return legacyPrefix == null ? Set.of() : Set.of(legacyPrefix + suffix);
+  }
+
   public int getMaxRetries() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".max-retries",
         maxRetries,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_PREFIX + ".maxRetries"));
+        legacyProperties(".maxRetries"));
   }
 
   public void setMaxRetries(final int maxRetries) {
@@ -45,7 +58,7 @@ public class SchemaManagerRetry {
         minRetryDelay,
         Duration.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_PREFIX + ".minRetryDelay"));
+        legacyProperties(".minRetryDelay"));
   }
 
   public void setMinRetryDelay(final Duration minRetryDelay) {
@@ -58,7 +71,7 @@ public class SchemaManagerRetry {
         maxRetryDelay,
         Duration.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_PREFIX + ".maxRetryDelay"));
+        legacyProperties(".maxRetryDelay"));
   }
 
   public void setMaxRetryDelay(final Duration maxRetryDelay) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
@@ -10,12 +10,14 @@ package io.camunda.configuration.beanoverrides;
 import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED;
 
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SchemaManagerRetry;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties;
 import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.search.schema.config.SchemaManagerConfiguration.SchemaManagerRetryConfiguration;
 import java.util.Set;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,6 +80,7 @@ public class SearchEngineSchemaManagerPropertiesOverride {
               override.setPerformCleanup(secondaryStorage.isPerformCleanup());
               override.setCreateSchema(secondaryStorage.isCreateSchema());
               override.setHealthCheckEnabled(secondaryStorage.isHealthCheckEnabled());
+              override.setRetry(toRetryConfiguration(secondaryStorage.getRetry()));
             });
 
     override.setHealthCheckEnabled(
@@ -87,5 +90,14 @@ public class SearchEngineSchemaManagerPropertiesOverride {
             Boolean.class,
             SUPPORTED,
             LEGACY_HEALTH_CHECK_ENABLED_PROPERTIES));
+  }
+
+  private static SchemaManagerRetryConfiguration toRetryConfiguration(
+      final SchemaManagerRetry retry) {
+    final var converted = new SchemaManagerRetryConfiguration();
+    converted.setMaxRetries(retry.getMaxRetries());
+    converted.setMinRetryDelay(retry.getMinRetryDelay());
+    converted.setMaxRetryDelay(retry.getMaxRetryDelay());
+    return converted;
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabaseTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabaseTest.java
@@ -10,6 +10,7 @@ package io.camunda.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,6 +37,14 @@ class DocumentBasedSecondaryStorageDatabaseTest {
       "camunda.database.schema-manager.health-check-enabled";
   private static final String NEW_HEALTH_CHECK_ENABLED_PROPERTY =
       "camunda.data.secondary-storage.elasticsearch.health-check-enabled";
+  private static final String LEGACY_RETRY_MAX_RETRIES_PROPERTY =
+      "camunda.database.schema-manager.retry.maxRetries";
+  private static final String LEGACY_RETRY_MIN_RETRY_DELAY_PROPERTY =
+      "camunda.database.schema-manager.retry.minRetryDelay";
+  private static final String LEGACY_RETRY_MAX_RETRY_DELAY_PROPERTY =
+      "camunda.database.schema-manager.retry.maxRetryDelay";
+  private static final String NEW_RETRY_MAX_RETRIES_PROPERTY =
+      "camunda.data.secondary-storage.elasticsearch.retry.max-retries";
 
   private MockEnvironment mockEnvironment;
   private Elasticsearch elasticsearch;
@@ -202,5 +211,68 @@ class DocumentBasedSecondaryStorageDatabaseTest {
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(elasticsearch::isHealthCheckEnabled)
         .withMessageContaining("Ambiguous legacy configuration");
+  }
+
+  @Test
+  void shouldDefaultRetryToUnboundedWithSchemaManagerDelays() {
+    // then
+    assertThat(elasticsearch.getRetry().getMaxRetries()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(elasticsearch.getRetry().getMinRetryDelay()).isEqualTo(Duration.ofMillis(500));
+    assertThat(elasticsearch.getRetry().getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(10));
+  }
+
+  @Test
+  void shouldUseNewRetryValuesWhenNoLegacyRetryPropertyIsSet() {
+    // given
+    elasticsearch.getRetry().setMaxRetries(7);
+    elasticsearch.getRetry().setMinRetryDelay(Duration.ofSeconds(1));
+    elasticsearch.getRetry().setMaxRetryDelay(Duration.ofSeconds(20));
+
+    // then
+    assertThat(elasticsearch.getRetry().getMaxRetries()).isEqualTo(7);
+    assertThat(elasticsearch.getRetry().getMinRetryDelay()).isEqualTo(Duration.ofSeconds(1));
+    assertThat(elasticsearch.getRetry().getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(20));
+  }
+
+  @Test
+  void shouldFallBackToLegacyRetryProperties() {
+    // given
+    mockEnvironment.setProperty(LEGACY_RETRY_MAX_RETRIES_PROPERTY, "5");
+    mockEnvironment.setProperty(LEGACY_RETRY_MIN_RETRY_DELAY_PROPERTY, "2s");
+    mockEnvironment.setProperty(LEGACY_RETRY_MAX_RETRY_DELAY_PROPERTY, "30s");
+
+    // then
+    assertThat(elasticsearch.getRetry().getMaxRetries()).isEqualTo(5);
+    assertThat(elasticsearch.getRetry().getMinRetryDelay()).isEqualTo(Duration.ofSeconds(2));
+    assertThat(elasticsearch.getRetry().getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void shouldFallBackToLegacyRetryPropertiesInKebabCase() {
+    // given
+    mockEnvironment.setProperty("camunda.database.schema-manager.retry.max-retries", "5");
+
+    // then
+    assertThat(elasticsearch.getRetry().getMaxRetries()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldPreferNewRetryValueOverLegacyRetryProperty() {
+    // given
+    elasticsearch.getRetry().setMaxRetries(7);
+    mockEnvironment.setProperty(NEW_RETRY_MAX_RETRIES_PROPERTY, "7");
+    mockEnvironment.setProperty(LEGACY_RETRY_MAX_RETRIES_PROPERTY, "5");
+
+    // then
+    assertThat(elasticsearch.getRetry().getMaxRetries()).isEqualTo(7);
+  }
+
+  @Test
+  void shouldFallBackToLegacyRetryPropertiesForOpensearch() {
+    // given
+    mockEnvironment.setProperty(LEGACY_RETRY_MAX_RETRIES_PROPERTY, "5");
+
+    // then
+    assertThat(opensearch.getRetry().getMaxRetries()).isEqualTo(5);
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SchemaManagerRetryTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SchemaManagerRetryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+final class SchemaManagerRetryTest {
+
+  private static final String LEGACY_MAX_RETRIES =
+      "camunda.database.schema-manager.retry.maxRetries";
+
+  private MockEnvironment mockEnvironment;
+
+  @BeforeEach
+  void setUp() {
+    mockEnvironment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnvironment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldDefaultToUnboundedRetryForEverySecondaryStorage() {
+    // given
+    final var elasticsearch = new Elasticsearch().getRetry();
+    final var rdbms = new Rdbms().getRetry();
+
+    // then
+    for (final var retry : new SchemaManagerRetry[] {elasticsearch, rdbms}) {
+      assertThat(retry.getMaxRetries()).isEqualTo(Integer.MAX_VALUE);
+      assertThat(retry.getMinRetryDelay()).isEqualTo(Duration.ofMillis(500));
+      assertThat(retry.getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldNotApplyTheSchemaManagerLegacyPropertyToRdbms() {
+    // given - the legacy prefix only ever configured the document-based schema manager
+    mockEnvironment.setProperty(LEGACY_MAX_RETRIES, "5");
+
+    // then
+    assertThat(new Rdbms().getRetry().getMaxRetries()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(new Elasticsearch().getRetry().getMaxRetries()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldUseConfiguredValuesForRdbms() {
+    // given
+    final var retry = new Rdbms().getRetry();
+    retry.setMaxRetries(7);
+    retry.setMinRetryDelay(Duration.ofSeconds(1));
+    retry.setMaxRetryDelay(Duration.ofSeconds(20));
+
+    // then
+    assertThat(retry.getMaxRetries()).isEqualTo(7);
+    assertThat(retry.getMinRetryDelay()).isEqualTo(Duration.ofSeconds(1));
+    assertThat(retry.getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(20));
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverrideTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverrideTest.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
+import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -122,5 +123,101 @@ class SearchEngineSchemaManagerPropertiesOverrideTest {
 
     // then
     assertThat(override.isVersionCheckRestrictionEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldApplyRetryForElasticsearch() {
+    // given
+    final Camunda camunda = new Camunda();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+    secondaryStorage.setType(SecondaryStorageType.elasticsearch);
+    secondaryStorage.getElasticsearch().getRetry().setMaxRetries(7);
+    secondaryStorage.getElasticsearch().getRetry().setMinRetryDelay(Duration.ofSeconds(1));
+    secondaryStorage.getElasticsearch().getRetry().setMaxRetryDelay(Duration.ofSeconds(20));
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.getRetry().getMaxRetries()).isEqualTo(7);
+    assertThat(override.getRetry().getMinRetryDelay()).isEqualTo(Duration.ofSeconds(1));
+    assertThat(override.getRetry().getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(20));
+  }
+
+  @Test
+  void shouldApplyRetryForOpensearch() {
+    // given
+    final Camunda camunda = new Camunda();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+    secondaryStorage.setType(SecondaryStorageType.opensearch);
+    secondaryStorage.getOpensearch().getRetry().setMaxRetries(7);
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.getRetry().getMaxRetries()).isEqualTo(7);
+  }
+
+  @Test
+  void shouldApplyUnboundedRetryByDefault() {
+    // given
+    final Camunda camunda = new Camunda();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+    secondaryStorage.setType(SecondaryStorageType.elasticsearch);
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.getRetry().getMaxRetries()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(override.getRetry().getMinRetryDelay()).isEqualTo(Duration.ofMillis(500));
+    assertThat(override.getRetry().getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(10));
+  }
+
+  /**
+   * The override shares its retry instance with the legacy bean after {@code
+   * BeanUtils.copyProperties}, so applying must replace it rather than mutate it in place.
+   */
+  @Test
+  void shouldReplaceRetryInstanceRatherThanMutateIt() {
+    // given
+    final Camunda camunda = new Camunda();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+    secondaryStorage.setType(SecondaryStorageType.elasticsearch);
+    secondaryStorage.getElasticsearch().getRetry().setMaxRetries(7);
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+    final var sharedRetry = override.getRetry();
+    sharedRetry.setMaxRetries(3);
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.getRetry()).isNotSameAs(sharedRetry);
+    assertThat(sharedRetry.getMaxRetries()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldNotTouchRetryForRdbms() {
+    // given
+    final Camunda camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+    final var untouchedRetry = override.getRetry();
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.getRetry()).isSameAs(untouchedRetry);
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -129,6 +129,7 @@ data.secondary-storage.elasticsearch.proxy.ssl-enabled
 data.secondary-storage.elasticsearch.proxy.username
 data.secondary-storage.elasticsearch.refresh-interval
 data.secondary-storage.elasticsearch.refresh-interval-by-index-name
+data.secondary-storage.elasticsearch.retry.database-name
 data.secondary-storage.elasticsearch.security.database-name
 data.secondary-storage.elasticsearch.socket-timeout
 data.secondary-storage.elasticsearch.template-priority
@@ -188,6 +189,7 @@ data.secondary-storage.opensearch.proxy.ssl-enabled
 data.secondary-storage.opensearch.proxy.username
 data.secondary-storage.opensearch.refresh-interval
 data.secondary-storage.opensearch.refresh-interval-by-index-name
+data.secondary-storage.opensearch.retry.database-name
 data.secondary-storage.opensearch.security.database-name
 data.secondary-storage.opensearch.socket-timeout
 data.secondary-storage.opensearch.template-priority
@@ -244,6 +246,7 @@ data.secondary-storage.rdbms.process-cache
 data.secondary-storage.rdbms.query.max-total-hits
 data.secondary-storage.rdbms.queue-memory-limit
 data.secondary-storage.rdbms.queue-size
+data.secondary-storage.rdbms.retry.database-name
 data.secondary-storage.rdbms.rewrite-batched-statements
 data.secondary-storage.rdbms.url
 data.secondary-storage.rdbms.urls

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.RdbmsSchemaMigrationStatusProvider;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -50,7 +51,24 @@ public class MyBatisConfiguration {
     return new RdbmsSchemaInitializer(
         RdbmsSchemaManagers.fromConfigs(
             physicalTenantSchemaConfigs(rdbmsDataSources, physicalTenantResolver),
-            VersionUtil.getVersion()));
+            VersionUtil.getVersion()),
+        physicalTenantId -> retryConfiguration(physicalTenantResolver, physicalTenantId));
+  }
+
+  private static RetryConfiguration retryConfiguration(
+      final PhysicalTenantResolver physicalTenantResolver, final String physicalTenantId) {
+    final var retry =
+        physicalTenantResolver
+            .forPhysicalTenant(physicalTenantId)
+            .getData()
+            .getSecondaryStorage()
+            .getRdbms()
+            .getRetry();
+    final var converted = new RetryConfiguration();
+    converted.setMaxRetries(retry.getMaxRetries());
+    converted.setMinRetryDelay(retry.getMinRetryDelay());
+    converted.setMaxRetryDelay(retry.getMaxRetryDelay());
+    return converted;
   }
 
   /**

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsSchemaInitializer.java
@@ -16,7 +16,6 @@ import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIndeterminateException;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
-import java.time.Duration;
 import java.util.Map;
 import java.util.function.Function;
 import org.jspecify.annotations.NullMarked;
@@ -62,36 +61,21 @@ import org.springframework.beans.factory.InitializingBean;
 public class RdbmsSchemaInitializer
     implements InitializingBean, DisposableBean, RdbmsSchemaManagerRegistry {
 
-  static final Duration MIN_RETRY_DELAY = Duration.ofMillis(500);
-  static final Duration MAX_RETRY_DELAY = Duration.ofSeconds(10);
-  static final int MAX_RETRIES = Integer.MAX_VALUE;
-
-  /**
-   * The backoff a degraded tenant retries on, deliberately not configurable: what a degraded node
-   * needs is to keep retrying, no deployment has asked to tune that, and a property surface is
-   * easier to add later than to withdraw. The values are Elasticsearch/OpenSearch's, so that a
-   * tenant degrades and recovers the same way whichever secondary storage it uses.
-   *
-   * <p>Unbounded is the load-bearing part. A finite budget would leave every tenant that was
-   * migrating during a transient database outage permanently degraded until an operator restarts
-   * the node, where a node with no serviceable tenant should stay held and retrying instead. It is
-   * also why {@code LiquibaseSchemaManager}'s own three attempts are not a give-up policy but a
-   * transient-deadlock retry inside a single attempt: nothing about this outer budget duplicates
-   * them.
-   */
-  @VisibleForTesting static final RetryConfiguration DEFAULT_RETRY = unboundedRetry();
-
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsSchemaInitializer.class);
 
   private final Map<String, RdbmsSchemaManager> schemaManagers;
   private final SchemaInitialization initialization;
 
-  public RdbmsSchemaInitializer(final Map<String, RdbmsSchemaManager> schemaManagersByTenant) {
-    this(schemaManagersByTenant, physicalTenantId -> DEFAULT_RETRY);
-  }
-
-  @VisibleForTesting
-  RdbmsSchemaInitializer(
+  /**
+   * @param retryConfig the backoff a degraded tenant retries on, per physical tenant. Unbounded is
+   *     the load-bearing default: a finite budget leaves every tenant that was migrating during a
+   *     transient database outage permanently degraded until an operator restarts the node, where a
+   *     node with no serviceable tenant should stay held and retrying instead. It is also why
+   *     {@code LiquibaseSchemaManager}'s own three attempts are not a give-up policy but a
+   *     transient-deadlock retry inside a single attempt: nothing about this outer budget
+   *     duplicates them.
+   */
+  public RdbmsSchemaInitializer(
       final Map<String, RdbmsSchemaManager> schemaManagersByTenant,
       final Function<String, RetryConfiguration> retryConfig) {
     schemaManagers = schemaManagersByTenant;
@@ -227,14 +211,6 @@ public class RdbmsSchemaInitializer
       LOG.debug("JVM is shutting down, cannot add the schema initializer shutdown hook", e);
       return false;
     }
-  }
-
-  private static RetryConfiguration unboundedRetry() {
-    final var retry = new RetryConfiguration();
-    retry.setMaxRetries(MAX_RETRIES);
-    retry.setMinRetryDelay(MIN_RETRY_DELAY);
-    retry.setMaxRetryDelay(MAX_RETRY_DELAY);
-    return retry;
   }
 
   /** Marks a failure that no amount of retrying can repair. */

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantSearchEngineConfigurations.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantSearchEngineConfigurations.java
@@ -20,6 +20,7 @@ import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Map;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,7 +43,8 @@ public class PhysicalTenantSearchEngineConfigurations {
     return physicalTenantResolver.mapValues(PhysicalTenantSearchEngineConfigurations::convert);
   }
 
-  private static SearchEngineConfiguration convert(final Camunda tenantCamunda) {
+  @VisibleForTesting
+  static SearchEngineConfiguration convert(final Camunda tenantCamunda) {
     final var index = new SearchEngineIndexProperties();
     SearchEngineIndexPropertiesOverride.applyTo(tenantCamunda, index);
     final var retention = new SearchEngineRetentionProperties();

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsSchemaInitializerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.application.commons.pt.EveryTenantTerminallyFailedException;
 import io.camunda.application.commons.rdbms.RdbmsSchemaInitializer.TerminalSchemaInitializationException;
+import io.camunda.configuration.Rdbms;
 import io.camunda.db.rdbms.NoopSchemaManager;
 import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
@@ -249,7 +250,7 @@ final class RdbmsSchemaInitializerTest {
   @Test
   void shouldRetryADegradedTenantWithoutABudgetThatRunsOut() {
     // given / when
-    final var retry = RdbmsSchemaInitializer.DEFAULT_RETRY;
+    final var retry = new Rdbms().getRetry();
 
     // then - a finite budget would leave every tenant that was migrating during a transient
     // database outage permanently degraded until an operator restarts the node

--- a/dist/src/test/java/io/camunda/application/commons/search/PhysicalTenantSearchEngineConfigurationsTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/PhysicalTenantSearchEngineConfigurationsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * The per-tenant path builds its schema-manager properties directly rather than through the {@code
+ * SearchEngineSchemaManagerProperties} bean, so it is the path that has to carry retry settings to
+ * {@link SearchEngineSchemaInitializer}.
+ */
+final class PhysicalTenantSearchEngineConfigurationsTest {
+
+  @BeforeAll
+  static void setUpEnvironment() {
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterAll
+  static void tearDownEnvironment() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldCarryRetryConfigurationToTheTenantConfiguration() {
+    // given
+    final var camunda = new Camunda();
+    final var secondaryStorage = camunda.getData().getSecondaryStorage();
+    secondaryStorage.setType(SecondaryStorageType.elasticsearch);
+    secondaryStorage.getElasticsearch().getRetry().setMaxRetries(7);
+    secondaryStorage.getElasticsearch().getRetry().setMinRetryDelay(Duration.ofSeconds(1));
+    secondaryStorage.getElasticsearch().getRetry().setMaxRetryDelay(Duration.ofSeconds(20));
+
+    // when
+    final var configuration = PhysicalTenantSearchEngineConfigurations.convert(camunda);
+
+    // then
+    final var retry = configuration.schemaManager().getRetry();
+    assertThat(retry.getMaxRetries()).isEqualTo(7);
+    assertThat(retry.getMinRetryDelay()).isEqualTo(Duration.ofSeconds(1));
+    assertThat(retry.getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(20));
+  }
+
+  @Test
+  void shouldDefaultToUnboundedRetry() {
+    // given
+    final var camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+
+    // when
+    final var configuration = PhysicalTenantSearchEngineConfigurations.convert(camunda);
+
+    // then
+    final var retry = configuration.schemaManager().getRetry();
+    assertThat(retry.getMaxRetries()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(retry.getMinRetryDelay()).isEqualTo(Duration.ofMillis(500));
+    assertThat(retry.getMaxRetryDelay()).isEqualTo(Duration.ofSeconds(10));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaInitializerH2IT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaInitializerH2IT.java
@@ -15,12 +15,14 @@ import io.camunda.application.commons.rdbms.RdbmsDataSources;
 import io.camunda.application.commons.rdbms.RdbmsSchemaInitializer;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Rdbms;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.db.rdbms.PerTenantSchemaConfig;
 import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.RdbmsSchemaManagers;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.sql.Connection;
 import java.util.LinkedHashMap;
@@ -142,7 +144,12 @@ class RdbmsSchemaInitializerH2IT {
   // ---- helpers ----
 
   private static RdbmsSchemaInitializer initializerFor(final RdbmsDataSources tenants) {
-    return new RdbmsSchemaInitializer(schemaManagersFor(tenants));
+    final var retry = new Rdbms().getRetry();
+    final var converted = new RetryConfiguration();
+    converted.setMaxRetries(retry.getMaxRetries());
+    converted.setMinRetryDelay(retry.getMinRetryDelay());
+    converted.setMaxRetryDelay(retry.getMaxRetryDelay());
+    return new RdbmsSchemaInitializer(schemaManagersFor(tenants), physicalTenantId -> converted);
   }
 
   private static Map<String, RdbmsSchemaManager> schemaManagersFor(final RdbmsDataSources tenants) {


### PR DESCRIPTION
Schema-manager retry was not configurable for any secondary storage. Exposes it as
`camunda.data.secondary-storage.{elasticsearch,opensearch,rdbms}.retry.*`, in two commits.

Because unbounded retry was a *subclass default* rather than a bound value, the ES/OS gap was
invisible at runtime — only an attempt to *bound* the retries revealed the setting was ignored.

### Elasticsearch / OpenSearch

Both routes to the setting were closed:

- Unified config had no property: `DocumentBasedSecondaryStorageDatabase` declared no `retry` member.
- The legacy prefix bound but never arrived: retry was the one schema-manager property carried by
  `BeanUtils.copyProperties` in the `@Bean` factory rather than re-derived in `applyTo`, and the
  runtime path (`PhysicalTenantSearchEngineConfigurations.convert()`) calls the static `applyTo`
  directly.

Adding the property and mapping it in `applyTo` closes both, since `convert()` calls that same
method. Legacy keys resolve from the Spring `Environment` rather than the legacy bean, so
`camunda.database.schema-manager.retry.*` now works on the per-tenant path too. Compatibility is
`BackwardsCompatibilityMode.SUPPORTED`, matching `healthCheckEnabled` in the same method: unified
wins over legacy with a warning, legacy alone still applies.

### RDBMS

`RdbmsSchemaInitializer` built its `RetryConfiguration` from local constants; it now resolves per
tenant from unified config, through the second constructor it already accepted but that only tests
passed. `DEFAULT_RETRY`, `unboundedRetry()` and the constants are gone. No legacy property exists
here — `camunda.database.schema-manager.*` only ever configured the document-based schema manager,
and #60745 introduced the RDBMS defaults with no legacy surface.

The removed javadoc called this backoff "deliberately not configurable", arguing a finite budget
leaves a tenant that was migrating during a transient outage permanently degraded until an operator
restarts the node. The issue asks for it to be configurable, so that reasoning now lives on the
constructor parameter rather than blocking the property.

### Defaults unchanged

Unbounded retries, 500 ms min delay, 10 s max delay, for both storages. `SchemaManagerRetry` sources
them from `SchemaManagerRetryConfiguration` so the two cannot drift; `SchemaManagerRetryTest` pins
the parity. `retryDelayMultiplier` is deliberately not exposed.

## Related issues

closes #60888

🤖 Generated with [Claude Code](https://claude.com/claude-code)