### PR TITLE
test: exclude randomized suites from default Maven runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -967,7 +967,7 @@ jobs:
           -D forkCount=7
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -D junitThreadCount=16
-          -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ env.GENERAL_UT_MODULES }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
@@ -1073,7 +1073,7 @@ jobs:
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -D junitThreadCount=16
           -D argLine="@{argLine} -Xmx4g"
-          -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -967,7 +967,7 @@ jobs:
           -D forkCount=7
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -D junitThreadCount=16
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild
+          -P include-slow-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ env.GENERAL_UT_MODULES }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
@@ -1073,7 +1073,7 @@ jobs:
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -D junitThreadCount=16
           -D argLine="@{argLine} -Xmx4g"
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild
+          -P include-slow-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2521,6 +2521,7 @@
             <!-- by default, exclude tests with dedicated CI jobs -->
             <excludedGroups>performance, randomized, slow, strace, io.camunda.zeebe.engine.processing.randomized.RandomizedTestCategory, io.camunda.zeebe.test.util.junit.SlowTest, ${failsafe.excluded.nightly}</excludedGroups>
             <failIfNoTests>false</failIfNoTests>
+            <failIfNoSpecifiedTests>true</failIfNoSpecifiedTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <systemPropertyVariables>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2519,7 +2519,7 @@
           <configuration>
             <argLine>${jvm.module.opens}</argLine>
             <!-- by default, exclude tests with dedicated CI jobs -->
-            <excludedGroups>performance, randomized, strace, io.camunda.zeebe.engine.processing.randomized.RandomizedTestCategory, ${failsafe.excluded.nightly}</excludedGroups>
+            <excludedGroups>performance, randomized, slow, strace, io.camunda.zeebe.engine.processing.randomized.RandomizedTestCategory, io.camunda.zeebe.test.util.junit.SlowTest, ${failsafe.excluded.nightly}</excludedGroups>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -3123,6 +3123,22 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <!-- Include deterministic slow tests in CI while excluding them from local runs by default. -->
+      <id>include-slow-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludedGroups>performance, randomized, strace, io.camunda.zeebe.engine.processing.randomized.RandomizedTestCategory, ${failsafe.excluded.nightly}</excludedGroups>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2518,8 +2518,8 @@
           <version>${plugin.version.surefire}</version>
           <configuration>
             <argLine>${jvm.module.opens}</argLine>
-            <!-- by default, exclude performance and strace tests -->
-            <excludedGroups>performance, strace, ${failsafe.excluded.nightly}</excludedGroups>
+            <!-- by default, exclude tests with dedicated CI jobs -->
+            <excludedGroups>performance, randomized, strace, io.camunda.zeebe.engine.processing.randomized.RandomizedTestCategory, ${failsafe.excluded.nightly}</excludedGroups>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -3092,27 +3092,7 @@
     </profile>
 
     <profile>
-      <id>skip-random-tests</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>**/*RandomizedPropertyTest.java</exclude>
-                <exclude>**/*RandomizedRaftTest.java</exclude>
-                <!-- Re-add the default exclude for inner classes, see https://github.com/camunda/camunda/issues/8637 -->
-                <exclude>**/*$*.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <!-- Dedicated profile to run ONLY random tests. The include config overwrites the default pattern-->
+      <!-- Dedicated profile to run only randomized tests. -->
       <id>include-random-tests</id>
       <build>
         <plugins>
@@ -3120,16 +3100,29 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <includes>
-                <include>**/*RandomizedPropertyTest.java</include>
-                <include>**/*RandomizedRaftTest.java</include>
-              </includes>
+              <groups>randomized</groups>
+              <excludedGroups combine.self="override"/>
+              <excludes combine.self="override"/>
               <systemPropertyVariables>
                 <processCount>10</processCount>
                 <executionCount>100</executionCount>
                 <replayExecutionCount>5</replayExecutionCount>
               </systemPropertyVariables>
             </configuration>
+            <executions>
+              <execution>
+                <id>legacy-randomized-tests</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <phase>test</phase>
+                <configuration>
+                  <groups combine.self="override">io.camunda.zeebe.engine.processing.randomized.RandomizedTestCategory</groups>
+                  <excludes combine.self="override"/>
+                  <excludedGroups combine.self="override"/>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftAppendTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftAppendTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -23,6 +22,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftAppendTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftAppendTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -27,12 +28,14 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
+@Category(SlowTest.class)
 public class RaftAppendTest {
 
   @Rule @Parameter public RaftRule raftRule;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -29,6 +28,7 @@ import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.roles.LeaderRole;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.concurrent.ArrayBlockingQueue;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCoordinatedLeadershipTransferTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -38,7 +39,9 @@ import java.util.concurrent.TimeoutException;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class RaftCoordinatedLeadershipTransferTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -7,11 +7,11 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.*;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -7,6 +7,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.*;
 
 import io.atomix.cluster.MemberId;
@@ -17,10 +18,12 @@ import java.util.concurrent.CompletableFuture;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.DisplayName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(SlowTest.class)
 public class RaftCorruptedDataTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(RaftCorruptedDataTest.class);
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -25,8 +26,10 @@ import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /** Coverage for the catch-up step of a coordinated leadership transfer. */
+@Category(SlowTest.class)
 public class RaftLeadershipTransferCatchUpTest {
 
   private static final Duration REPLICATION_TIMEOUT = Duration.ofSeconds(2);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -23,6 +22,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferConfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferConfigurationTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -25,6 +24,7 @@ import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferConfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferConfigurationTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -34,12 +35,14 @@ import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /** Coverage for the leader-side rebalance settings (and overrides). */
 @RunWith(Parameterized.class)
+@Category(SlowTest.class)
 public class RaftLeadershipTransferConfigurationTest {
 
   private static final Duration HEARTBEAT_INTERVAL = Duration.ofMillis(100);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -35,7 +36,9 @@ import java.util.function.Supplier;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class RaftLeadershipTransferInitiateTest {
   /**
    * For tests we don't install a real coordinator check, so any member ID and config version will

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferInitiateTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -27,6 +26,7 @@ import io.atomix.raft.protocol.TimeoutNowRequest;
 import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.roles.LeaderRole;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPauseTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPauseTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -24,6 +23,7 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.roles.LeaderRole;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPauseTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPauseTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -31,12 +32,14 @@ import java.util.function.Supplier;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Coverage for the paused-mode watchdog on the Raft thread (Coordinated Leadership Transfer). The
  * watchdog guarantees a partition is never left paused and unavailable: if it is not resumed in
  * time, the leader steps down so services restart and a new leader can be elected.
  */
+@Category(SlowTest.class)
 public class RaftLeadershipTransferPauseTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
@@ -15,11 +15,11 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftRule.Configurator;
 import io.atomix.raft.RaftServer.Builder;
 import io.atomix.raft.partition.RaftElectionConfig;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
@@ -15,18 +15,21 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftRule.Configurator;
 import io.atomix.raft.RaftServer.Builder;
 import io.atomix.raft.partition.RaftElectionConfig;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
+@Category(SlowTest.class)
 public class RaftPriorityElectionTest {
 
   @Rule @Parameter public RaftRule raftRule;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationLagTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationLagTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -23,6 +22,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationLagTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationLagTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -33,7 +34,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class RaftReplicationLagTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationTest.java
@@ -15,10 +15,10 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.junit.Rule;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.RaftServer.Role;
@@ -22,12 +23,14 @@ import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
+@Category(SlowTest.class)
 public class RaftReplicationTest {
   @Rule @Parameter public RaftRule raftRule;
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftServerDisconnectTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftServerDisconnectTest.java
@@ -7,6 +7,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -18,8 +19,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runners.Parameterized.Parameter;
 
+@Category(SlowTest.class)
 public class RaftServerDisconnectTest {
 
   @Rule @Parameter public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftServerDisconnectTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftServerDisconnectTest.java
@@ -7,11 +7,11 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.RaftError.Type;
@@ -32,7 +33,9 @@ import java.util.function.Function;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class RaftSnapshotReplicationFailureHandlingTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.RaftError.Type;
@@ -23,6 +22,7 @@ import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.protocol.TestRaftServerProtocol.ResponseInterceptor;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftStartupConsistencyCheckTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftStartupConsistencyCheckTest.java
@@ -7,6 +7,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -23,7 +24,9 @@ import org.agrona.LangUtil;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class RaftStartupConsistencyCheckTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftStartupConsistencyCheckTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftStartupConsistencyCheckTest.java
@@ -7,7 +7,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -17,6 +16,7 @@ import io.atomix.raft.RaftServer.Builder;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.snapshot.TestSnapshotStore;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -16,7 +16,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.hamcrest.Matchers.greaterThan;
@@ -45,6 +44,7 @@ import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.journal.CorruptedJournalException;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -16,6 +16,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.hamcrest.Matchers.greaterThan;
@@ -77,12 +78,14 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Raft test. */
+@Category(SlowTest.class)
 public class RaftTest extends ConcurrentTestCase {
   private static final Logger LOGGER = LoggerFactory.getLogger(RaftTest.class);
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -28,6 +27,7 @@ import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.protocol.TimeoutNowRequest;
 import io.atomix.raft.protocol.TimeoutNowResponse;
 import io.atomix.raft.protocol.VoteRequest;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -35,7 +36,9 @@ import java.util.function.Function;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class RaftTimeoutNowTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedForceConfigureTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedForceConfigureTest.java
@@ -38,11 +38,13 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
 import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.Tag;
 import net.jqwik.api.lifecycle.AfterTry;
 import net.jqwik.api.lifecycle.BeforeProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Tag("randomized")
 public final class RandomizedForceConfigureTest {
 
   private static final int OPERATION_SIZE = 2000;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
@@ -29,12 +29,14 @@ import net.jqwik.api.Property;
 import net.jqwik.api.PropertyDefaults;
 import net.jqwik.api.Provide;
 import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.Tag;
 import net.jqwik.api.lifecycle.AfterTry;
 import net.jqwik.api.lifecycle.BeforeProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+@Tag("randomized")
 public class RandomizedRaftJoinTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RandomizedRaftJoinTest.class);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftScaleDownTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftScaleDownTest.java
@@ -29,6 +29,7 @@ import net.jqwik.api.Property;
 import net.jqwik.api.PropertyDefaults;
 import net.jqwik.api.Provide;
 import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.Tag;
 import net.jqwik.api.lifecycle.AfterTry;
 import net.jqwik.api.lifecycle.BeforeProperty;
 import org.slf4j.Logger;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
  * RandomizedRaftJoinTest}, but with three bootstrapped ACTIVE members.
  */
 @PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+@Tag("randomized")
 public class RandomizedRaftScaleDownTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RandomizedRaftScaleDownTest.class);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -35,6 +35,7 @@ import net.jqwik.api.Property;
 import net.jqwik.api.PropertyDefaults;
 import net.jqwik.api.Provide;
 import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.Tag;
 import net.jqwik.api.lifecycle.AfterTry;
 import net.jqwik.api.lifecycle.BeforeProperty;
 import org.slf4j.Logger;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 @PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+@Tag("randomized")
 public class RandomizedRaftTest {
 
   private static final int OPERATION_SIZE = 10000;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -7,7 +7,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.ClusterMembershipService;
@@ -30,6 +29,7 @@ import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.utils.concurrent.SingleThreadContext;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -7,6 +7,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.ClusterMembershipService;
@@ -63,6 +64,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+@SlowTest
 final class ReconfigurationTest {
   private final SingleThreadContext context = new SingleThreadContext("raft-%d");
   private final TestRaftProtocolFactory protocolFactory = new TestRaftProtocolFactory();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
@@ -25,7 +26,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class SnapshotReplicationListenerTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
@@ -15,13 +15,13 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Rule;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/VotingTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/VotingTest.java
@@ -7,6 +7,7 @@
  */
 package io.atomix.raft;
 
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.ClusterMembershipService;
@@ -57,6 +58,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+@SlowTest
 final class VotingTest {
   private final SingleThreadContext context = new SingleThreadContext("raft-%d");
   private final TestRaftProtocolFactory protocolFactory = new TestRaftProtocolFactory();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/VotingTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/VotingTest.java
@@ -7,7 +7,6 @@
  */
 package io.atomix.raft;
 
-import io.camunda.zeebe.test.util.junit.SlowTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.ClusterMembershipService;
@@ -30,6 +29,7 @@ import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.utils.concurrent.SingleThreadContext;
+import io.camunda.zeebe.test.util.junit.SlowTest;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.ByteBuffer;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -43,11 +43,13 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.GenerationMode;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import net.jqwik.api.Tag;
 import net.jqwik.api.lifecycle.AfterTry;
 import net.jqwik.api.lifecycle.BeforeTry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Tag("randomized")
 public class RandomizedPartitionTransitionTest {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(RandomizedPartitionTransitionTest.class);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -16,9 +16,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Tag;
 import net.jqwik.api.domains.Domain;
 import net.jqwik.api.domains.DomainContext;
 
+@Tag("randomized")
 final class PersistedClusterConfigurationRandomizedPropertyTest {
 
   @Property(tries = 100)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.Collection;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -28,6 +29,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
+@Category(RandomizedTestCategory.class)
 public class ProcessExecutionRandomizedPropertyTest {
 
   /*

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/RandomizedTestCategory.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/RandomizedTestCategory.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.randomized;
+
+/** JUnit 4 category for randomized tests run by the dedicated property-test job. */
+public interface RandomizedTestCategory {}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
@@ -26,6 +26,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -33,6 +34,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
+@Category(RandomizedTestCategory.class)
 public class ReplayStateRandomizedPropertyTest {
 
   private static final String PROCESS_COUNT = System.getProperty("processCount", "3");

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/SlowTest.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/SlowTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+/** Marks deterministic tests that are too slow for the default local Maven test cycle. */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Tag("slow")
+public @interface SlowTest {}

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
@@ -21,12 +21,14 @@ import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import net.jqwik.api.Tag;
 import net.jqwik.api.arbitraries.ListArbitrary;
 import net.jqwik.api.lifecycle.AfterProperty;
 import net.jqwik.api.lifecycle.AfterTry;
 import net.jqwik.api.lifecycle.BeforeProperty;
 import org.assertj.core.util.Files;
 
+@Tag("randomized")
 public class ColumnFamilyRandomizedPropertyTest {
 
   private Map<Long, Long> map;


### PR DESCRIPTION
## Description

Plain Maven test runs currently execute heavyweight randomized suites and deterministic multi-node Raft simulations. The Atomix cluster module took roughly nine minutes locally, dominated by one randomized class and a set of timing-heavy simulations.

### Randomized tests

Classify jqwik suites with `@Tag("randomized")` and exclude that tag in the default Surefire configuration. Keep the dedicated `include-random-tests` profile used by `Zeebe / Unit - Property Tests`, but select jqwik tests by tag rather than filename.

Two legacy randomized engine tests still use JUnit 4. They receive a matching JUnit 4 category and a second profile execution, so the dedicated CI job retains their coverage without running them during normal local Maven builds.

### Slow deterministic simulations

Add a cross-engine `SlowTest` marker for deterministic tests that are too expensive for the default local cycle. JUnit 5 classes use it as a meta-annotation; JUnit 4 classes use it as a category.

The measured multi-node/timing-heavy Atomix tests are excluded from plain Maven runs. Standard `General / Unit` and `Zeebe / Unit` CI jobs explicitly activate `include-slow-tests`, so CI coverage is unchanged.

Fast storage, serialization, protocol, utility, and single-node Raft tests remain in the default local suite.

## Usage

```bash
# Fast local cycle
./mvnw test

# Randomized/property suites
./mvnw test -Pinclude-random-tests

# Deterministic slow simulations
./mvnw test -Pinclude-slow-tests

# Full local coverage
./mvnw test -Pinclude-random-tests,include-slow-tests
```

## Measured impact

For `zeebe/atomix/cluster` on the same machine:

- Before categorization: about 9 minutes, plus roughly 9.5 minutes for `RandomizedRaftTest` when included.
- Unsafe four-fork experiment: 2:53, but produced timing failures and Surefire report collisions.
- Default sequential run after categorization: 2:14.

The remaining run still hit two pre-existing `DynamicDiscoveryProviderTest` local DNS/Awaitility timeouts. Those are unrelated to the category changes; all randomized and tagged slow tests were absent from the default run.

## Verification

- Default `RandomizedRaftJoinTest`: 0 tests.
- `-Pinclude-random-tests` `RandomizedRaftJoinTest`: 2 tests passed, exactly once.
- Default legacy `ProcessExecutionRandomizedPropertyTest`: 0 tests.
- `-Pinclude-random-tests` legacy test: passed.
- Default JUnit 4 slow `RaftServerDisconnectTest`: 0 tests.
- `-Pinclude-slow-tests` JUnit 4 slow test: 3 tests passed.
- Default JUnit 5 slow `VotingTest`: 0 tests.
- `-Pinclude-slow-tests` JUnit 5 slow test: 8 tests passed.

## Related issues

- [x] This PR does not need a linked issue