### PR TITLE
feat: reject requests to partitions in recovery mode with a clear error

### DIFF
--- a/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
+++ b/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
@@ -24,6 +24,7 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
+import io.camunda.zeebe.broker.client.api.PartitionInRecoveryException;
 import io.camunda.zeebe.broker.client.api.PartitionInactiveException;
 import io.camunda.zeebe.broker.client.api.PartitionNotFoundException;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
@@ -206,6 +207,10 @@ public class ErrorMapper {
             "Expected to handle request, but the target partition is currently inactive";
         LOGGER.trace(message, rootError);
         yield new ServiceError(message, UNAVAILABLE);
+      }
+      case final PartitionInRecoveryException e -> {
+        LOGGER.trace(e.getMessage(), rootError);
+        yield new ServiceError(e.getMessage(), UNAVAILABLE);
       }
       case final NoTopologyAvailableException ignored -> {
         final var message =

--- a/service/src/test/java/io/camunda/service/exception/ErrorMapperTest.java
+++ b/service/src/test/java/io/camunda/service/exception/ErrorMapperTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.broker.client.api.PartitionInRecoveryException;
+import org.junit.jupiter.api.Test;
+
+final class ErrorMapperTest {
+
+  @Test
+  void shouldMapPartitionInRecoveryExceptionToUnavailable() {
+    // given
+    final var error = new PartitionInRecoveryException(1);
+
+    // when
+    final ServiceException exception = ErrorMapper.mapError(error);
+
+    // then -- the client gets a retryable status with the recovery explanation, not INTERNAL
+    assertThat(exception.getStatus()).isEqualTo(Status.UNAVAILABLE);
+    assertThat(exception.getMessage()).contains("recovery mode");
+  }
+}

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientMetricsDoc.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientMetricsDoc.java
@@ -144,6 +144,11 @@ public enum BrokerClientMetricsDoc implements ExtendedMeterDocumentation {
     TIMEOUT,
     /** The requested partition was inactive, meaning it could not process requests at the time */
     PARTITION_INACTIVE,
+    /**
+     * The requested partition was in recovery mode, during which only backup and recovery related
+     * requests are served.
+     */
+    PARTITION_IN_RECOVERY,
     UNKNOWN
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/PartitionInRecoveryException.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/PartitionInRecoveryException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.client.api;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Represents an exceptional error that occurs when a request is sent to a partition that is in
+ * recovery mode. While a partition is recovering, only backup and recovery related requests are
+ * served; every other request is rejected with this exception.
+ */
+@NullMarked
+public class PartitionInRecoveryException extends BrokerClientException {
+  private static final String DEFAULT_ERROR_MESSAGE = "Partition %d is currently in recovery mode.";
+  private final int partitionId;
+
+  public PartitionInRecoveryException(final int partitionId) {
+    super(String.format(DEFAULT_ERROR_MESSAGE, partitionId));
+    this.partitionId = partitionId;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+}

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerResponseException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
+import io.camunda.zeebe.broker.client.api.PartitionInRecoveryException;
 import io.camunda.zeebe.broker.client.api.PartitionInactiveException;
 import io.camunda.zeebe.broker.client.api.PartitionNotFoundException;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
@@ -147,6 +148,11 @@ final class BrokerRequestManager extends Actor {
       metrics.registerFailedRequest(
           request.getPartitionId(), request.getType(), AdditionalErrorCodes.PARTITION_INACTIVE);
       return;
+    } catch (final PartitionInRecoveryException e) {
+      returnFuture.completeExceptionally(e);
+      metrics.registerFailedRequest(
+          request.getPartitionId(), request.getType(), AdditionalErrorCodes.PARTITION_IN_RECOVERY);
+      return;
     }
 
     final ActorFuture<DirectBuffer> responseFuture =
@@ -238,7 +244,8 @@ final class BrokerRequestManager extends Actor {
       if (topology != null && !topology.getPartitions().contains(request.getPartitionId())) {
         throw new PartitionNotFoundException(request.getPartitionId());
       }
-      throwIfPartitionInactive(partitionGroup, request.getPartitionId());
+      throwIfPartitionInactive(
+          partitionGroup, request.getPartitionId(), request.shouldRouteToRecovery());
       if (request.shouldRouteToRecovery()) {
         return BrokerAddressProvider.leaderOrAnyRecovery(
             topologyManager, new PartitionId(partitionGroup, request.getPartitionId()));
@@ -258,7 +265,7 @@ final class BrokerRequestManager extends Actor {
       }
       request.setPartitionId(partitionId);
 
-      throwIfPartitionInactive(partitionGroup, partitionId);
+      throwIfPartitionInactive(partitionGroup, partitionId, request.shouldRouteToRecovery());
 
       return BrokerAddressProvider.leader(
           topologyManager, partitionGroup, request.getPartitionId());
@@ -275,7 +282,8 @@ final class BrokerRequestManager extends Actor {
             .formatted(request.getType()));
   }
 
-  private void throwIfPartitionInactive(final String partitionGroup, final int partitionId) {
+  private void throwIfPartitionInactive(
+      final String partitionGroup, final int partitionId, final boolean recoveryRoutable) {
     final BrokerClusterState topology = topologyManager.getTopology(partitionGroup);
     if (topology == null) {
       throw new NoTopologyAvailableException();
@@ -285,9 +293,10 @@ final class BrokerRequestManager extends Actor {
     final var someNodesInactive = !inactiveNodes.isEmpty();
     final var leaderNode = topology.getLeaderForPartition(partitionId);
 
-    // If nodes are in recovery, do not throw so that requests can be routed to the
-    // recovering partitions. Whether a request is actually routed there is decided separately,
-    // based on BrokerRequest#shouldRouteToRecovery, when picking the BrokerAddressProvider.
+    if (!someNodesInactive || leaderNode != null) {
+      return;
+    }
+
     final var clusterConfiguration = topologyManager.getClusterConfiguration();
     final var nodeInRecovery =
         inactiveNodes.stream()
@@ -302,8 +311,13 @@ final class BrokerRequestManager extends Actor {
                   return member != null && member.mode() == Mode.RECOVERING;
                 });
 
-    if (someNodesInactive && leaderNode == null && !nodeInRecovery) {
+    if (!nodeInRecovery) {
       throw new PartitionInactiveException(partitionId);
+    }
+
+    // Only recovery-routable requests can be served by a recovering partition
+    if (!recoveryRoutable) {
+      throw new PartitionInRecoveryException(partitionId);
     }
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.AdditionalErrorCodes;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.transport.ClientRequest;
 import io.camunda.zeebe.transport.ClientTransport;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -244,7 +246,7 @@ final class BrokerRequestManager extends Actor {
       if (topology != null && !topology.getPartitions().contains(request.getPartitionId())) {
         throw new PartitionNotFoundException(request.getPartitionId());
       }
-      throwIfPartitionInactive(
+      throwIfPartitionUnavailable(
           partitionGroup, request.getPartitionId(), request.shouldRouteToRecovery());
       if (request.shouldRouteToRecovery()) {
         return BrokerAddressProvider.leaderOrAnyRecovery(
@@ -265,7 +267,7 @@ final class BrokerRequestManager extends Actor {
       }
       request.setPartitionId(partitionId);
 
-      throwIfPartitionInactive(partitionGroup, partitionId, request.shouldRouteToRecovery());
+      throwIfPartitionUnavailable(partitionGroup, partitionId, request.shouldRouteToRecovery());
 
       return BrokerAddressProvider.leader(
           topologyManager, partitionGroup, request.getPartitionId());
@@ -282,7 +284,7 @@ final class BrokerRequestManager extends Actor {
             .formatted(request.getType()));
   }
 
-  private void throwIfPartitionInactive(
+  private void throwIfPartitionUnavailable(
       final String partitionGroup, final int partitionId, final boolean recoveryRoutable) {
     final BrokerClusterState topology = topologyManager.getTopology(partitionGroup);
     if (topology == null) {
@@ -290,28 +292,12 @@ final class BrokerRequestManager extends Actor {
     }
 
     final var inactiveNodes = topology.getInactiveNodesForPartition(partitionId);
-    final var someNodesInactive = !inactiveNodes.isEmpty();
-    final var leaderNode = topology.getLeaderForPartition(partitionId);
-
-    if (!someNodesInactive || leaderNode != null) {
+    final var hasLeader = topology.getLeaderForPartition(partitionId) != null;
+    if (hasLeader || inactiveNodes.isEmpty()) {
       return;
     }
 
-    final var clusterConfiguration = topologyManager.getClusterConfiguration();
-    final var nodeInRecovery =
-        inactiveNodes.stream()
-            .anyMatch(
-                node -> {
-                  final var partitionGroupConfiguration =
-                      clusterConfiguration.partitionGroup(partitionGroup);
-                  if (partitionGroupConfiguration == null) {
-                    return false;
-                  }
-                  final var member = partitionGroupConfiguration.members().get(node.memberId());
-                  return member != null && member.mode() == Mode.RECOVERING;
-                });
-
-    if (!nodeInRecovery) {
+    if (!anyNodeRecovering(partitionGroup, inactiveNodes)) {
       throw new PartitionInactiveException(partitionId);
     }
 
@@ -319,6 +305,18 @@ final class BrokerRequestManager extends Actor {
     if (!recoveryRoutable) {
       throw new PartitionInRecoveryException(partitionId);
     }
+  }
+
+  private boolean anyNodeRecovering(final String partitionGroup, final Set<BrokerMemberId> nodes) {
+    final var partitionGroupConfiguration =
+        topologyManager.getClusterConfiguration().partitionGroup(partitionGroup);
+    if (partitionGroupConfiguration == null) {
+      return false;
+    }
+
+    return nodes.stream()
+        .map(node -> partitionGroupConfiguration.members().get(node.memberId()))
+        .anyMatch(member -> member != null && member.mode() == Mode.RECOVERING);
   }
 
   private static class RequestResult {

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -497,6 +498,63 @@ public final class BrokerClientTest {
     assertThatCode(() -> client.sendRequest(request).join())
         .isInstanceOf(CompletionException.class)
         .hasMessageContaining("The partition " + partitionId + " is currently INACTIVE");
+  }
+
+  @Test
+  public void shouldRejectRequestWhenPartitionIsInRecoveryMode() {
+    // given -- the only replica of partition 1 is inactive and flagged as RECOVERING in the
+    // cluster configuration
+    final var partitionId = 1;
+    final var request = new TestCommand(1, (topologyManager, partitionGroup) -> partitionId);
+    makeBrokerRecoverForPartition(partitionId);
+
+    // then -- a request that is not recovery-routable fails fast with a dedicated error instead
+    // of timing out against a leaderless partition
+    assertThatCode(() -> client.sendRequest(request).join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(PartitionInRecoveryException.class)
+        .hasMessageContaining("recovery mode");
+  }
+
+  @Test
+  public void shouldRouteRecoveryRoutableRequestToRecoveringNode() {
+    // given
+    final var partitionId = 1;
+    final var request =
+        new TestCommand(1L) {
+          @Override
+          public boolean shouldRouteToRecovery() {
+            return true;
+          }
+        };
+    request.setPartitionId(partitionId);
+    registerSuccessResponse(broker);
+    makeBrokerRecoverForPartition(partitionId);
+
+    // when
+    final var response = client.sendRequest(request).join();
+
+    // then
+    assertThat(response.isResponse()).isTrue();
+  }
+
+  private void makeBrokerRecoverForPartition(final int partitionId) {
+    topologyManager.onClusterConfigurationUpdated(
+        topologyManager
+            .getClusterConfiguration()
+            .updatePartitionGroupConfig(
+                CurrentClusterConfiguration.DEFAULT_GROUP,
+                group ->
+                    group.updateMember(
+                        broker.member().id(), member -> member.setMode(Mode.RECOVERING))));
+
+    broker.updateInfo(info -> info.setInactiveForPartition(partitionId));
+    topologyManager.event(new ClusterMembershipEvent(Type.METADATA_CHANGED, broker.member()));
+    Awaitility.await("Partition is inactive.")
+        .untilAsserted(
+            () ->
+                assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partitionId))
+                    .isNotEmpty());
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -16,6 +16,7 @@ import io.atomix.cluster.messaging.MessagingException;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
+import io.camunda.zeebe.broker.client.api.PartitionInRecoveryException;
 import io.camunda.zeebe.broker.client.api.PartitionInactiveException;
 import io.camunda.zeebe.broker.client.api.PartitionNotFoundException;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
@@ -130,6 +131,12 @@ public final class GrpcErrorMapper {
         builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
         logger.trace(
             "Expected to handle gRPC request, but the target partition is currently inactive",
+            rootError);
+      }
+      case final PartitionInRecoveryException ignored -> {
+        builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
+        logger.trace(
+            "Expected to handle gRPC request, but the target partition is in recovery mode",
             rootError);
       }
       case final NoTopologyAvailableException ignored -> {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -93,6 +93,9 @@ final class GrpcErrorMapperTest {
     // then
     assertThat(statusException.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(statusException.getStatus().getDescription()).contains("recovery mode");
+    assertThat(recorder.getAppendedEvents()).hasSize(1);
+    final LogEvent event = recorder.getAppendedEvents().getFirst();
+    assertThat(event.getLevel()).isEqualTo(Level.TRACE);
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -16,6 +16,7 @@ import com.google.rpc.Status;
 import io.atomix.cluster.messaging.MessagingException.ConnectionClosed;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.PartitionInRecoveryException;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -78,6 +79,20 @@ final class GrpcErrorMapperTest {
     assertThat(recorder.getAppendedEvents()).hasSize(1);
     final LogEvent event = recorder.getAppendedEvents().get(0);
     assertThat(event.getLevel()).isEqualTo(Level.TRACE);
+  }
+
+  @Test
+  void shouldReturnUnavailableOnPartitionInRecovery() {
+    // given
+    final var exception = new PartitionInRecoveryException(1);
+
+    // when
+    log.setLevel(Level.TRACE);
+    final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(statusException.getStatus().getDescription()).contains("recovery mode");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

While a partition is in recovery mode its replicas advertise
themselves as INACTIVE and no leader can be elected, so any client
request that is not recovery-routable (backup status, list, ranges)
never resolves a target broker address and only fails with a generic
timeout or connection error once the request timeout expires. Users
had no way to tell that the partition was deliberately recovering.

Fail such requests fast in the gateway instead. BrokerRequestManager
already consults the gossiped cluster configuration to detect
recovering partitions so that recovery-routable requests can pass
through; extend that check to throw a dedicated
PartitionInRecoveryException for every other request, in both the
fixed-partition and the round-robin dispatch paths. The gRPC and REST
error mappers translate the exception to UNAVAILABLE with a message
explaining that only backup and recovery related requests are served
until the partition resumes processing.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #61279

- [ ] This PR does not need a linked issue

