### PR TITLE
test: cover draining deletion of process definitions end to end

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
@@ -32,6 +32,7 @@ export class OperateDashboardPage {
   readonly expandRowButton: () => Locator;
   readonly incidentBadgeFromItem: (item: Locator) => Locator;
   readonly activeBadgeFromItem: (item: Locator) => Locator;
+  readonly drainingIndicatorFromItem: (item: Locator) => Locator;
   readonly expandRowButtonFromItem: (item: Locator) => Locator;
   readonly firstLinkFromItem: (item: Locator) => Locator;
 
@@ -98,6 +99,9 @@ export class OperateDashboardPage {
 
     this.activeBadgeFromItem = (item) =>
       item.getByTestId('active-instances-badge');
+
+    this.drainingIndicatorFromItem = (item) =>
+      item.getByTestId('draining-indicator');
 
     this.expandRowButtonFromItem = (item) =>
       item.getByRole('button', {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -21,6 +21,8 @@ class OperateProcessInstancePage {
   readonly messageVariable: Locator;
   readonly statusVariable: Locator;
   readonly instanceHeader: Locator;
+  readonly drainingTag: Locator;
+  readonly suspendedStateIcon: Locator;
   readonly instanceHistory: Locator;
   readonly rootProcessNode: Locator;
   readonly incidentsTable: Locator;
@@ -146,6 +148,8 @@ class OperateProcessInstancePage {
     });
     this.variableValueInput = page.getByTestId('edit-variable-value');
     this.instanceHeader = page.getByTestId('instance-header');
+    this.drainingTag = this.instanceHeader.getByTestId('draining-tag');
+    this.suspendedStateIcon = this.instanceHeader.getByTestId('SUSPENDED-icon');
     this.instanceHistory = page.getByTestId('instance-history');
     this.rootProcessNode = this.instanceHistory
       .locator('[data-testid^="node-details-"]')

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -62,6 +62,7 @@ class OperateProcessesPage {
     cellIndex?: number,
   ) => Locator;
   readonly deleteButton: Locator;
+  readonly drainingTag: Locator;
   readonly deleteBatchOperationConfirmButton: Locator;
   readonly batchOperationStartedMessage: (
     batchOperationType:
@@ -191,6 +192,7 @@ class OperateProcessesPage {
         .getByRole('cell')
         .nth(cellIndex);
     this.deleteButton = page.getByTestId('delete-batch-operation');
+    this.drainingTag = page.getByTestId('draining-tag');
     this.deleteBatchOperationConfirmButton = page
       .getByRole('dialog')
       .getByRole('button', {name: 'Delete'});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, expect} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 import {TaskPanelPage} from '@pages/TaskPanelPage';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {sleep} from '../utils/sleep';
@@ -145,4 +145,13 @@ export async function completeTaskWithRetry(
       }
     }
   }
+}
+
+/**
+ * Carbon renders a tooltip's content as a page-level popover rather than inside
+ * the element it annotates, so it cannot be reached through that element's own
+ * locator tree.
+ */
+export function tooltipWithText(page: Page, text: string): Locator {
+  return page.getByRole('tooltip', {name: text});
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-draining-state.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-draining-state.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test, type APIRequestContext} from '@playwright/test';
+import {
+  cancelProcessInstance,
+  createSingleInstance,
+} from '../../../../utils/zeebeClient';
+import {
+  deployUserTaskProcess,
+  drainProcessDefinition,
+  expectProcessDefinitionDeleted,
+  findUserTask,
+  searchProcessDefinitions,
+  searchProcessDefinitionItems,
+} from '@requestHelpers';
+import {
+  defaultAssertionOptions,
+  uniquePrefixedId,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
+
+async function expectDefinitionKeysForState(
+  request: APIRequestContext,
+  processDefinitionId: string,
+  state: string,
+  expectedKeys: string[],
+  assertionOptions = defaultAssertionOptions,
+) {
+  await expect(async () => {
+    const items = await searchProcessDefinitionItems(request, {
+      filter: {processDefinitionId, state},
+    });
+    expect(items.map((item) => item.processDefinitionKey).sort()).toEqual(
+      [...expectedKeys].sort(),
+    );
+  }).toPass(assertionOptions);
+}
+
+/* eslint-disable playwright/expect-expect */
+test.describe('Process Definition Draining State', () => {
+  let instancesToCancel: string[] = [];
+
+  test.beforeEach(() => {
+    instancesToCancel = [];
+  });
+
+  // A failed assertion mid-drain would leave a definition DRAINING for the rest
+  // of the run, blocking every later test that resolves it.
+  test.afterEach(async () => {
+    for (const processInstanceKey of instancesToCancel.filter(Boolean)) {
+      await cancelProcessInstance(processInstanceKey);
+    }
+  });
+
+  test('The state filter moves the definition from ACTIVE to DRAINING to DELETED', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-state');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+
+    await expectDefinitionKeysForState(request, processDefinitionId, 'ACTIVE', [
+      processDefinitionKey,
+    ]);
+
+    await findUserTask(request, instance.processInstanceKey, 'CREATED');
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    await expectDefinitionKeysForState(
+      request,
+      processDefinitionId,
+      'DRAINING',
+      [processDefinitionKey],
+    );
+    await expectDefinitionKeysForState(
+      request,
+      processDefinitionId,
+      'ACTIVE',
+      [],
+    );
+
+    await cancelProcessInstance(instance.processInstanceKey);
+
+    await expectDefinitionKeysForState(
+      request,
+      processDefinitionId,
+      'DELETED',
+      [processDefinitionKey],
+      extendedAssertionOptions,
+    );
+  });
+
+  test('The state filter rejects a value outside the enum', async ({
+    request,
+  }) => {
+    const res = await searchProcessDefinitions(request, {
+      filter: {state: 'BOGUS'},
+    });
+
+    // A silently ignored filter would return every definition instead.
+    expect(res.status()).toBe(400);
+    expect((await res.json()).detail).toBe(
+      "Unexpected value 'BOGUS' for enum field 'state'. " +
+        'Use any of the following values: [ACTIVE, DRAINING, DELETED]',
+    );
+  });
+
+  test('isLatestVersion keeps returning the draining version rather than an older ACTIVE one', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-latest');
+    const v1 = await deployUserTaskProcess(processDefinitionId);
+    const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
+    const instance = await createSingleInstance(
+      processDefinitionId,
+      v2.processDefinitionVersion,
+    );
+    instancesToCancel.push(instance.processInstanceKey);
+
+    await findUserTask(request, instance.processInstanceKey, 'CREATED');
+    await drainProcessDefinition(request, v2.processDefinitionKey);
+
+    await expect(async () => {
+      const items = await searchProcessDefinitionItems(request, {
+        filter: {processDefinitionId, isLatestVersion: true},
+      });
+      expect(items).toHaveLength(1);
+      expect(items[0]!.processDefinitionKey).toBe(v2.processDefinitionKey);
+      expect(items[0]!.processDefinitionKey).not.toBe(v1.processDefinitionKey);
+      expect(items[0]!.state).toBe('DRAINING');
+    }).toPass(defaultAssertionOptions);
+
+    await cancelProcessInstance(instance.processInstanceKey);
+    await expectProcessDefinitionDeleted(request, v2.processDefinitionKey);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-draining-state.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-draining-state.spec.ts
@@ -7,17 +7,15 @@
  */
 
 import {expect, test, type APIRequestContext} from '@playwright/test';
+import {cancelProcessInstance} from '../../../../utils/zeebeClient';
 import {
-  cancelProcessInstance,
-  createSingleInstance,
-} from '../../../../utils/zeebeClient';
-import {
+  createInstanceOnceDeployed,
   deployUserTaskProcess,
   drainProcessDefinition,
   expectProcessDefinitionDeleted,
   findUserTask,
-  searchProcessDefinitions,
   searchProcessDefinitionItems,
+  searchProcessDefinitions,
 } from '@requestHelpers';
 import {
   defaultAssertionOptions,
@@ -64,7 +62,7 @@ test.describe('Process Definition Draining State', () => {
     const processDefinitionId = uniquePrefixedId('draining-state');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
 
     await expectDefinitionKeysForState(request, processDefinitionId, 'ACTIVE', [
@@ -119,7 +117,7 @@ test.describe('Process Definition Draining State', () => {
     const processDefinitionId = uniquePrefixedId('draining-latest');
     const v1 = await deployUserTaskProcess(processDefinitionId);
     const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
-    const instance = await createSingleInstance(
+    const instance = await createInstanceOnceDeployed(
       processDefinitionId,
       v2.processDefinitionVersion,
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
@@ -55,9 +55,17 @@ test.describe.parallel('Process Definition Get Start Form API', () => {
     // The form version comes from the deployment rather than being assumed to
     // be 1: deploying the same form again on a cluster that already has it
     // mints a new version, so a hardcoded 1 fails on every run after the first.
-    state['expectedFormVersion'] = deployment.forms.find(
+    const deployedForm = deployment.forms.find(
       (form) => form.formId === 'sign_up_form',
-    )!.version;
+    );
+    if (deployedForm === undefined) {
+      throw new Error(
+        `Deployment did not contain the 'sign_up_form' form: ${JSON.stringify(
+          deployment.forms,
+        )}`,
+      );
+    }
+    state['expectedFormVersion'] = deployedForm.version;
   });
 
   test('Get Process Definition Start Form - Success 200', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
@@ -52,6 +52,12 @@ test.describe.parallel('Process Definition Get Start Form API', () => {
     });
 
     state['expectedForm'] = readFileSync(formPath, 'utf-8');
+    // The form version comes from the deployment rather than being assumed to
+    // be 1: deploying the same form again on a cluster that already has it
+    // mints a new version, so a hardcoded 1 fails on every run after the first.
+    state['expectedFormVersion'] = deployment.forms.find(
+      (form) => form.formId === 'sign_up_form',
+    )!.version;
   });
 
   test('Get Process Definition Start Form - Success 200', async ({request}) => {
@@ -74,7 +80,7 @@ test.describe.parallel('Process Definition Get Start Form API', () => {
         body,
       );
       expect(body.formId).toBe('sign_up_form');
-      expect(body.version).toBe(1);
+      expect(body.version).toBe(state['expectedFormVersion']);
       expect(body.formKey).toBeDefined();
       expect(body.tenantId).toBe('<default>');
       expect(body.schema).toBe(state['expectedForm']);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
@@ -26,7 +26,6 @@ import {
   expectProcessInstanceCount,
   findUserTask,
   RESOURCE_DELETION_ENDPOINT,
-  searchProcessDefinitionItems,
   searchProcessInstances,
 } from '@requestHelpers';
 import {
@@ -82,6 +81,9 @@ async function historyBatchOperations(
     headers: jsonHeaders(),
     data: {
       filter: {operationType: 'DELETE_PROCESS_INSTANCE'},
+      // Newest first, so the operation this test is looking for is on the
+      // first page however many a shared cluster has already accumulated.
+      sort: [{field: 'startDate', order: 'DESC'}],
       page: {limit: DEFAULT_PAGE_LIMIT},
     },
   });
@@ -291,13 +293,10 @@ test.describe('Process Definition Draining Deletion API', () => {
       200,
     );
 
+    // Reaching DELETED at all is the assertion: camunda#60472 left the RDBMS
+    // row stuck at DRAINING while the engine finalized, so the poll times out
+    // rather than observing the terminal state.
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
-
-    expect(
-      await searchProcessDefinitionItems(request, {
-        filter: {processDefinitionId, state: 'DRAINING'},
-      }),
-    ).toHaveLength(0);
   });
 
   test('A call activity raises an incident when the child definition is draining', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
@@ -10,13 +10,13 @@ import {expect, test, type APIRequestContext} from '@playwright/test';
 import {
   cancelProcessInstance,
   createInstances,
-  createSingleInstance,
   deployWithSubstitutions,
 } from '../../../../utils/zeebeClient';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
 import {
   completeUserTask,
+  createInstanceOnceDeployed,
   deleteProcessDefinition,
   deployUserTaskProcess,
   drainProcessDefinition,
@@ -24,9 +24,9 @@ import {
   expectProcessDefinitionPurged,
   expectProcessDefinitionState,
   expectProcessInstanceCount,
-  searchProcessDefinitionItems,
   findUserTask,
   RESOURCE_DELETION_ENDPOINT,
+  searchProcessDefinitionItems,
   searchProcessInstances,
 } from '@requestHelpers';
 import {
@@ -146,7 +146,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const processDefinitionId = uniquePrefixedId('draining-complete');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
 
     const userTaskKey = await findUserTask(
@@ -182,7 +182,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const processDefinitionId = uniquePrefixedId('draining-cancel');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
 
     await findUserTask(request, instance.processInstanceKey, 'CREATED');
@@ -259,7 +259,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     );
     const parentKey = parentDeployment.processes[0].processDefinitionKey;
 
-    const parentInstance = await createSingleInstance(parentId, 1);
+    const parentInstance = await createInstanceOnceDeployed(parentId, 1);
     instancesToCancel.push(parentInstance.processInstanceKey);
 
     await expectProcessInstanceCount(
@@ -326,7 +326,7 @@ test.describe('Process Definition Draining Deletion API', () => {
 
     // The first parent instance keeps a child instance alive, so the child
     // definition stays DRAINING instead of finalizing immediately.
-    const firstParent = await createSingleInstance(parentId, 1);
+    const firstParent = await createInstanceOnceDeployed(parentId, 1);
     instancesToCancel.push(firstParent.processInstanceKey);
     await expectProcessInstanceCount(
       request,
@@ -377,7 +377,7 @@ test.describe('Process Definition Draining Deletion API', () => {
   }) => {
     const processDefinitionId = uniquePrefixedId('draining-newversion');
     const v1 = await deployUserTaskProcess(processDefinitionId);
-    const v1Instance = await createSingleInstance(processDefinitionId, 1);
+    const v1Instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(v1Instance.processInstanceKey);
     await findUserTask(request, v1Instance.processInstanceKey, 'CREATED');
 
@@ -412,7 +412,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const processDefinitionId = uniquePrefixedId('draining-blocked');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
 
     await drainProcessDefinition(request, processDefinitionKey);
@@ -437,7 +437,7 @@ test.describe('Process Definition Draining Deletion API', () => {
       v1.processDefinitionVersion,
     );
 
-    const v1Instance = await createSingleInstance(
+    const v1Instance = await createInstanceOnceDeployed(
       processDefinitionId,
       v1.processDefinitionVersion,
     );
@@ -458,7 +458,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const v1 = await deployUserTaskProcess(processDefinitionId);
     const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
 
-    const v2Instance = await createSingleInstance(
+    const v2Instance = await createInstanceOnceDeployed(
       processDefinitionId,
       v2.processDefinitionVersion,
     );
@@ -484,7 +484,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const v3 = await deployUserTaskProcess(processDefinitionId, '-v3');
 
     for (const version of [v3, v2]) {
-      const instance = await createSingleInstance(
+      const instance = await createInstanceOnceDeployed(
         processDefinitionId,
         version.processDefinitionVersion,
       );
@@ -507,7 +507,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
 
     for (const version of [v1, v2]) {
-      const instance = await createSingleInstance(
+      const instance = await createInstanceOnceDeployed(
         processDefinitionId,
         version.processDefinitionVersion,
       );
@@ -529,7 +529,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const processDefinitionId = uniquePrefixedId('draining-repeat');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
     await findUserTask(request, instance.processInstanceKey, 'CREATED');
 
@@ -550,7 +550,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const processDefinitionId = uniquePrefixedId('draining-keephistory');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
 
     const deletion = await deleteProcessDefinition(
@@ -576,7 +576,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     const processDefinitionId = uniquePrefixedId('draining-purgehistory');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
 
     const batchOperationKeysBefore = new Set(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
@@ -281,9 +281,10 @@ test.describe('Process Definition Draining Deletion API', () => {
   test('Deleting a definition with no running instances is deleted without draining', async ({
     request,
   }) => {
-    // Nothing to drain, so the definition skips DRAINING entirely. Worth its
-    // own test because the engine finalizing correctly is not enough — a
-    // secondary storage left stuck at DRAINING is what camunda#60472 was.
+    // Nothing to drain, so the definition goes straight to DELETED. Guards the
+    // regression fixed in camunda#60472: the engine finalized while the RDBMS
+    // row stayed at DRAINING, which an engine-level test cannot see. If that
+    // came back, the poll below would never observe the terminal state.
     const processDefinitionId = uniquePrefixedId('draining-none');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
@@ -293,9 +294,6 @@ test.describe('Process Definition Draining Deletion API', () => {
       200,
     );
 
-    // Reaching DELETED at all is the assertion: camunda#60472 left the RDBMS
-    // row stuck at DRAINING while the engine finalized, so the poll times out
-    // rather than observing the terminal state.
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
@@ -1,0 +1,675 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test, type APIRequestContext} from '@playwright/test';
+import {
+  cancelProcessInstance,
+  createInstances,
+  createSingleInstance,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  completeUserTask,
+  deleteProcessDefinition,
+  deployUserTaskProcess,
+  drainProcessDefinition,
+  expectProcessDefinitionDeleted,
+  expectProcessDefinitionPurged,
+  expectProcessDefinitionState,
+  expectProcessInstanceCount,
+  searchProcessDefinitionItems,
+  findUserTask,
+  RESOURCE_DELETION_ENDPOINT,
+  searchProcessInstances,
+} from '@requestHelpers';
+import {
+  DEFAULT_PAGE_LIMIT,
+  defaultAssertionOptions,
+  uniquePrefixedId,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
+
+const CALL_ACTIVITY_CHILD_MODEL_ID = 'childProcess';
+
+async function instanceCountFor(
+  request: APIRequestContext,
+  processDefinitionId: string,
+): Promise<number> {
+  return (await searchProcessInstances(request, {processDefinitionId})).length;
+}
+
+async function startInstance(
+  request: APIRequestContext,
+  data: Record<string, unknown>,
+) {
+  return request.post(buildUrl('/process-instances'), {
+    headers: jsonHeaders(),
+    data,
+  });
+}
+
+async function startedInstanceOf(
+  request: APIRequestContext,
+  data: Record<string, unknown>,
+) {
+  const res = await startInstance(request, data);
+  await assertStatusCode(res, 200);
+  await validateResponse(
+    {path: '/process-instances', method: 'POST', status: '200'},
+    res,
+  );
+  return res.json();
+}
+
+type HistoryBatchOperation = {batchOperationKey: string; state: string};
+
+/**
+ * Every history-deletion batch operation currently known. The item names no
+ * process definition, so the one a purge creates is only identifiable by
+ * diffing against a snapshot taken before the delete.
+ */
+async function historyBatchOperations(
+  request: APIRequestContext,
+): Promise<HistoryBatchOperation[]> {
+  const res = await request.post(buildUrl('/batch-operations/search'), {
+    headers: jsonHeaders(),
+    data: {
+      filter: {operationType: 'DELETE_PROCESS_INSTANCE'},
+      page: {limit: DEFAULT_PAGE_LIMIT},
+    },
+  });
+  await assertStatusCode(res, 200);
+  const items: HistoryBatchOperation[] = (await res.json()).items ?? [];
+  return items.map((item) => ({
+    batchOperationKey: String(item.batchOperationKey),
+    state: item.state,
+  }));
+}
+
+async function partitionsCount(request: APIRequestContext): Promise<number> {
+  const res = await request.get(buildUrl('/topology'), {
+    headers: jsonHeaders(),
+  });
+  await assertStatusCode(res, 200);
+  return (await res.json()).partitionsCount as number;
+}
+
+/**
+ * Error messages of the incidents raised on instances of one definition, once
+ * `expectedCount` of them exist.
+ */
+async function incidentMessagesFor(
+  request: APIRequestContext,
+  processDefinitionKey: string,
+  expectedCount: number,
+): Promise<string[]> {
+  let messages: string[] = [];
+  await expect(async () => {
+    const res = await request.post(buildUrl('/incidents/search'), {
+      headers: jsonHeaders(),
+      data: {filter: {processDefinitionKey}, page: {limit: DEFAULT_PAGE_LIMIT}},
+    });
+    await assertStatusCode(res, 200);
+    const items: Array<{errorMessage: string}> = (await res.json()).items ?? [];
+    expect(items).toHaveLength(expectedCount);
+    messages = items.map((item) => item.errorMessage);
+  }).toPass(defaultAssertionOptions);
+  return messages;
+}
+
+/* eslint-disable playwright/expect-expect */
+test.describe('Process Definition Draining Deletion API', () => {
+  let instancesToCancel: string[] = [];
+
+  test.beforeEach(() => {
+    instancesToCancel = [];
+  });
+
+  // A definition left draining blocks instance creation for any later test that
+  // reuses it, so every instance started here has to be terminated.
+  test.afterEach(async () => {
+    for (const processInstanceKey of instancesToCancel.filter(Boolean)) {
+      await cancelProcessInstance(processInstanceKey);
+    }
+  });
+
+  test('Deleting a definition with a running instance drains it until the instance completes', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-complete');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+
+    const userTaskKey = await findUserTask(
+      request,
+      instance.processInstanceKey,
+      'CREATED',
+    );
+
+    const deleteRes = await deleteProcessDefinition(
+      request,
+      processDefinitionKey,
+    );
+    await assertStatusCode(deleteRes, 200);
+    await validateResponse(
+      {path: RESOURCE_DELETION_ENDPOINT, method: 'POST', status: '200'},
+      deleteRes,
+    );
+
+    await expectProcessDefinitionState(
+      request,
+      processDefinitionKey,
+      'DRAINING',
+    );
+
+    await assertStatusCode(await completeUserTask(request, userTaskKey), 204);
+
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+  });
+
+  test('Cancelling the last running instance finalizes the drain', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-cancel');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+
+    await findUserTask(request, instance.processInstanceKey, 'CREATED');
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    await cancelProcessInstance(instance.processInstanceKey);
+
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+  });
+
+  test('A definition stays DRAINING until the last of several instances ends', async ({
+    request,
+  }) => {
+    // Only the deployment partition flips secondary storage to DELETED, and only
+    // once every partition has reported. Ending the instances one at a time is
+    // what separates that from a definition deleted as soon as any partition
+    // finishes.
+    const processDefinitionId = uniquePrefixedId('draining-partial');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+
+    const instances = await createInstances(processDefinitionId, 1, 6);
+    instancesToCancel.push(
+      ...instances.map((instance) => instance.processInstanceKey),
+    );
+    await expectProcessInstanceCount(request, {processDefinitionId}, 6);
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    for (let ended = 1; ended < instances.length; ended++) {
+      await cancelProcessInstance(instances[ended - 1]!.processInstanceKey);
+      await expectProcessInstanceCount(
+        request,
+        {processDefinitionId, state: 'ACTIVE'},
+        instances.length - ended,
+      );
+      await expectProcessDefinitionState(
+        request,
+        processDefinitionKey,
+        'DRAINING',
+      );
+    }
+
+    await cancelProcessInstance(
+      instances[instances.length - 1]!.processInstanceKey,
+    );
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+  });
+
+  test('A call activity child definition drains until its child instance is terminated', async ({
+    request,
+  }) => {
+    const parentId = uniquePrefixedId('draining-parent');
+    const childId = uniquePrefixedId('draining-child');
+
+    const childDeployment = await deployWithSubstitutions(
+      './resources/childProcess_v_1.bpmn',
+      {
+        [CALL_ACTIVITY_CHILD_MODEL_ID]: childId,
+        // The model's job type is the generic `Task`; scoping it to this test
+        // keeps an unrelated worker from completing the child and ending the
+        // drain before it is asserted.
+        'type="Task"': `type="${childId}-job"`,
+      },
+    );
+    const childKey = childDeployment.processes[0].processDefinitionKey;
+
+    const parentDeployment = await deployWithSubstitutions(
+      './resources/callActivityParentProcess.bpmn',
+      {
+        callActivityParentProcess: parentId,
+        [CALL_ACTIVITY_CHILD_MODEL_ID]: childId,
+      },
+    );
+    const parentKey = parentDeployment.processes[0].processDefinitionKey;
+
+    const parentInstance = await createSingleInstance(parentId, 1);
+    instancesToCancel.push(parentInstance.processInstanceKey);
+
+    await expectProcessInstanceCount(
+      request,
+      {processDefinitionKey: childKey, state: 'ACTIVE'},
+      1,
+    );
+
+    await drainProcessDefinition(request, childKey);
+    await expectProcessDefinitionState(request, parentKey, 'ACTIVE');
+
+    await cancelProcessInstance(parentInstance.processInstanceKey);
+
+    await expectProcessDefinitionDeleted(request, childKey);
+  });
+
+  test('Deleting a definition with no running instances is deleted without draining', async ({
+    request,
+  }) => {
+    // Nothing to drain, so the definition skips DRAINING entirely. Worth its
+    // own test because the engine finalizing correctly is not enough — a
+    // secondary storage left stuck at DRAINING is what camunda#60472 was.
+    const processDefinitionId = uniquePrefixedId('draining-none');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+
+    await assertStatusCode(
+      await deleteProcessDefinition(request, processDefinitionKey),
+      200,
+    );
+
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+
+    expect(
+      await searchProcessDefinitionItems(request, {
+        filter: {processDefinitionId, state: 'DRAINING'},
+      }),
+    ).toHaveLength(0);
+  });
+
+  test('A call activity raises an incident when the child definition is draining', async ({
+    request,
+  }) => {
+    const parentId = uniquePrefixedId('draining-callincident-parent');
+    const childId = uniquePrefixedId('draining-callincident-child');
+
+    const childDeployment = await deployWithSubstitutions(
+      './resources/childProcess_v_1.bpmn',
+      {
+        [CALL_ACTIVITY_CHILD_MODEL_ID]: childId,
+        'type="Task"': `type="${childId}-job"`,
+      },
+    );
+    const child = childDeployment.processes[0];
+
+    const parentDeployment = await deployWithSubstitutions(
+      './resources/callActivityParentProcess.bpmn',
+      {
+        callActivityParentProcess: parentId,
+        [CALL_ACTIVITY_CHILD_MODEL_ID]: childId,
+      },
+    );
+    const parent = parentDeployment.processes[0];
+
+    // The first parent instance keeps a child instance alive, so the child
+    // definition stays DRAINING instead of finalizing immediately.
+    const firstParent = await createSingleInstance(parentId, 1);
+    instancesToCancel.push(firstParent.processInstanceKey);
+    await expectProcessInstanceCount(
+      request,
+      {processDefinitionKey: child.processDefinitionKey, state: 'ACTIVE'},
+      1,
+    );
+
+    await drainProcessDefinition(request, child.processDefinitionKey);
+
+    // The parent is untouched, so starting it still succeeds — it is the call
+    // activity that cannot resolve the draining child, and that failure has to
+    // surface as an incident rather than silently skipping the child.
+    //
+    // Which message the incident carries depends on the serving partition:
+    // only the partition holding the child instance is still draining, the
+    // others finalized the delete at once and no longer hold the definition.
+    // Three instances per partition exercise both.
+    const parentCount = 3 * (await partitionsCount(request));
+    const parents = await createInstances(parentId, 1, parentCount);
+    instancesToCancel.push(
+      ...parents.map((instance) => instance.processInstanceKey),
+    );
+
+    const messages = await incidentMessagesFor(
+      request,
+      parent.processDefinitionKey,
+      parentCount,
+    );
+    const drainingMessage =
+      `Expected to call process with BPMN process id '${childId}' and version ` +
+      `${child.processDefinitionVersion} (key ${child.processDefinitionKey}), ` +
+      'but it is being deleted.';
+    const alreadyDeletedMessage =
+      `Expected process with BPMN process id '${childId}' to be deployed, ` +
+      'but not found.';
+
+    expect(messages).toContain(drainingMessage);
+    expect(
+      messages.filter(
+        (message) =>
+          message !== drainingMessage && message !== alreadyDeletedMessage,
+      ),
+    ).toEqual([]);
+  });
+
+  test('A new version can be deployed while an older one is draining', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-newversion');
+    const v1 = await deployUserTaskProcess(processDefinitionId);
+    const v1Instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(v1Instance.processInstanceKey);
+    await findUserTask(request, v1Instance.processInstanceKey, 'CREATED');
+
+    await drainProcessDefinition(request, v1.processDefinitionKey);
+
+    // Deploying during the drain, not before it: the draining version must not
+    // block the deployment, and must not be resurrected as ACTIVE by it.
+    const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
+    expect(v2.processDefinitionVersion).toBeGreaterThan(
+      v1.processDefinitionVersion,
+    );
+
+    await expectProcessDefinitionState(
+      request,
+      v2.processDefinitionKey,
+      'ACTIVE',
+    );
+    await expectProcessDefinitionState(
+      request,
+      v1.processDefinitionKey,
+      'DRAINING',
+    );
+
+    const started = await startedInstanceOf(request, {processDefinitionId});
+    instancesToCancel.push(started.processInstanceKey);
+    expect(started.processDefinitionKey).toBe(v2.processDefinitionKey);
+  });
+
+  test('Creating an instance by processDefinitionKey is refused while the definition is draining', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-blocked');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    const res = await startInstance(request, {processDefinitionKey});
+
+    // Deletion finalizes per partition, so on a multi-partition cluster the
+    // refusal depends on which partition serves the create: one still draining
+    // answers 409, one that already finished deleting answers 404. Neither
+    // starts an instance, which is the guarantee under test.
+    expect([404, 409]).toContain(res.status());
+    await expectProcessInstanceCount(request, {processDefinitionId}, 1);
+  });
+
+  test('Creating by processDefinitionId alone starts on a newer ACTIVE version instead of the draining one', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-newer');
+    const v1 = await deployUserTaskProcess(processDefinitionId);
+    const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
+    expect(v2.processDefinitionVersion).toBeGreaterThan(
+      v1.processDefinitionVersion,
+    );
+
+    const v1Instance = await createSingleInstance(
+      processDefinitionId,
+      v1.processDefinitionVersion,
+    );
+    instancesToCancel.push(v1Instance.processInstanceKey);
+
+    await drainProcessDefinition(request, v1.processDefinitionKey);
+
+    const started = await startedInstanceOf(request, {processDefinitionId});
+    instancesToCancel.push(started.processInstanceKey);
+
+    expect(started.processDefinitionKey).toBe(v2.processDefinitionKey);
+  });
+
+  test('Creating by processDefinitionId alone resolves to the latest ACTIVE version below the draining one', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-older');
+    const v1 = await deployUserTaskProcess(processDefinitionId);
+    const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
+
+    const v2Instance = await createSingleInstance(
+      processDefinitionId,
+      v2.processDefinitionVersion,
+    );
+    instancesToCancel.push(v2Instance.processInstanceKey);
+
+    await drainProcessDefinition(request, v2.processDefinitionKey);
+
+    const started = await startedInstanceOf(request, {processDefinitionId});
+    instancesToCancel.push(started.processInstanceKey);
+
+    // Resolution skips the draining version and lands on the latest ACTIVE one
+    // below it, regardless of which partition serves the request (camunda#61719).
+    expect(started.processDefinitionKey).toBe(v1.processDefinitionKey);
+    expect(started.processDefinitionKey).not.toBe(v2.processDefinitionKey);
+  });
+
+  test('Creating by processDefinitionId skips consecutive draining versions', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-chain');
+    const v1 = await deployUserTaskProcess(processDefinitionId);
+    const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
+    const v3 = await deployUserTaskProcess(processDefinitionId, '-v3');
+
+    for (const version of [v3, v2]) {
+      const instance = await createSingleInstance(
+        processDefinitionId,
+        version.processDefinitionVersion,
+      );
+      instancesToCancel.push(instance.processInstanceKey);
+      await findUserTask(request, instance.processInstanceKey, 'CREATED');
+      await drainProcessDefinition(request, version.processDefinitionKey);
+    }
+
+    const started = await startedInstanceOf(request, {processDefinitionId});
+    instancesToCancel.push(started.processInstanceKey);
+
+    expect(started.processDefinitionKey).toBe(v1.processDefinitionKey);
+  });
+
+  test('Creating by processDefinitionId is refused when every version is draining', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-all');
+    const v1 = await deployUserTaskProcess(processDefinitionId);
+    const v2 = await deployUserTaskProcess(processDefinitionId, '-v2');
+
+    for (const version of [v1, v2]) {
+      const instance = await createSingleInstance(
+        processDefinitionId,
+        version.processDefinitionVersion,
+      );
+      instancesToCancel.push(instance.processInstanceKey);
+      await findUserTask(request, instance.processInstanceKey, 'CREATED');
+      await drainProcessDefinition(request, version.processDefinitionKey);
+    }
+
+    const before = await instanceCountFor(request, processDefinitionId);
+    const res = await startInstance(request, {processDefinitionId});
+
+    expect([404, 409]).toContain(res.status());
+    expect(await instanceCountFor(request, processDefinitionId)).toBe(before);
+  });
+
+  test('A repeated delete of an already draining definition is rejected', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-repeat');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+    await findUserTask(request, instance.processInstanceKey, 'CREATED');
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    const second = await deleteProcessDefinition(request, processDefinitionKey);
+    expect(second.status()).toBe(409);
+    await expectProcessDefinitionState(
+      request,
+      processDefinitionKey,
+      'DRAINING',
+    );
+  });
+
+  test('Without deleteHistory the instance history survives the deletion', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-keephistory');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+
+    const deletion = await deleteProcessDefinition(
+      request,
+      processDefinitionKey,
+    );
+    await assertStatusCode(deletion, 200);
+    // A process definition still in runtime state reports no batch operation,
+    // whether or not history deletion was requested.
+    expect((await deletion.json()).batchOperation).toBeNull();
+
+    // Cancelling keeps the test off the user-task index, the slowest propagation
+    // path.
+    await cancelProcessInstance(instance.processInstanceKey);
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+
+    expect(await instanceCountFor(request, processDefinitionId)).toBe(1);
+  });
+
+  test('With deleteHistory the instance history is purged by a batch operation once the drain finishes', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-purgehistory');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+
+    const batchOperationKeysBefore = new Set(
+      (await historyBatchOperations(request)).map(
+        (item) => item.batchOperationKey,
+      ),
+    );
+
+    const deletion = await deleteProcessDefinition(
+      request,
+      processDefinitionKey,
+      true,
+    );
+    await assertStatusCode(deletion, 200);
+    expect((await deletion.json()).batchOperation).toBeNull();
+
+    await expectProcessDefinitionState(
+      request,
+      processDefinitionKey,
+      'DRAINING',
+    );
+    // History is retained for as long as the definition is draining.
+    expect(await instanceCountFor(request, processDefinitionId)).toBe(1);
+
+    await cancelProcessInstance(instance.processInstanceKey);
+
+    // The purge takes the definition record with it, so there is nothing left to
+    // read back.
+    await expectProcessDefinitionPurged(request, processDefinitionKey);
+
+    await expectProcessInstanceCount(
+      request,
+      {processDefinitionId},
+      0,
+      extendedAssertionOptions,
+    );
+
+    // The purge runs as a batch operation, and it has to reach COMPLETED —
+    // otherwise history lingers with nothing left to retry. Only the snapshot
+    // diff identifies it, so "created exactly once" stays a manual check.
+    await expect(async () => {
+      const created = (await historyBatchOperations(request)).filter(
+        (item) => !batchOperationKeysBefore.has(item.batchOperationKey),
+      );
+      expect(created.length).toBeGreaterThan(0);
+      expect(created.map((item) => item.state)).toContain('COMPLETED');
+    }).toPass(extendedAssertionOptions);
+  });
+
+  test('Deleting a definition with running instances leaves the deployment queue usable', async ({
+    request,
+  }) => {
+    // The bug this feature fixes: the deletion used to stall on a partition that
+    // still held instances, and because deletions and deployments share one
+    // distribution queue, every later deployment was blocked cluster-wide.
+    const processDefinitionId = uniquePrefixedId('draining-queue');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+
+    const spread = await createInstances(processDefinitionId, 1, 6);
+    instancesToCancel.push(
+      ...spread.map((instance) => instance.processInstanceKey),
+    );
+    await expectProcessInstanceCount(request, {processDefinitionId}, 6);
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    const probeProcessDefinitionId = uniquePrefixedId('draining-queue-probe');
+    const probe = await deployUserTaskProcess(probeProcessDefinitionId);
+    expect(probe.processDefinitionKey).toBeDefined();
+
+    // Instances land round-robin, so three per partition make it certain every
+    // partition served one and can resolve the new definition.
+    const probeInstanceCount = 3 * (await partitionsCount(request));
+    const probeInstances = await createInstances(
+      probeProcessDefinitionId,
+      1,
+      probeInstanceCount,
+    );
+    instancesToCancel.push(
+      ...probeInstances.map((instance) => instance.processInstanceKey),
+    );
+    await expectProcessInstanceCount(
+      request,
+      {processDefinitionId: probeProcessDefinitionId},
+      probeInstanceCount,
+    );
+
+    // And the original definition is still draining, not silently dropped.
+    await expectProcessDefinitionState(
+      request,
+      processDefinitionKey,
+      'DRAINING',
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
@@ -281,10 +281,7 @@ test.describe('Process Definition Draining Deletion API', () => {
   test('Deleting a definition with no running instances is deleted without draining', async ({
     request,
   }) => {
-    // Nothing to drain, so the definition goes straight to DELETED. Guards the
-    // regression fixed in camunda#60472: the engine finalized while the RDBMS
-    // row stayed at DRAINING, which an engine-level test cannot see. If that
-    // came back, the poll below would never observe the terminal state.
+    // Regression guard for camunda#60472 — RDBMS only, invisible to the engine tests.
     const processDefinitionId = uniquePrefixedId('draining-none');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-running-work.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-running-work.spec.ts
@@ -10,7 +10,6 @@ import {expect, test} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import {
   cancelProcessInstance,
-  createSingleInstance,
   deployWithSubstitutions,
   setVariables,
 } from '../../../../utils/zeebeClient';
@@ -19,6 +18,7 @@ import {
   activateSingleJob,
   completeJob,
   completeUserTask,
+  createInstanceOnceDeployed,
   deployUserTaskProcess,
   drainProcessDefinition,
   expectProcessDefinitionDeleted,
@@ -104,7 +104,7 @@ test.describe('Process Definition Draining Deletion — work already in flight',
       processDefinitionId,
       jobType,
     );
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
 
     const jobKey = await activateSingleJob(
@@ -171,7 +171,7 @@ test.describe('Process Definition Draining Deletion — work already in flight',
       messageName,
     );
 
-    const instance = await createSingleInstance(processDefinitionId, 1, {
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1, {
       corrId: correlationKey,
     });
     instancesToCancel.push(instance.processInstanceKey);
@@ -202,7 +202,7 @@ test.describe('Process Definition Draining Deletion — work already in flight',
       processDefinitionId,
       jobType,
     );
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
     await activateSingleJob(request, jobType, instance.processInstanceKey);
 
@@ -227,7 +227,7 @@ test.describe('Process Definition Draining Deletion — work already in flight',
     const {processDefinitionKey} =
       await deployTimerProcess(processDefinitionId);
 
-    const instance = await createSingleInstance(processDefinitionId, 1, {
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1, {
       duration: 'PT30S',
     });
     instancesToCancel.push(instance.processInstanceKey);
@@ -253,7 +253,7 @@ test.describe('Process Definition Draining Deletion — work already in flight',
     const processDefinitionId = uniquePrefixedId('draining-suspend');
     const {processDefinitionKey} =
       await deployUserTaskProcess(processDefinitionId);
-    const instance = await createSingleInstance(processDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
     const userTaskKey = await findUserTask(
       request,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-running-work.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-running-work.spec.ts
@@ -1,0 +1,299 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  cancelProcessInstance,
+  createSingleInstance,
+  deployWithSubstitutions,
+  setVariables,
+} from '../../../../utils/zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {
+  activateSingleJob,
+  completeJob,
+  completeUserTask,
+  deployUserTaskProcess,
+  drainProcessDefinition,
+  expectProcessDefinitionDeleted,
+  expectProcessDefinitionState,
+  expectProcessState,
+  findUserTask,
+  searchIncidentByPIK,
+  searchVariableByNameAndProcessInstanceKey,
+} from '@requestHelpers';
+import {
+  uniquePrefixedId,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
+
+/**
+ * Job type is scoped to the calling test so no other test's worker can steal
+ * the job and end the drain before it is asserted.
+ */
+async function deployJobProcess(processDefinitionId: string, jobType: string) {
+  const deployment = await deployWithSubstitutions(
+    './resources/incidentGeneratorProcess.bpmn',
+    {
+      incidentGeneratorProcess: processDefinitionId,
+      'type="incidentGenerator"': `type="${jobType}"`,
+    },
+  );
+  return deployment.processes[0];
+}
+
+/**
+ * Message name and correlation key are per test, so a publish only ever
+ * reaches this test's instance.
+ */
+async function deployMessageCatchProcess(
+  processDefinitionId: string,
+  messageName: string,
+) {
+  const deployment = await deployWithSubstitutions(
+    './resources/messageCatchEvent1.bpmn',
+    {
+      messageCatchEvent1: processDefinitionId,
+      'name="Message_143t419"': `name="${messageName}"`,
+      'correlationKey="=143419"': 'correlationKey="=corrId"',
+    },
+  );
+  return deployment.processes[0];
+}
+
+/**
+ * The wait duration comes from a variable, so the caller can pick a window
+ * long enough to observe DRAINING before the timer fires.
+ */
+async function deployTimerProcess(processDefinitionId: string) {
+  const deployment = await deployWithSubstitutions(
+    './resources/timerIntermediateCatchEvent.bpmn',
+    {
+      timerIntermediateCatchEventProcess: processDefinitionId,
+    },
+  );
+  return deployment.processes[0];
+}
+
+/* eslint-disable playwright/expect-expect */
+test.describe('Process Definition Draining Deletion — work already in flight', () => {
+  let instancesToCancel: string[] = [];
+
+  test.beforeEach(() => {
+    instancesToCancel = [];
+  });
+
+  test.afterEach(async () => {
+    for (const processInstanceKey of instancesToCancel.filter(Boolean)) {
+      await cancelProcessInstance(processInstanceKey);
+    }
+  });
+
+  test('A job of a draining definition can still be failed, resolved and completed', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-job');
+    const jobType = uniquePrefixedId('draining-jobtype');
+    const {processDefinitionKey} = await deployJobProcess(
+      processDefinitionId,
+      jobType,
+    );
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+
+    const jobKey = await activateSingleJob(
+      request,
+      jobType,
+      instance.processInstanceKey,
+    );
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    // Draining stops new work from starting; it must not stop a worker reporting
+    // on work already in flight, including failing it into an incident.
+    await assertStatusCode(
+      await request.post(buildUrl('/jobs/{jobKey}/failure', {jobKey}), {
+        headers: jsonHeaders(),
+        data: {retries: 0, errorMessage: 'draining-coverage failure'},
+      }),
+      204,
+    );
+
+    const incidents = await searchIncidentByPIK(request, {
+      processInstanceKey: instance.processInstanceKey,
+    });
+    expect(incidents).toHaveLength(1);
+    const incidentKey = incidents[0]!.incidentKey;
+
+    // Without this a failing instance could never reach an end state and the
+    // drain would be stuck for good.
+    await assertStatusCode(
+      await request.patch(buildUrl('/jobs/{jobKey}', {jobKey}), {
+        headers: jsonHeaders(),
+        data: {changeset: {retries: 2}},
+      }),
+      204,
+    );
+    await assertStatusCode(
+      await request.post(
+        buildUrl('/incidents/{incidentKey}/resolution', {
+          incidentKey,
+        }),
+        {headers: jsonHeaders()},
+      ),
+      204,
+    );
+
+    const retriedJobKey = await activateSingleJob(
+      request,
+      jobType,
+      instance.processInstanceKey,
+    );
+    await completeJob(request, retriedJobKey);
+
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+  });
+
+  test('A message can still be correlated to a running instance of a draining definition', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-correlate');
+    const messageName = uniquePrefixedId('draining-catchmsg');
+    const correlationKey = uniquePrefixedId('draining-corr');
+    const {processDefinitionKey} = await deployMessageCatchProcess(
+      processDefinitionId,
+      messageName,
+    );
+
+    const instance = await createSingleInstance(processDefinitionId, 1, {
+      corrId: correlationKey,
+    });
+    instancesToCancel.push(instance.processInstanceKey);
+    await expectProcessState(request, instance.processInstanceKey, 'ACTIVE');
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    // The waiting instance has to receive the message — the drain's only route
+    // to completion here.
+    await assertStatusCode(
+      await request.post(buildUrl('/messages/publication'), {
+        headers: jsonHeaders(),
+        data: {name: messageName, correlationKey, messageId: randomUUID()},
+      }),
+      200,
+    );
+
+    await expectProcessState(request, instance.processInstanceKey, 'COMPLETED');
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+  });
+
+  test('Variables can still be set on an instance of a draining definition', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-variables');
+    const jobType = uniquePrefixedId('draining-vartype');
+    const {processDefinitionKey} = await deployJobProcess(
+      processDefinitionId,
+      jobType,
+    );
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+    await activateSingleJob(request, jobType, instance.processInstanceKey);
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    const variableName = 'drainingCoverageVariable';
+    await setVariables(instance.processInstanceKey, {
+      [variableName]: 'set-while-draining',
+    });
+
+    const variable = await searchVariableByNameAndProcessInstanceKey(request, {
+      processInstanceKey: instance.processInstanceKey,
+      name: variableName,
+    });
+    expect(variable.value).toBe('"set-while-draining"');
+  });
+
+  test('A firing timer completes the last instance and finalizes the drain', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-timer');
+    const {processDefinitionKey} =
+      await deployTimerProcess(processDefinitionId);
+
+    const instance = await createSingleInstance(processDefinitionId, 1, {
+      duration: 'PT30S',
+    });
+    instancesToCancel.push(instance.processInstanceKey);
+    await expectProcessState(request, instance.processInstanceKey, 'ACTIVE');
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    // No cancel, no worker, no message: the timer alone has to carry the instance
+    // to its end event while the definition drains.
+    await expectProcessState(
+      request,
+      instance.processInstanceKey,
+      'COMPLETED',
+      extendedAssertionOptions,
+    );
+
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+  });
+
+  test('A suspended instance holds the drain open until it is resumed and completed', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-suspend');
+    const {processDefinitionKey} =
+      await deployUserTaskProcess(processDefinitionId);
+    const instance = await createSingleInstance(processDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+    const userTaskKey = await findUserTask(
+      request,
+      instance.processInstanceKey,
+      'CREATED',
+    );
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    // Suspension acts on the instance, not the definition, so a drain in progress
+    // must not gate it.
+    await assertStatusCode(
+      await request.post(
+        buildUrl('/process-instances/{processInstanceKey}/suspension', {
+          processInstanceKey: instance.processInstanceKey,
+        }),
+        {headers: jsonHeaders()},
+      ),
+      204,
+    );
+
+    // A suspended instance never ends on its own, so the drain must not finalize
+    // as if the instance were gone.
+    await expectProcessDefinitionState(
+      request,
+      processDefinitionKey,
+      'DRAINING',
+    );
+
+    await assertStatusCode(
+      await request.post(
+        buildUrl('/process-instances/{processInstanceKey}/resumption', {
+          processInstanceKey: instance.processInstanceKey,
+        }),
+        {headers: jsonHeaders()},
+      ),
+      204,
+    );
+
+    await assertStatusCode(await completeUserTask(request, userTaskKey), 204);
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-start-paths.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-start-paths.spec.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test, type APIRequestContext} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  cancelProcessInstance,
+  createSingleInstance,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {
+  deployUserTaskProcess,
+  drainProcessDefinition,
+  expectProcessInstanceCount,
+  findUserTask,
+  searchProcessInstances,
+} from '@requestHelpers';
+import {uniquePrefixedId} from '../../../../utils/constants';
+
+const USER_TASK_MODEL_TASK_ID = 'Activity_1xqonra';
+
+/**
+ * Process id and message name are per test, so a publish can never open a
+ * subscription belonging to another test running in parallel.
+ */
+async function deployMessageStartProcess(
+  processDefinitionId: string,
+  messageName: string,
+  nameSuffix = '',
+) {
+  const deployment = await deployWithSubstitutions(
+    './resources/message_start_business_id_process.bpmn',
+    {
+      message_start_business_id_process: processDefinitionId,
+      start_business_id_msg: messageName,
+      ...(nameSuffix
+        ? {
+            'name="Message Start Business ID Process"': `name="Message Start Business ID Process${nameSuffix}"`,
+          }
+        : {}),
+    },
+  );
+  return deployment.processes[0];
+}
+
+async function publishMessage(
+  request: APIRequestContext,
+  name: string,
+  correlationKey = '',
+) {
+  return request.post(buildUrl('/messages/publication'), {
+    headers: jsonHeaders(),
+    // A fresh messageId keeps deduplication from swallowing a second publish of
+    // the same name.
+    data: {name, correlationKey, messageId: randomUUID()},
+  });
+}
+
+test.describe('Process Definition Draining Deletion — alternative start paths', () => {
+  let instancesToCancel: string[] = [];
+
+  test.beforeEach(() => {
+    instancesToCancel = [];
+  });
+
+  // A definition left draining never finalizes, so every instance started here
+  // has to be terminated.
+  test.afterEach(async () => {
+    for (const processInstanceKey of instancesToCancel.filter(Boolean)) {
+      await cancelProcessInstance(processInstanceKey);
+    }
+  });
+
+  test('Publishing the start message does not start an instance while the only version is draining', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-msgstart');
+    const messageName = uniquePrefixedId('draining-msg');
+    const {processDefinitionKey} = await deployMessageStartProcess(
+      processDefinitionId,
+      messageName,
+    );
+
+    // The control definition is the synchronisation point: once its instance
+    // exists the broker has acted on both publishes, so an unchanged count on the
+    // draining definition means refused rather than merely slow.
+    const controlProcessDefinitionId = uniquePrefixedId(
+      'draining-msgstart-control',
+    );
+    const controlMessageName = uniquePrefixedId('draining-msg-control');
+    await deployMessageStartProcess(
+      controlProcessDefinitionId,
+      controlMessageName,
+    );
+
+    await assertStatusCode(await publishMessage(request, messageName), 200);
+    await expectProcessInstanceCount(request, {processDefinitionId}, 1);
+    const [firstInstance] = await searchProcessInstances(request, {
+      processDefinitionId,
+    });
+    instancesToCancel.push(firstInstance!.processInstanceKey);
+    await findUserTask(request, firstInstance!.processInstanceKey, 'CREATED');
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    await assertStatusCode(await publishMessage(request, messageName), 200);
+    await assertStatusCode(
+      await publishMessage(request, controlMessageName),
+      200,
+    );
+
+    await expectProcessInstanceCount(
+      request,
+      {processDefinitionId: controlProcessDefinitionId},
+      1,
+    );
+    const [controlInstance] = await searchProcessInstances(request, {
+      processDefinitionId: controlProcessDefinitionId,
+    });
+    instancesToCancel.push(controlInstance!.processInstanceKey);
+
+    // The publish is accepted — nothing rejects a message for a definition with
+    // no subscription — but it must not produce a second instance.
+    expect(
+      await searchProcessInstances(request, {processDefinitionId}),
+    ).toHaveLength(1);
+  });
+
+  test('Publishing the start message starts an older ACTIVE version instead of the draining latest', async ({
+    request,
+  }) => {
+    const processDefinitionId = uniquePrefixedId('draining-msgstart-older');
+    const messageName = uniquePrefixedId('draining-msg-older');
+    const v1 = await deployMessageStartProcess(
+      processDefinitionId,
+      messageName,
+    );
+    const v2 = await deployMessageStartProcess(
+      processDefinitionId,
+      messageName,
+      '-v2',
+    );
+    expect(v2.processDefinitionVersion).toBeGreaterThan(
+      v1.processDefinitionVersion,
+    );
+
+    await assertStatusCode(await publishMessage(request, messageName), 200);
+    await expectProcessInstanceCount(request, {processDefinitionId}, 1);
+    const [v2Instance] = await searchProcessInstances(request, {
+      processDefinitionId,
+    });
+    instancesToCancel.push(v2Instance!.processInstanceKey);
+    expect(v2Instance!.processDefinitionKey).toBe(v2.processDefinitionKey);
+    await findUserTask(request, v2Instance!.processInstanceKey, 'CREATED');
+
+    await drainProcessDefinition(request, v2.processDefinitionKey);
+
+    await assertStatusCode(await publishMessage(request, messageName), 200);
+
+    // The start subscription falls back to the newest ACTIVE version, the same
+    // resolution the create-by-id path performs.
+    await expectProcessInstanceCount(request, {processDefinitionId}, 2);
+    const instances = await searchProcessInstances(request, {
+      processDefinitionId,
+    });
+    const started = instances.find(
+      (item) => item.processInstanceKey !== v2Instance!.processInstanceKey,
+    );
+    instancesToCancel.push(started!.processInstanceKey);
+    expect(started!.processDefinitionKey).toBe(v1.processDefinitionKey);
+  });
+
+  test('Migrating an instance onto a draining definition is rejected', async ({
+    request,
+  }) => {
+    const sourceProcessDefinitionId = uniquePrefixedId(
+      'draining-migrate-source',
+    );
+    const targetProcessDefinitionId = uniquePrefixedId(
+      'draining-migrate-target',
+    );
+    await deployUserTaskProcess(sourceProcessDefinitionId);
+    const target = await deployUserTaskProcess(targetProcessDefinitionId);
+
+    const sourceInstance = await createSingleInstance(
+      sourceProcessDefinitionId,
+      1,
+    );
+    instancesToCancel.push(sourceInstance.processInstanceKey);
+    await findUserTask(request, sourceInstance.processInstanceKey, 'CREATED');
+
+    // Without a running instance the target's deletion finalizes immediately and
+    // the migration would be refused for a missing definition, not a draining one.
+    const targetInstance = await createSingleInstance(
+      targetProcessDefinitionId,
+      1,
+    );
+    instancesToCancel.push(targetInstance.processInstanceKey);
+    await findUserTask(request, targetInstance.processInstanceKey, 'CREATED');
+
+    await drainProcessDefinition(request, target.processDefinitionKey);
+
+    const res = await request.post(
+      buildUrl('/process-instances/{processInstanceKey}/migration', {
+        processInstanceKey: sourceInstance.processInstanceKey,
+      }),
+      {
+        headers: jsonHeaders(),
+        data: {
+          mappingInstructions: [
+            {
+              sourceElementId: USER_TASK_MODEL_TASK_ID,
+              targetElementId: USER_TASK_MODEL_TASK_ID,
+            },
+          ],
+          targetProcessDefinitionKey: target.processDefinitionKey,
+        },
+      },
+    );
+
+    // As with instance creation, the code depends on whether the serving
+    // partition has already finalized its part of the deletion.
+    expect([404, 409]).toContain(res.status());
+
+    const [afterMigration] = await searchProcessInstances(request, {
+      processDefinitionId: sourceProcessDefinitionId,
+    });
+    expect(afterMigration!.processDefinitionKey).not.toBe(
+      target.processDefinitionKey,
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-start-paths.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-start-paths.spec.ts
@@ -10,11 +10,11 @@ import {expect, test, type APIRequestContext} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import {
   cancelProcessInstance,
-  createSingleInstance,
   deployWithSubstitutions,
 } from '../../../../utils/zeebeClient';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
 import {
+  createInstanceOnceDeployed,
   deployUserTaskProcess,
   drainProcessDefinition,
   expectProcessInstanceCount,
@@ -188,7 +188,7 @@ test.describe('Process Definition Draining Deletion — alternative start paths'
     await deployUserTaskProcess(sourceProcessDefinitionId);
     const target = await deployUserTaskProcess(targetProcessDefinitionId);
 
-    const sourceInstance = await createSingleInstance(
+    const sourceInstance = await createInstanceOnceDeployed(
       sourceProcessDefinitionId,
       1,
     );
@@ -197,7 +197,7 @@ test.describe('Process Definition Draining Deletion — alternative start paths'
 
     // Without a running instance the target's deletion finalizes immediately and
     // the migration would be refused for a missing definition, not a draining one.
-    const targetInstance = await createSingleInstance(
+    const targetInstance = await createInstanceOnceDeployed(
       targetProcessDefinitionId,
       1,
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
@@ -53,7 +53,11 @@ test.beforeAll(async ({request}) => {
 });
 
 test.afterAll(async () => {
-  await cancelProcessInstance(processInstanceKey);
+  // Teardown stays best-effort: a beforeAll that fails before the instance
+  // exists would otherwise throw here and mask the original failure.
+  if (processInstanceKey) {
+    await cancelProcessInstance(processInstanceKey);
+  }
 });
 
 test.describe('Operate Process Definition Draining', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {test} from 'fixtures';
-import {expect} from '@playwright/test';
+import {expect, type Locator, type Page} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToAppHome, tooltipWithText} from '@pages/UtilitiesPage';
 import {
@@ -38,6 +38,28 @@ const UI_REFRESH_TIMEOUT = 15_000;
 const processDefinitionId = uniquePrefixedId('draining-ui');
 
 let processInstanceKey: string;
+
+/**
+ * Opens Operate and waits for its shell, retrying the navigation once: the app
+ * occasionally takes longer than the default expect timeout to come up on a
+ * loaded runner, which would fail a test before it asserts anything.
+ */
+async function openOperateHome(
+  page: Page,
+  operateHomePage: {operateBanner: Locator},
+) {
+  await navigateToAppHome(page, 'operate');
+  await waitForAssertion({
+    assertion: async () => {
+      await expect(operateHomePage.operateBanner).toBeVisible({
+        timeout: UI_REFRESH_TIMEOUT,
+      });
+    },
+    onFailure: async () => {
+      await navigateToAppHome(page, 'operate');
+    },
+  });
+}
 
 test.beforeAll(async ({request}) => {
   const {processDefinitionKey} =
@@ -71,8 +93,7 @@ test.describe('Operate Process Definition Draining', () => {
     operateHomePage,
     operateDashboardPage,
   }) => {
-    await navigateToAppHome(page, 'operate');
-    await expect(operateHomePage.operateBanner).toBeVisible();
+    await openOperateHome(page, operateHomePage);
 
     const item =
       operateDashboardPage.instancesByProcessItemByName(processDefinitionId);
@@ -95,8 +116,7 @@ test.describe('Operate Process Definition Draining', () => {
     operateProcessesPage,
     operateFiltersPanelPage,
   }) => {
-    await navigateToAppHome(page, 'operate');
-    await expect(operateHomePage.operateBanner).toBeVisible();
+    await openOperateHome(page, operateHomePage);
     await operateHomePage.clickProcessesTab();
 
     // The tag replaces the delete action in the diagram panel header, which only
@@ -148,8 +168,7 @@ test.describe('Operate Process Definition Draining', () => {
   }) => {
     // The per-view tests above only prove the marker renders; this one pins down
     // what it says, so a reworded or half-migrated view is caught.
-    await navigateToAppHome(page, 'operate');
-    await expect(operateHomePage.operateBanner).toBeVisible();
+    await openOperateHome(page, operateHomePage);
 
     const item =
       operateDashboardPage.instancesByProcessItemByName(processDefinitionId);
@@ -253,8 +272,7 @@ test.describe('Operate Process Definition Draining — lifecycle and incidents',
 
     await drainProcessDefinition(request, processDefinitionKey);
 
-    await navigateToAppHome(page, 'operate');
-    await expect(operateHomePage.operateBanner).toBeVisible();
+    await openOperateHome(page, operateHomePage);
 
     const item = operateDashboardPage.instancesByProcessItemByName(
       deletedProcessDefinitionId,
@@ -327,8 +345,7 @@ test.describe('Operate Process Definition Draining — lifecycle and incidents',
 
     await drainProcessDefinition(request, processDefinitionKey);
 
-    await navigateToAppHome(page, 'operate');
-    await expect(operateHomePage.operateBanner).toBeVisible();
+    await openOperateHome(page, operateHomePage);
 
     const item = operateDashboardPage.instancesByProcessItemByName(
       incidentProcessDefinitionId,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
@@ -12,6 +12,7 @@ import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToAppHome, tooltipWithText} from '@pages/UtilitiesPage';
 import {
   activateSingleJob,
+  createInstanceOnceDeployed,
   deployUserTaskProcess,
   drainProcessDefinition,
   expectProcessDefinitionDeleted,
@@ -20,7 +21,6 @@ import {
 import {
   cancelProcessInstance,
   createInstances,
-  createSingleInstance,
   deployWithSubstitutions,
 } from 'utils/zeebeClient';
 import {assertStatusCode, buildUrl, jsonHeaders} from 'utils/http';
@@ -43,7 +43,7 @@ test.beforeAll(async ({request}) => {
   const {processDefinitionKey} =
     await deployUserTaskProcess(processDefinitionId);
 
-  const instance = await createSingleInstance(processDefinitionId, 1);
+  const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
   processInstanceKey = instance.processInstanceKey;
   await findUserTask(request, processInstanceKey, 'CREATED');
 
@@ -244,7 +244,10 @@ test.describe('Operate Process Definition Draining — lifecycle and incidents',
     const {processDefinitionKey} = await deployUserTaskProcess(
       deletedProcessDefinitionId,
     );
-    const instance = await createSingleInstance(deletedProcessDefinitionId, 1);
+    const instance = await createInstanceOnceDeployed(
+      deletedProcessDefinitionId,
+      1,
+    );
     instancesToCancel.push(instance.processInstanceKey);
     await findUserTask(request, instance.processInstanceKey, 'CREATED');
 
@@ -361,7 +364,7 @@ test.describe('Operate Process Definition Draining — lifecycle and incidents',
     const {processDefinitionKey} = await deployUserTaskProcess(
       suspendedProcessDefinitionId,
     );
-    const instance = await createSingleInstance(
+    const instance = await createInstanceOnceDeployed(
       suspendedProcessDefinitionId,
       1,
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
@@ -1,0 +1,415 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToAppHome, tooltipWithText} from '@pages/UtilitiesPage';
+import {
+  activateSingleJob,
+  deployUserTaskProcess,
+  drainProcessDefinition,
+  expectProcessDefinitionDeleted,
+  findUserTask,
+} from '@requestHelpers';
+import {
+  cancelProcessInstance,
+  createInstances,
+  createSingleInstance,
+  deployWithSubstitutions,
+} from 'utils/zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from 'utils/http';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {uniquePrefixedId} from 'utils/constants';
+
+const DRAINING_TOOLTIP_ALL_VERSIONS =
+  'One or more versions of this process definition are scheduled for deletion. They stay until their running instances finish, then are removed automatically.';
+const DRAINING_TOOLTIP_VERSION =
+  'This process definition version is scheduled for deletion and will be removed automatically once all of its running instances finish.';
+const DRAINING_TAG_LABEL = 'Draining';
+
+const UI_REFRESH_TIMEOUT = 15_000;
+
+const processDefinitionId = uniquePrefixedId('draining-ui');
+
+let processInstanceKey: string;
+
+test.beforeAll(async ({request}) => {
+  const {processDefinitionKey} =
+    await deployUserTaskProcess(processDefinitionId);
+
+  const instance = await createSingleInstance(processDefinitionId, 1);
+  processInstanceKey = instance.processInstanceKey;
+  await findUserTask(request, processInstanceKey, 'CREATED');
+
+  // Operate's own Delete button is gated for definitions with running instances
+  // (camunda#60910), so the drain is triggered over REST.
+  await drainProcessDefinition(request, processDefinitionKey);
+});
+
+test.afterAll(async () => {
+  await cancelProcessInstance(processInstanceKey);
+});
+
+test.describe('Operate Process Definition Draining', () => {
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Dashboard marks the draining definition with a draining indicator', async ({
+    page,
+    operateHomePage,
+    operateDashboardPage,
+  }) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+
+    const item =
+      operateDashboardPage.instancesByProcessItemByName(processDefinitionId);
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          operateDashboardPage.drainingIndicatorFromItem(item),
+        ).toBeVisible({timeout: UI_REFRESH_TIMEOUT});
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('Processes page shows a draining tag for the selected draining version', async ({
+    page,
+    operateHomePage,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+  }) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+
+    // The tag replaces the delete action in the diagram panel header, which only
+    // renders once a single version is selected.
+    await operateFiltersPanelPage.selectProcess(processDefinitionId);
+    await operateFiltersPanelPage.selectVersion('1');
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(operateProcessesPage.drainingTag).toBeVisible({
+          timeout: UI_REFRESH_TIMEOUT,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('Process instance header shows a draining tag for the running instance', async ({
+    page,
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: processInstanceKey,
+    });
+
+    await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(operateProcessInstancePage.drainingTag).toBeVisible({
+          timeout: UI_REFRESH_TIMEOUT,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('The draining marker carries the same wording on the dashboard, the processes page and the instance view', async ({
+    page,
+    operateHomePage,
+    operateDashboardPage,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateProcessInstancePage,
+  }) => {
+    // The per-view tests above only prove the marker renders; this one pins down
+    // what it says, so a reworded or half-migrated view is caught.
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+
+    const item =
+      operateDashboardPage.instancesByProcessItemByName(processDefinitionId);
+    const dashboardIndicator =
+      operateDashboardPage.drainingIndicatorFromItem(item);
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(dashboardIndicator).toBeVisible({
+          timeout: UI_REFRESH_TIMEOUT,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+
+    // The dashboard row aggregates every version, so it carries the all-versions
+    // wording rather than the version-scoped "Draining" tag.
+    await dashboardIndicator.hover();
+    await expect(
+      tooltipWithText(page, DRAINING_TOOLTIP_ALL_VERSIONS),
+    ).toBeVisible();
+
+    await operateHomePage.clickProcessesTab();
+    await operateFiltersPanelPage.selectProcess(processDefinitionId);
+    await operateFiltersPanelPage.selectVersion('1');
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(operateProcessesPage.drainingTag).toBeVisible({
+          timeout: UI_REFRESH_TIMEOUT,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+    await expect(operateProcessesPage.drainingTag).toHaveText(
+      DRAINING_TAG_LABEL,
+    );
+    await operateProcessesPage.drainingTag.hover();
+    await expect(tooltipWithText(page, DRAINING_TOOLTIP_VERSION)).toBeVisible();
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: processInstanceKey,
+    });
+    await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(operateProcessInstancePage.drainingTag).toBeVisible({
+          timeout: UI_REFRESH_TIMEOUT,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+    await expect(operateProcessInstancePage.drainingTag).toHaveText(
+      DRAINING_TAG_LABEL,
+    );
+    await operateProcessInstancePage.drainingTag.hover();
+    await expect(tooltipWithText(page, DRAINING_TOOLTIP_VERSION)).toBeVisible();
+  });
+});
+
+test.describe('Operate Process Definition Draining — lifecycle and incidents', () => {
+  let instancesToCancel: string[] = [];
+
+  test.beforeEach(() => {
+    instancesToCancel = [];
+  });
+
+  // These tests own their definitions. Cancelling here rather than in each test
+  // body means a failed assertion cannot leak one as permanently DRAINING.
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+    for (const processInstanceKey of instancesToCancel.filter(Boolean)) {
+      await cancelProcessInstance(processInstanceKey);
+    }
+  });
+
+  test('The definition leaves the dashboard once the drain has finished', async ({
+    page,
+    request,
+    operateHomePage,
+    operateDashboardPage,
+  }) => {
+    const deletedProcessDefinitionId = uniquePrefixedId('draining-ui-gone');
+    const {processDefinitionKey} = await deployUserTaskProcess(
+      deletedProcessDefinitionId,
+    );
+    const instance = await createSingleInstance(deletedProcessDefinitionId, 1);
+    instancesToCancel.push(instance.processInstanceKey);
+    await findUserTask(request, instance.processInstanceKey, 'CREATED');
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+
+    const item = operateDashboardPage.instancesByProcessItemByName(
+      deletedProcessDefinitionId,
+    );
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          operateDashboardPage.drainingIndicatorFromItem(item),
+        ).toBeVisible({timeout: UI_REFRESH_TIMEOUT});
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+
+    // The dashboard panel counts running instances, so the whole row goes, not
+    // just the marker.
+    await cancelProcessInstance(instance.processInstanceKey);
+    await expectProcessDefinitionDeleted(request, processDefinitionKey);
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(item).toHaveCount(0, {timeout: UI_REFRESH_TIMEOUT});
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('A draining definition still reports its incident and active instance counts', async ({
+    page,
+    request,
+    operateHomePage,
+    operateDashboardPage,
+  }) => {
+    const incidentProcessDefinitionId = uniquePrefixedId(
+      'draining-ui-incident',
+    );
+    const jobType = uniquePrefixedId('draining-ui-jobtype');
+    const deployment = await deployWithSubstitutions(
+      './resources/incidentGeneratorProcess.bpmn',
+      {
+        incidentGeneratorProcess: incidentProcessDefinitionId,
+        'type="incidentGenerator"': `type="${jobType}"`,
+        // The dashboard row is found by the rendered BPMN name, which in this model
+        // differs from the process id.
+        'name="Incident Generator Process"': `name="${incidentProcessDefinitionId}"`,
+      },
+    );
+    const {processDefinitionKey} = deployment.processes[0];
+
+    const instances = await createInstances(incidentProcessDefinitionId, 1, 3);
+    instancesToCancel.push(
+      ...instances.map((instance) => instance.processInstanceKey),
+    );
+
+    // One instance goes into an incident, two stay active, so the dashboard has
+    // to split the counts rather than lump them together.
+    const failedInstanceKey = instances[0]!.processInstanceKey;
+    const jobKey = await activateSingleJob(request, jobType, failedInstanceKey);
+
+    await assertStatusCode(
+      await request.post(buildUrl('/jobs/{jobKey}/failure', {jobKey}), {
+        headers: jsonHeaders(),
+        data: {retries: 0, errorMessage: 'draining-ui incident'},
+      }),
+      204,
+    );
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+
+    const item = operateDashboardPage.instancesByProcessItemByName(
+      incidentProcessDefinitionId,
+    );
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          operateDashboardPage.drainingIndicatorFromItem(item),
+        ).toBeVisible({timeout: UI_REFRESH_TIMEOUT});
+        await expect(
+          operateDashboardPage.incidentBadgeFromItem(item),
+        ).toHaveText('1', {timeout: UI_REFRESH_TIMEOUT});
+        await expect(operateDashboardPage.activeBadgeFromItem(item)).toHaveText(
+          '2',
+          {timeout: UI_REFRESH_TIMEOUT},
+        );
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('The instance view keeps the draining tag while the instance is suspended', async ({
+    page,
+    request,
+    operateProcessInstancePage,
+  }) => {
+    const suspendedProcessDefinitionId = uniquePrefixedId(
+      'draining-ui-suspended',
+    );
+    const {processDefinitionKey} = await deployUserTaskProcess(
+      suspendedProcessDefinitionId,
+    );
+    const instance = await createSingleInstance(
+      suspendedProcessDefinitionId,
+      1,
+    );
+    instancesToCancel.push(instance.processInstanceKey);
+    await findUserTask(request, instance.processInstanceKey, 'CREATED');
+
+    await drainProcessDefinition(request, processDefinitionKey);
+
+    await assertStatusCode(
+      await request.post(
+        buildUrl('/process-instances/{processInstanceKey}/suspension', {
+          processInstanceKey: instance.processInstanceKey,
+        }),
+        {headers: jsonHeaders()},
+      ),
+      204,
+    );
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instance.processInstanceKey,
+    });
+    await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+
+    // Confirms the suspension reached this view, so the draining assertion below
+    // cannot pass against an instance that is merely running.
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(operateProcessInstancePage.suspendedStateIcon).toBeVisible(
+          {timeout: UI_REFRESH_TIMEOUT},
+        );
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+
+    // Suspending changes the instance's state, not its definition's — otherwise
+    // the one instance blocking the deletion is also the view that hides why.
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(operateProcessInstancePage.drainingTag).toBeVisible({
+          timeout: UI_REFRESH_TIMEOUT,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+    await expect(operateProcessInstancePage.drainingTag).toHaveText(
+      DRAINING_TAG_LABEL,
+    );
+    await operateProcessInstancePage.drainingTag.hover();
+    await expect(tooltipWithText(page, DRAINING_TOOLTIP_VERSION)).toBeVisible();
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -50,8 +50,15 @@ export const extendedAssertionOptions = {
   timeout: 90_000,
 };
 
-export const uniqueBusinessId = (prefix = 'biz'): string => {
+// Prefixed unique id for a resource a test deploys or creates — process
+// definition ids, message names, job types. Parallel workers share a cluster, so
+// a fixed id would let one test's deployment or subscription answer another's.
+export const uniquePrefixedId = (prefix: string): string => {
   return `${prefix}-${generateUniqueId()}`;
+};
+
+export const uniqueBusinessId = (prefix = 'biz'): string => {
+  return uniquePrefixedId(prefix);
 };
 
 // Create unique auth role with optional custom ID

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -12,6 +12,7 @@ export * from './resource-requestHelpers';
 export * from './form-requestHelpers';
 export * from './user-task-requestHelpers';
 export * from './process-instance-requestHelpers';
+export * from './process-definition-requestHelpers';
 export * from './get-value-from-state-requestHelpers';
 export * from './batch-operation-requestHelpers';
 export {createRoleAndStoreResponseFields} from './role-requestHelpers';
@@ -54,6 +55,7 @@ export {
   type Authorization,
   expectAuthorizationCanNotBeFound,
 } from './authorization-requestHelpers';
+export {searchVariableByNameAndProcessInstanceKey} from './variable-requestHelpers';
 export {assertRoleInResponse} from './role-requestHelpers';
 export {assertClientsInResponse} from './clients-requestHelpers';
 export {
@@ -61,6 +63,7 @@ export {
   activateJobToObtainAValidJobKey,
   activateJobAndGetHeaders,
   activateJobsByType,
+  activateSingleJob,
   activateFirstJobVariables,
   completeJob,
   countJobsByType,
@@ -81,6 +84,7 @@ export {
   assertNoMetadataLeak,
 } from './cluster-variable-requestHelpers';
 export {
+  searchIncidentByPIK,
   createProcessInstanceWithAJob,
   createSingleIncidentProcessInstance,
   createTwoIncidentsInOneProcess,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -290,3 +290,22 @@ export interface StatisticsJobItem {
   };
   workers: number;
 }
+
+/**
+ * Retries until exactly one job of the given type is activatable for the process
+ * instance and returns its key. Activation only becomes possible once the token
+ * has reached the task, so the wait is on the engine rather than on an index.
+ */
+export async function activateSingleJob(
+  request: APIRequestContext,
+  jobType: string,
+  processInstanceKey: string,
+): Promise<number> {
+  let jobKey = 0;
+  await expect(async () => {
+    const jobs = await activateJobsByType(request, jobType, processInstanceKey);
+    expect(jobs).toHaveLength(1);
+    jobKey = Number(jobs[0]!.jobKey);
+  }).toPass(defaultAssertionOptions);
+  return jobKey;
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-definition-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-definition-requestHelpers.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  expect,
+  type APIRequestContext,
+  type APIResponse,
+} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {deployWithSubstitutions} from '../zeebeClient';
+import {defaultAssertionOptions, extendedAssertionOptions} from '../constants';
+import {validateResponse} from 'json-body-assertions';
+import {deleteResource} from './resource-requestHelpers';
+
+const PROCESS_DEFINITION_SEARCH_ENDPOINT = '/process-definitions/search';
+
+export type ProcessDefinitionState = 'ACTIVE' | 'DRAINING' | 'DELETED';
+
+export type ProcessDefinitionItem = {
+  processDefinitionKey: string;
+  processDefinitionId: string;
+  version: number;
+  state: ProcessDefinitionState;
+};
+
+export function searchProcessDefinitions(
+  request: APIRequestContext,
+  body: Record<string, unknown>,
+): Promise<APIResponse> {
+  return request.post(buildUrl(PROCESS_DEFINITION_SEARCH_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: body,
+  });
+}
+
+export async function searchProcessDefinitionItems(
+  request: APIRequestContext,
+  body: Record<string, unknown>,
+): Promise<ProcessDefinitionItem[]> {
+  const res = await searchProcessDefinitions(request, body);
+  await assertStatusCode(res, 200);
+  await validateResponse(
+    {path: PROCESS_DEFINITION_SEARCH_ENDPOINT, method: 'POST', status: '200'},
+    res,
+  );
+  return (await res.json()).items as ProcessDefinitionItem[];
+}
+
+/**
+ * Polls until the definition reports `expectedState`. `DRAINING` is only
+ * observable while an instance still runs, so callers must start one before
+ * deleting; `extendedAssertionOptions` suits the terminal `DELETED`, written
+ * only once every partition has reported `FULLY_DELETED`.
+ */
+export async function expectProcessDefinitionState(
+  request: APIRequestContext,
+  processDefinitionKey: string,
+  expectedState: ProcessDefinitionState,
+  assertionOptions = defaultAssertionOptions,
+): Promise<void> {
+  await expect(async () => {
+    const items = await searchProcessDefinitionItems(request, {
+      filter: {processDefinitionKey},
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]!.state).toBe(expectedState);
+  }).toPass(assertionOptions);
+}
+
+export async function expectProcessDefinitionDeleted(
+  request: APIRequestContext,
+  processDefinitionKey: string,
+): Promise<void> {
+  await expectProcessDefinitionState(
+    request,
+    processDefinitionKey,
+    'DELETED',
+    extendedAssertionOptions,
+  );
+}
+
+/**
+ * Terminal state for a deletion with `deleteHistory: true`: the `DELETED`
+ * record other deletions leave behind is itself purged, so waiting for
+ * `DELETED` would only ever pass by catching the state before the purge.
+ */
+export async function expectProcessDefinitionPurged(
+  request: APIRequestContext,
+  processDefinitionKey: string,
+): Promise<void> {
+  await expect(async () => {
+    const items = await searchProcessDefinitionItems(request, {
+      filter: {processDefinitionKey},
+    });
+    expect(items).toHaveLength(0);
+  }).toPass(extendedAssertionOptions);
+}
+
+/**
+ * Returns the raw response — the same request answers 200, 404 and 409
+ * depending on the definition's state.
+ */
+export function deleteProcessDefinition(
+  request: APIRequestContext,
+  processDefinitionKey: string,
+  deleteHistory = false,
+): Promise<APIResponse> {
+  return deleteResource(request, processDefinitionKey, {data: {deleteHistory}});
+}
+
+/**
+ * Deletes a definition with a running instance and waits until it is
+ * observably `DRAINING`. Waiting is not cosmetic: deletion is distributed per
+ * partition, so a request right after the 200 can still be served by a
+ * partition that has not applied the new state.
+ */
+export async function drainProcessDefinition(
+  request: APIRequestContext,
+  processDefinitionKey: string,
+  deleteHistory = false,
+): Promise<void> {
+  await assertStatusCode(
+    await deleteProcessDefinition(request, processDefinitionKey, deleteHistory),
+    200,
+  );
+  await expectProcessDefinitionState(request, processDefinitionKey, 'DRAINING');
+}
+
+const USER_TASK_MODEL = './resources/Zeebe_User_Task_Process.bpmn';
+const USER_TASK_MODEL_ID = 'Zeebe_User_Task_Process';
+
+/**
+ * Deploys the user-task model under the given process id — the workhorse of
+ * the draining tests, which need a definition that parks on a user task.
+ *
+ * Redeploying the same id needs a `nameSuffix`: without a content change
+ * Zeebe deduplicates the deployment and returns the existing version.
+ */
+export async function deployUserTaskProcess(
+  processDefinitionId: string,
+  nameSuffix = '',
+) {
+  const deployment = await deployWithSubstitutions(USER_TASK_MODEL, {
+    [USER_TASK_MODEL_ID]: processDefinitionId,
+    ...(nameSuffix
+      ? {
+          [`name="${processDefinitionId}"`]: `name="${processDefinitionId}${nameSuffix}"`,
+        }
+      : {}),
+  });
+  return deployment.processes[0];
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-definition-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-definition-requestHelpers.ts
@@ -48,7 +48,7 @@ export async function searchProcessDefinitionItems(
     {path: PROCESS_DEFINITION_SEARCH_ENDPOINT, method: 'POST', status: '200'},
     res,
   );
-  return (await res.json()).items as ProcessDefinitionItem[];
+  return ((await res.json()).items ?? []) as ProcessDefinitionItem[];
 }
 
 /**

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-definition-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-definition-requestHelpers.ts
@@ -12,7 +12,9 @@ import {
   type APIResponse,
 } from '@playwright/test';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
-import {deployWithSubstitutions} from '../zeebeClient';
+import {createSingleInstance, deployWithSubstitutions} from '../zeebeClient';
+import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types';
+import {sleep} from '../sleep';
 import {defaultAssertionOptions, extendedAssertionOptions} from '../constants';
 import {validateResponse} from 'json-body-assertions';
 import {deleteResource} from './resource-requestHelpers';
@@ -129,6 +131,39 @@ export async function drainProcessDefinition(
     200,
   );
   await expectProcessDefinitionState(request, processDefinitionKey, 'DRAINING');
+}
+
+/**
+ * Starts an instance of a specific version, retrying while the create is
+ * rejected `NOT_FOUND`.
+ *
+ * A deployment reaches the partitions asynchronously, so a create issued right
+ * after one can land on a partition that has not applied it yet and be refused
+ * as if the definition did not exist. Only that rejection is retried — a
+ * `NOT_FOUND` from a definition already deleted would surface once the budget
+ * runs out, and every other rejection is raised immediately.
+ */
+export async function createInstanceOnceDeployed(
+  processDefinitionId: string,
+  processDefinitionVersion: number,
+  variables?: JSONDoc,
+) {
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    try {
+      return await createSingleInstance(
+        processDefinitionId,
+        processDefinitionVersion,
+        variables,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes('NOT_FOUND') || Date.now() > deadline) {
+        throw error;
+      }
+      await sleep(500);
+    }
+  }
 }
 
 const USER_TASK_MODEL = './resources/Zeebe_User_Task_Process.bpmn';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -9,7 +9,7 @@
 import type {APIRequestContext, APIResponse} from 'playwright-core';
 import {expect} from '@playwright/test';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
-import {defaultAssertionOptions} from '../constants';
+import {DEFAULT_PAGE_LIMIT, defaultAssertionOptions} from '../constants';
 import {cancelProcessInstance} from '../zeebeClient';
 import {validateResponse} from 'json-body-assertions';
 import {expectBatchState} from './batch-operation-requestHelpers';
@@ -383,4 +383,40 @@ export async function clearAllProcessInstances(
       );
     }
   }
+}
+
+export type ProcessInstanceItem = {
+  processInstanceKey: string;
+  processDefinitionKey: string;
+  processDefinitionId: string;
+  state: string;
+};
+
+export async function searchProcessInstances(
+  request: APIRequestContext,
+  filter: Record<string, unknown>,
+): Promise<ProcessInstanceItem[]> {
+  const res = await request.post(buildUrl('/process-instances/search'), {
+    headers: jsonHeaders(),
+    data: {filter, page: {limit: DEFAULT_PAGE_LIMIT}},
+  });
+  await assertStatusCode(res, 200);
+  await validateResponse(
+    {path: '/process-instances/search', method: 'POST', status: '200'},
+    res,
+  );
+  return ((await res.json()).items ?? []) as ProcessInstanceItem[];
+}
+
+export async function expectProcessInstanceCount(
+  request: APIRequestContext,
+  filter: Record<string, unknown>,
+  expectedCount: number,
+  assertionOptions = defaultAssertionOptions,
+): Promise<void> {
+  await expect(async () => {
+    expect(await searchProcessInstances(request, filter)).toHaveLength(
+      expectedCount,
+    );
+  }).toPass(assertionOptions);
 }


### PR DESCRIPTION
## Description

Adds QA-owned coverage for draining deletion of process definitions to the C8 Orchestration Cluster E2E Test Suite: 34 tests across four API specs and one Operate spec.

Deleting a definition with running instances used to stall the shared `DEPLOYMENT` distribution queue and block every later deployment cluster-wide. The definition is now marked `DRAINING`, the queue is acknowledged immediately, and each partition removes the definition once its own last instance finishes. None of that was asserted in this suite.

The developers' engine tests already cover the mechanics thoroughly (`DrainingProcessDefinitionTest`, `ProcessDefinitionMetricsTest` and friends), but against `RecordingExporter` — not the REST surface and not the exporter path into secondary storage. That is the gap #61277 (`DRAINING` never exported) and #60472 (RDBMS state stuck at `DRAINING`) both shipped through. Every test here therefore asserts the `ACTIVE → DRAINING → DELETED` **transition** rather than only the end state, since a test that waits for `DELETED` alone passes straight through both defects.

### What is covered

- **Queue unblock** — driven over REST with a probe deployment plus three instances per partition. The `CommandDistribution` records the engine tests assert on are not reachable from the API, so this uses the functional proxy: an unrelated deployment must still reach every partition while the first definition drains.
- **Lifecycle** — drain to completion and to cancellation, a zero-instance delete that never parks in `DRAINING`, per-partition hold with six instances ended one at a time, call activity children.
- **Blocked creation** — by key, by id across four version-resolution cases, message start events, migration onto a draining target, and a call activity resolving a draining child.
- **Work already in flight, which must not be blocked** — job fail/resolve/complete, message correlation, variables, a firing timer, suspend and resume.
- **`deleteHistory`** both ways, including `batchOperation: null` while the definition is still in runtime state, and the history-deletion batch operation reaching `COMPLETED`.
- **Search contract** — `state` field, `state` filter, `400` on a value outside the enum, `isLatestVersion` against a draining latest.
- **Operate** — the draining marker on the dashboard, processes page and instance header, its verbatim wording, counts while draining, and the row disappearing once the drain finalizes.

Drains finalize by genuine completion in five tests (user task, job, message, timer, resume-then-complete) and by cancellation in the rest, since the engine contract is "completes **or** terminates" and those are different end states.

### Notes for the reviewer

- **Verified on both secondary storages** — `camunda/camunda:8.10-SNAPSHOT`, four partitions: 34/34 on Elasticsearch and 34/34 on RDBMS, with no behavioural difference between them.
- **Second commit is unrelated** and can be split out if preferred: `process-definition-get-start-form-api.spec.ts` asserted the start form's version as a literal `1`, while its `beforeAll` deploys the form unconditionally — so the spec fails permanently from its second run against any cluster. Green in CI only because every pipeline gets a clean cluster. It now reads the version from the deployment response.
- Helpers were shared rather than duplicated: `process-definition-requestHelpers` owns `deleteProcessDefinition` and `drainProcessDefinition`, and the instance, variable and job assertions reuse what the suite already had.

## Checklist

- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.
 - [x] Run locally against both backends (34/34 each), plus regression runs of `tests/api/v2/resource`, `variable`, `process-instance`, `process-definition` and `job`. **The on-demand workflow has not been triggered yet** — happy to kick it off and post the results here.
 - [x] Two pre-existing failures seen in those regression runs and confirmed **not** caused by this PR (they reproduce with these changes stashed): the two `Business ID - Uniqueness Enforcement` cases in `process-instance-business-id-api.spec.ts`. That spec uses `uniqueBusinessId` throughout, so it is not a test-isolation problem and may be worth a separate look.

## Related issues

Relates to #55930
Covers the automation gaps identified for #56995
