### PR TITLE
feat: expose mapping rule UI on SaaS when an additional IdP is configured

### DIFF
--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -54,22 +55,31 @@ public class AdminClientConfigController {
     final boolean isSaas = SaasConfigurationHelper.isSaas(cslProperties.getSaas());
     final boolean isNewDesignSystemEnabled =
         resolvedWebappConfiguration.resolveNewDesignSystemEnabled(isSaas);
+    final var namedProviders = namedProviders(cslProperties);
+    final boolean isAdditionalIdpConfigured = isAdditionalIdpConfigured(namedProviders);
 
     LOG.info(
         "Admin new design system resolved to {} (explicit override={}, isSaas={})",
         isNewDesignSystemEnabled,
         resolvedWebappConfiguration.getNewDesignSystemEnabled(),
         isSaas);
+    LOG.info(
+        "Admin additional IdP resolved to {} (namedProviders={})",
+        isAdditionalIdpConfigured,
+        namedProviders.keySet());
 
     objectMapper = new ObjectMapper();
-    clientConfigAsJS = generateClientConfig(cslProperties, isNewDesignSystemEnabled);
+    clientConfigAsJS =
+        generateClientConfig(cslProperties, isNewDesignSystemEnabled, isAdditionalIdpConfigured);
   }
 
   private String generateClientConfig(
       final CamundaSecurityLibraryProperties cslProperties,
-      final boolean isNewDesignSystemEnabled) {
+      final boolean isNewDesignSystemEnabled,
+      final boolean isAdditionalIdpConfigured) {
     try {
-      final Map<String, Object> config = createConfigMap(cslProperties, isNewDesignSystemEnabled);
+      final Map<String, Object> config =
+          createConfigMap(cslProperties, isNewDesignSystemEnabled, isAdditionalIdpConfigured);
       final String configJson = objectMapper.writeValueAsString(config);
       return String.format(CONFIG_JS_TEMPLATE, configJson);
     } catch (final JsonProcessingException e) {
@@ -80,7 +90,8 @@ public class AdminClientConfigController {
 
   private Map<String, Object> createConfigMap(
       final CamundaSecurityLibraryProperties cslProperties,
-      final boolean isNewDesignSystemEnabled) {
+      final boolean isNewDesignSystemEnabled,
+      final boolean isAdditionalIdpConfigured) {
     final var config = new java.util.HashMap<String, Object>();
     final var saasConfiguration = cslProperties.getSaas();
 
@@ -88,8 +99,7 @@ public class AdminClientConfigController {
     config.put(IS_CAMUNDA_GROUPS_ENABLED, String.valueOf(isCamundaGroupsEnabled(cslProperties)));
     config.put(
         IS_TENANTS_API_ENABLED, String.valueOf(cslProperties.getMultiTenancy().isApiEnabled()));
-    config.put(
-        IS_ADDITIONAL_IDP_CONFIGURED, String.valueOf(isAdditionalIdpConfigured(cslProperties)));
+    config.put(IS_ADDITIONAL_IDP_CONFIGURED, String.valueOf(isAdditionalIdpConfigured));
     config.put(ORGANIZATION_ID, saasConfiguration.getOrganizationId());
     config.put(CLUSTER_ID, saasConfiguration.getClusterId());
     config.put(ID_PATTERN, cslProperties.getIdValidationPattern());
@@ -104,15 +114,19 @@ public class AdminClientConfigController {
     return AuthenticationMethod.OIDC.equals(cslProperties.getAuthentication().getMethod());
   }
 
-  private boolean isAdditionalIdpConfigured(final CamundaSecurityLibraryProperties cslProperties) {
+  private static Map<String, OidcConfiguration> namedProviders(
+      final CamundaSecurityLibraryProperties cslProperties) {
     final var providers = cslProperties.getAuthentication().getProviders();
     final var namedProviders = providers != null ? providers.getOidc() : null;
-    if (namedProviders == null) {
-      return false;
-    }
+    return namedProviders != null ? namedProviders : Map.of();
+  }
+
+  // Only the named providers.oidc.* slot counts (the BYOIDP additional-IdP surface); the flat
+  // authentication.oidc block is the primary IdP and is intentionally excluded.
+  private boolean isAdditionalIdpConfigured(final Map<String, OidcConfiguration> namedProviders) {
     return namedProviders.values().stream()
         .filter(Objects::nonNull)
-        .anyMatch(OidcConfiguration::isAnyPropertySet);
+        .anyMatch(oidc -> StringUtils.hasText(oidc.getClientId()));
   }
 
   private boolean isCamundaGroupsEnabled(final CamundaSecurityLibraryProperties cslProperties) {

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
@@ -12,11 +12,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.api.model.config.oidc.OidcConfiguration;
 import io.camunda.security.configuration.SaasConfigurationHelper;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
 import io.swagger.v3.oas.annotations.Hidden;
 import java.util.Map;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +33,7 @@ public class AdminClientConfigController {
   private static final String IS_OIDC = "isOidc";
   private static final String IS_CAMUNDA_GROUPS_ENABLED = "isCamundaGroupsEnabled";
   private static final String IS_TENANTS_API_ENABLED = "isTenantsApiEnabled";
+  private static final String IS_ADDITIONAL_IDP_CONFIGURED = "isAdditionalIdpConfigured";
   private static final String ORGANIZATION_ID = "organizationId";
   private static final String CLUSTER_ID = "clusterId";
   private static final String ID_PATTERN = "idPattern";
@@ -85,6 +88,8 @@ public class AdminClientConfigController {
     config.put(IS_CAMUNDA_GROUPS_ENABLED, String.valueOf(isCamundaGroupsEnabled(cslProperties)));
     config.put(
         IS_TENANTS_API_ENABLED, String.valueOf(cslProperties.getMultiTenancy().isApiEnabled()));
+    config.put(
+        IS_ADDITIONAL_IDP_CONFIGURED, String.valueOf(isAdditionalIdpConfigured(cslProperties)));
     config.put(ORGANIZATION_ID, saasConfiguration.getOrganizationId());
     config.put(CLUSTER_ID, saasConfiguration.getClusterId());
     config.put(ID_PATTERN, cslProperties.getIdValidationPattern());
@@ -97,6 +102,17 @@ public class AdminClientConfigController {
 
   private boolean isOidcAuthentication(final CamundaSecurityLibraryProperties cslProperties) {
     return AuthenticationMethod.OIDC.equals(cslProperties.getAuthentication().getMethod());
+  }
+
+  private boolean isAdditionalIdpConfigured(final CamundaSecurityLibraryProperties cslProperties) {
+    final var providers = cslProperties.getAuthentication().getProviders();
+    final var namedProviders = providers != null ? providers.getOidc() : null;
+    if (namedProviders == null) {
+      return false;
+    }
+    return namedProviders.values().stream()
+        .filter(Objects::nonNull)
+        .anyMatch(OidcConfiguration::isAnyPropertySet);
   }
 
   private boolean isCamundaGroupsEnabled(final CamundaSecurityLibraryProperties cslProperties) {

--- a/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
@@ -24,8 +24,10 @@ import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.security.api.model.config.SaasConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.api.model.config.oidc.OidcProvidersConfiguration;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -175,6 +177,87 @@ public class AdminClientConfigControllerTest {
         .containsEntry("isNewDesignSystemEnabled", "true");
     assertThat(extractConfig(selfManagedProperties, disabledConfiguration))
         .containsEntry("isNewDesignSystemEnabled", "false");
+  }
+
+  @Test
+  void shouldSetAdditionalIdpConfiguredWhenNamedProviderHasContent() throws Exception {
+    // given
+    final var cslProperties =
+        createCamundaSecurityLibraryProperties(
+            AuthenticationMethod.OIDC, null, false, "test-org", "test-cluster");
+    final var namedProvider = new OidcConfiguration();
+    namedProvider.setIssuerUri("https://customer-idp.example.com");
+    final var providers = new OidcProvidersConfiguration();
+    providers.setOidc(Map.of("entra", namedProvider));
+    cslProperties.getAuthentication().setProviders(providers);
+    final var controller = new AdminClientConfigController(cslProperties, null);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final var config = extractConfigFromResponse(performGetConfig());
+
+    // then
+    assertThat(config).containsEntry("isAdditionalIdpConfigured", "true");
+  }
+
+  @Test
+  void shouldNotSetAdditionalIdpConfiguredWhenNoNamedProviderConfigured() throws Exception {
+    // given
+    final var cslProperties =
+        createCamundaSecurityLibraryProperties(
+            AuthenticationMethod.OIDC, null, false, "test-org", "test-cluster");
+    final var controller = new AdminClientConfigController(cslProperties, null);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final var config = extractConfigFromResponse(performGetConfig());
+
+    // then
+    assertThat(config).containsEntry("isAdditionalIdpConfigured", "false");
+  }
+
+  @Test
+  void shouldNotSetAdditionalIdpConfiguredWhenNamedProviderHasNoContent() throws Exception {
+    // given: a named provider map entry exists but carries no actual configuration
+    final var cslProperties =
+        createCamundaSecurityLibraryProperties(
+            AuthenticationMethod.OIDC, null, false, "test-org", "test-cluster");
+    final var providers = new OidcProvidersConfiguration();
+    providers.setOidc(Map.of("entra", new OidcConfiguration()));
+    cslProperties.getAuthentication().setProviders(providers);
+    final var controller = new AdminClientConfigController(cslProperties, null);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final var config = extractConfigFromResponse(performGetConfig());
+
+    // then
+    assertThat(config).containsEntry("isAdditionalIdpConfigured", "false");
+  }
+
+  @Test
+  void shouldNotSetAdditionalIdpConfiguredWhenNamedProviderMapContainsNullValue() throws Exception {
+    // given: a named provider id is present but its configuration entry is null
+    final var cslProperties =
+        createCamundaSecurityLibraryProperties(
+            AuthenticationMethod.OIDC, null, false, "test-org", "test-cluster");
+    final var providers = new OidcProvidersConfiguration();
+    final Map<String, OidcConfiguration> oidcProvidersWithNullEntry = new HashMap<>();
+    oidcProvidersWithNullEntry.put("entra", null);
+    providers.setOidc(oidcProvidersWithNullEntry);
+    cslProperties.getAuthentication().setProviders(providers);
+    final var controller = new AdminClientConfigController(cslProperties, null);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final var config = extractConfigFromResponse(performGetConfig());
+
+    // then
+    assertThat(config).containsEntry("isAdditionalIdpConfigured", "false");
+  }
+
+  private String performGetConfig() throws Exception {
+    return mockMvc.perform(get("/admin/config.js")).andReturn().getResponse().getContentAsString();
   }
 
   private CamundaSecurityLibraryProperties createCamundaSecurityLibraryProperties(

--- a/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
@@ -187,6 +187,7 @@ public class AdminClientConfigControllerTest {
             AuthenticationMethod.OIDC, null, false, "test-org", "test-cluster");
     final var namedProvider = new OidcConfiguration();
     namedProvider.setIssuerUri("https://customer-idp.example.com");
+    namedProvider.setClientId("customer-client-id");
     final var providers = new OidcProvidersConfiguration();
     providers.setOidc(Map.of("entra", namedProvider));
     cslProperties.getAuthentication().setProviders(providers);
@@ -245,6 +246,47 @@ public class AdminClientConfigControllerTest {
     final Map<String, OidcConfiguration> oidcProvidersWithNullEntry = new HashMap<>();
     oidcProvidersWithNullEntry.put("entra", null);
     providers.setOidc(oidcProvidersWithNullEntry);
+    cslProperties.getAuthentication().setProviders(providers);
+    final var controller = new AdminClientConfigController(cslProperties, null);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final var config = extractConfigFromResponse(performGetConfig());
+
+    // then
+    assertThat(config).containsEntry("isAdditionalIdpConfigured", "false");
+  }
+
+  @Test
+  void shouldNotSetAdditionalIdpConfiguredWhenOnlyFlatProviderIsConfigured() throws Exception {
+    // given: the flat authentication.oidc slot (the primary IdP) is fully configured, but no
+    // named provider exists
+    final var cslProperties =
+        createCamundaSecurityLibraryProperties(
+            AuthenticationMethod.OIDC, null, false, "test-org", "test-cluster");
+    cslProperties.getAuthentication().getOidc().setClientId("primary-client-id");
+    cslProperties.getAuthentication().getOidc().setIssuerUri("https://primary-idp.example.com");
+    final var controller = new AdminClientConfigController(cslProperties, null);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final var config = extractConfigFromResponse(performGetConfig());
+
+    // then
+    assertThat(config).containsEntry("isAdditionalIdpConfigured", "false");
+  }
+
+  @Test
+  void shouldNotSetAdditionalIdpConfiguredWhenNamedProviderHasNoClientId() throws Exception {
+    // given: a named provider deviates from the default configuration (e.g. a groups claim) but
+    // has no clientId, so it cannot back a working registration
+    final var cslProperties =
+        createCamundaSecurityLibraryProperties(
+            AuthenticationMethod.OIDC, null, false, "test-org", "test-cluster");
+    final var namedProvider = new OidcConfiguration();
+    namedProvider.setGroupsClaim("groups");
+    final var providers = new OidcProvidersConfiguration();
+    providers.setOidc(Map.of("entra", namedProvider));
     cslProperties.getAuthentication().setProviders(providers);
     final var controller = new AdminClientConfigController(cslProperties, null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();

--- a/identity/client/src/components/global/useGlobalRoutes.tsx
+++ b/identity/client/src/components/global/useGlobalRoutes.tsx
@@ -33,6 +33,13 @@ export const useGlobalRoutes = () => {
   const { t } = useTranslate();
   const { pathname } = useLocation();
 
+  const mappingRulesRoute = {
+    path: `${Paths.mappingRules()}/*`,
+    key: Paths.mappingRules(),
+    label: t("mappingRules"),
+    element: <MappingRules />,
+  };
+
   const OIDCDependentRoutes = !isOIDC
     ? [
         {
@@ -42,16 +49,14 @@ export const useGlobalRoutes = () => {
           element: <Users />,
         },
       ]
-    : !isSaaS || isAdditionalIdpConfigured
-      ? [
-          {
-            path: `${Paths.mappingRules()}/*`,
-            key: Paths.mappingRules(),
-            label: t("mappingRules"),
-            element: <MappingRules />,
-          },
-        ]
+    : !isSaaS
+      ? [mappingRulesRoute]
       : [];
+
+  // Kept out of OIDCDependentRoutes, whose first entry sets the index-route
+  // redirect (GlobalRoutes.tsx), so it doesn't change the SaaS landing page.
+  const saasMappingRulesRoutes =
+    isOIDC && isSaaS && isAdditionalIdpConfigured ? [mappingRulesRoute] : [];
 
   const camundaGroupsDependentRoutes = isCamundaGroupsEnabled
     ? [
@@ -134,6 +139,7 @@ export const useGlobalRoutes = () => {
       label: t("operationsLog"),
       element: <OperationsLog />,
     },
+    ...saasMappingRulesRoutes,
   ];
 
   return routes.map((route) => ({

--- a/identity/client/src/components/global/useGlobalRoutes.tsx
+++ b/identity/client/src/components/global/useGlobalRoutes.tsx
@@ -19,6 +19,7 @@ import OperationsLog from "src/pages/operations-log";
 import GlobalTaskListeners from "src/pages/global-task-listeners";
 import McpProcesses from "src/pages/mcp-processes";
 import {
+  isAdditionalIdpConfigured,
   isCamundaGroupsEnabled,
   isOIDC,
   isSaaS,
@@ -41,7 +42,7 @@ export const useGlobalRoutes = () => {
           element: <Users />,
         },
       ]
-    : !isSaaS
+    : !isSaaS || isAdditionalIdpConfigured
       ? [
           {
             path: `${Paths.mappingRules()}/*`,

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -29,6 +29,10 @@ export const isNewDesignSystemEnabled = getClientConfigBoolean(
   "isNewDesignSystemEnabled",
   false,
 );
+export const isAdditionalIdpConfigured = getClientConfigBoolean(
+  "isAdditionalIdpConfigured",
+  false,
+);
 
 export const docsUrl = "https://docs.camunda.io/docs/next";
 

--- a/identity/client/src/types/global.d.ts
+++ b/identity/client/src/types/global.d.ts
@@ -12,6 +12,7 @@ export declare global {
     isCamundaGroupsEnabled?: string;
     isTenantsApiEnabled?: string;
     isNewDesignSystemEnabled?: string;
+    isAdditionalIdpConfigured?: string;
     organizationId?: string;
     clusterId?: string;
     idPattern?: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
@@ -38,6 +38,7 @@ export class IdentityMappingRulesPage {
   readonly deleteMappingRuleModalDeleteButton: Locator;
   readonly emptyStateLocator: Locator;
   readonly usersNavItem: Locator;
+  readonly rolesNavItem: Locator;
   readonly mappingRulesNavItem: Locator;
   readonly selectMappingRuleRow: (name: string) => Locator;
   readonly mappingRuleCell: (name: string) => Locator;
@@ -152,6 +153,7 @@ export class IdentityMappingRulesPage {
 
     this.emptyStateLocator = page.getByText('No mapping rules created yet');
     this.usersNavItem = page.getByText('Users');
+    this.rolesNavItem = page.getByText('Roles');
     this.mappingRulesNavItem = page.getByText('Mapping rules');
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
@@ -38,6 +38,7 @@ export class IdentityMappingRulesPage {
   readonly deleteMappingRuleModalDeleteButton: Locator;
   readonly emptyStateLocator: Locator;
   readonly usersNavItem: Locator;
+  readonly mappingRulesNavItem: Locator;
   readonly selectMappingRuleRow: (name: string) => Locator;
   readonly mappingRuleCell: (name: string) => Locator;
 
@@ -151,6 +152,7 @@ export class IdentityMappingRulesPage {
 
     this.emptyStateLocator = page.getByText('No mapping rules created yet');
     this.usersNavItem = page.getByText('Users');
+    this.mappingRulesNavItem = page.getByText('Mapping rules');
   }
 
   async navigateToMappingRules() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules-saas-visibility.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules-saas-visibility.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {publicTest as test} from 'fixtures';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {LOGIN_CREDENTIALS} from 'utils/constants';
+import {mockOIDCModeUI} from 'utils/mockOIDCModeUI';
+
+test.describe('mapping rules visibility on SaaS', () => {
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('hides mapping rules when no additional IdP is configured', async ({
+    page,
+    loginPage,
+    identityMappingRulesPage,
+  }) => {
+    await navigateToApp(page, 'admin');
+    await mockOIDCModeUI(page, {
+      isOidc: 'true',
+      organizationId: 'test-org',
+      isAdditionalIdpConfigured: 'false',
+    });
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+
+    await expect(identityMappingRulesPage.mappingRulesNavItem).toBeHidden();
+  });
+
+  test('shows mapping rules when an additional IdP is configured', async ({
+    page,
+    loginPage,
+    identityMappingRulesPage,
+  }) => {
+    await navigateToApp(page, 'admin');
+    await mockOIDCModeUI(page, {
+      isOidc: 'true',
+      organizationId: 'test-org',
+      isAdditionalIdpConfigured: 'true',
+    });
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+
+    await expect(identityMappingRulesPage.mappingRulesNavItem).toBeVisible();
+    await identityMappingRulesPage.mappingRulesNavItem.click();
+    await expect(identityMappingRulesPage.mappingRulesList).toBeVisible();
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules-saas-visibility.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules-saas-visibility.spec.ts
@@ -12,6 +12,7 @@ import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {LOGIN_CREDENTIALS} from 'utils/constants';
 import {mockOIDCModeUI} from 'utils/mockOIDCModeUI';
+import {relativizePath, Paths} from 'utils/relativizePath';
 
 test.describe('mapping rules visibility on SaaS', () => {
   test.afterEach(async ({page}, testInfo) => {
@@ -35,6 +36,8 @@ test.describe('mapping rules visibility on SaaS', () => {
       LOGIN_CREDENTIALS.password,
     );
 
+    // Anchor on an unconditional nav item: toBeHidden() alone also passes if the sidebar never renders.
+    await expect(identityMappingRulesPage.rolesNavItem).toBeVisible();
     await expect(identityMappingRulesPage.mappingRulesNavItem).toBeHidden();
   });
 
@@ -54,8 +57,16 @@ test.describe('mapping rules visibility on SaaS', () => {
       LOGIN_CREDENTIALS.password,
     );
 
+    // Regression guard: unhiding the route must not change the index redirect.
+    await expect(page).not.toHaveURL(relativizePath(Paths.mappingRules()));
+
     await expect(identityMappingRulesPage.mappingRulesNavItem).toBeVisible();
     await identityMappingRulesPage.mappingRulesNavItem.click();
-    await expect(identityMappingRulesPage.mappingRulesList).toBeVisible();
+
+    // URL + Create button hold whether or not rules already exist on this shared cluster.
+    await expect(page).toHaveURL(relativizePath(Paths.mappingRules()));
+    await expect(
+      identityMappingRulesPage.createMappingRuleButton,
+    ).toBeVisible();
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/mockOIDCModeUI.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/mockOIDCModeUI.ts
@@ -8,12 +8,15 @@
 
 import {Page, Route} from '@playwright/test';
 
-export async function mockOIDCModeUI(page: Page): Promise<void> {
+export async function mockOIDCModeUI(
+  page: Page,
+  overrides: Record<string, string> = {isOidc: 'true'},
+): Promise<void> {
   await page.route('**/config.js', async (route: Route) => {
     const response = await route.fetch();
     const originalBody = await response.text();
 
-    let config: Record<string, string> = {};
+    let config: Record<string, unknown> = {};
 
     const match = originalBody.match(
       /window\.clientConfig\s*=\s*(\{[\s\S]*\});?/,
@@ -23,10 +26,8 @@ export async function mockOIDCModeUI(page: Page): Promise<void> {
       config = eval('(' + match[1] + ')');
     }
 
-    Object.keys(config).forEach((key) => {
-      if (key === 'isOidc') {
-        config[key] = 'true';
-      }
+    Object.entries(overrides).forEach(([key, value]) => {
+      config[key] = value;
     });
 
     await route.fulfill({


### PR DESCRIPTION
## Summary

- Mapping Rules UI was unconditionally hidden on SaaS, even though the API is fully functional there and mapping rules are the supported way to onboard users from a BYOIDP additional IdP.
- Adds an `isAdditionalIdpConfigured` client-config flag, derived from whether any named OIDC provider (`camunda.security.authentication.providers.oidc.*`, the BYOIDP additional-IdP surface) has a `clientId`, and uses it to unhide the Mapping Rules route on SaaS clusters that have one configured. Self-managed OIDC behavior is unchanged.
- Generalizes the e2e `mockOIDCModeUI` helper to accept arbitrary client-config overrides, needed to simulate SaaS mode with/without an additional IdP.

**Provisioning shape.** The operator renders BYOIDP additional-IdP config into exactly this key: `pkg/apps/camunda/oidc/providers.go` writes `camunda.security.authentication.providers.oidc.<id>.*` from `ZeebeCluster`'s `identity.oidcProviders[]`, e.g. `CAMUNDA_SECURITY_AUTHENTICATION_PROVIDERS_OIDC_ENTRA_ISSUERURI` / `..._CLIENTID` / `..._CLIENTSECRET`. That wiring lives in the operator/Console repos, not here, which is why "BYOIDP" and "additional IdP" don't otherwise appear in `camunda/camunda`.

**Known limitation.** The flag currently can't distinguish "a named provider backing a real BYOIDP additional IdP" from "a named provider used for unrelated per-physical-tenant provider selection" (see ADR `docs/adr/orchestration-cluster/0004-per-physical-tenant-provider-selection-via-assigned.md`) — if physical tenants are ever configured on a SaaS cluster without a real BYOIDP, this may over-report `true`. Fails soft (an extra visible nav item), not silently inert.

## Related issues

closes #61921

## Test plan

- [x] `AdminClientConfigControllerTest` covers: named provider with `clientId` → flag `true`; no named providers → `false`; named provider present but empty → `false`; named provider present but null-valued → `false`; named provider with only `groupsClaim` (no `clientId`) → `false`; flat `authentication.oidc` fully configured with no named providers → `false`
- [x] New Playwright spec `mapping-rules-saas-visibility.spec.ts` covers: SaaS + no additional IdP → Mapping Rules hidden (anchored on an unconditional nav item); SaaS + additional IdP → Mapping Rules visible, reachable, and the SaaS index-route redirect is unchanged
