### PR TITLE
Gate the AGENT_INSTANCE:UPDATE status write behind the active job lease

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -166,7 +166,7 @@ public class AgentInstanceFetchIT {
         .elementInstanceKey(ei2)
         .status(AgentInstanceUpdateStatus.THINKING)
         .jobKey(activatedJob2.getKey())
-        .jobLease("test-job-lease")
+        .jobLease(activatedJob2.getLeaseToken())
         .history(
             List.of(
                 new AgentInstanceHistoryItem()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -218,6 +219,10 @@ public final class AgentInstanceUpdateProcessor
       return;
     }
 
+    final var job = validJob.get();
+    final var isRequestLevelStale =
+        !Objects.equals(commandValue.getJobLease(), job.getLeaseToken());
+
     final var isHistoryValid = historyBatchHelper.validateHistory(commandValue.getHistory());
     if (isHistoryValid.isLeft()) {
       final var rejection = isHistoryValid.getLeft();
@@ -225,7 +230,18 @@ public final class AgentInstanceUpdateProcessor
       return;
     }
 
-    final var validPatch = validateRequestLevelChanges(command, current);
+    // Request-level changes (currently just status) bypass the history commit/discard lifecycle,
+    // so unlike history items they have no way to resolve a stale write after the fact: the active
+    // lease's own update already applied (or will apply) the change, so a request-level change
+    // under a superseded lease must not be applied. We are not just skipping validation here: by
+    // setting validPatch to an empty list instead of validating the command's own changes, the
+    // later applyRequestLevelChanges call below sees nothing to apply either, so both validation
+    // and application are skipped in one go — validating a change that will never be applied could
+    // otherwise reject the whole command over a transition that never actually happens.
+    final var validPatch =
+        isRequestLevelStale
+            ? Either.<Rejection, List<String>>right(List.of())
+            : validateRequestLevelChanges(command, current);
     if (validPatch.isLeft()) {
       final var rejection = validPatch.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -1601,6 +1601,101 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldNotApplyStatusFromUpdateWithSupersededJobLease() {
+    // given — job worker A holds lease1, then the job is re-activated (fail + re-activate) so
+    // worker B holds lease2. Worker B's update (under the current lease2) sets status=IDLE.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    final var batch1 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobIndex1 = batch1.getValue().getJobKeys().indexOf(jobKey);
+    final var lease1 = batch1.getValue().getJobs().get(jobIndex1).getLeaseToken();
+
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1);
+    configItem.setModel("gpt-4o").setProvider("openai");
+    configItem.setChangedAttributes(List.of("model", "provider"));
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(lease1)
+            .withHistory(List.of(configItem))
+            .create()
+            .getKey();
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(helper.getJobType())
+        .withLeaseToken(lease1)
+        .withRetries(1)
+        .fail();
+
+    final var batch2 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobIndex2 = batch2.getValue().getJobKeys().indexOf(jobKey);
+    final var lease2 = batch2.getValue().getJobs().get(jobIndex2).getLeaseToken();
+    assertThat(lease2).as("re-activation must advance the lease token").isNotEqualTo(lease1);
+
+    // worker B (current lease2) sets status=IDLE
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease(lease2)
+        .withStatus(AgentInstanceStatus.IDLE)
+        .withChangedAttributes(List.of("status"))
+        .update();
+
+    // when — a delayed/retried update from worker A arrives afterward, still carrying the
+    // superseded lease1, attempting to move status to THINKING.
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(lease1)
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .update();
+
+    // then — the command is still accepted (ALLOW_STALE), but the stale-lease status write is
+    // skipped: the active lease's status (IDLE) is preserved, not overwritten.
+    assertThat(updated.getIntent()).isEqualTo(AgentInstanceIntent.UPDATED);
+    assertThat(updated.getValue().getStatus()).isEqualTo(AgentInstanceStatus.IDLE);
+    assertThat(updated.getValue().getChangedAttributes()).doesNotContain("status");
+  }
+
+  @Test
   public void shouldEmitHistoryEventForEachItemInOrderOnUpdate() {
     // given
     ENGINE


### PR DESCRIPTION
## Description

`AGENT_INSTANCE:UPDATE` can carry a request-level status change alongside a history batch. When two job leases race — worker A's stale lease still holds an in-flight `UPDATE` while worker B has already been issued a new lease and applied its own status change — the stale `UPDATE` from worker A can land afterwards and overwrite the status that worker B's active lease just set.

This fixes it by detecting, in `AgentInstanceUpdateProcessor`, when the command's `jobLease` no longer matches the job's current lease token. When it doesn't, the command's own request-level changes (currently just `status`) are neither validated nor applied — the active lease's own update already applied (or will apply) that change, and a superseded lease has no way to resolve a stale write after the fact the way history items do via the commit/discard lifecycle.

## Why this is stacked on #62372

This PR is based on `60864-enforce-jobkey-joblease-requiredness` (#62372) rather than `main`.

The staleness check relies on `AgentHistoryBatchBehavior#validateJobContext` returning a non-null `JobRecord` that unconditionally holds a real lease token whenever the command is accepted. On plain `main`, `validateJobContext` still allows `jobKey == -1` (returning `Either.right(null)` when no history batch is attached) and only rejects a lease mismatch when the job already `hasLeaseToken()` — a job that never held a real lease passes through silently. Against that contract, this fix's `job.getLeaseToken()` call would either NPE (null job) or compare against a meaningless default empty-string lease token (job never leased), instead of reliably detecting staleness.

#62372 closes both gaps: `jobKey` becomes unconditionally required and a job is unconditionally rejected if it doesn't hold a lease, guaranteeing the non-null, always-leased `JobRecord` this fix depends on. Once #62372 merges into `main`, this PR's base moves along with it.

## Related issues

Closes #61984
