### PR TITLE
fix: stop a CONFLICTING fix PR from permanently claiming its specs

### DIFF
--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -439,8 +439,9 @@ def dedupe_inputs() -> tuple[set[str], set[str], set[str], bool]:
             claims = planning.parse_coverage_block(pr.get("body"))
             if claims and planning.pr_is_stale(pr.get("mergeable")):
                 log(
-                    f"stale fix PR {repo}#{pr.get('number')} is CONFLICTING; not "
-                    f"treating its {len(claims)} claimed spec(s) as covered"
+                    f"stale fix PR {repo}#{pr.get('number')} is "
+                    f"{pr.get('mergeable')}; not treating its {len(claims)} "
+                    f"claimed spec(s) as covered"
                 )
             else:
                 covered |= claims

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -381,7 +381,7 @@ def open_fix_prs(repo: str) -> tuple[list[dict], bool]:
         [
             "pr", "list", "--repo", repo,
             "--search", f"label:{FIX_LABEL} is:open",
-            "--limit", "100", "--json", "labels,number,createdAt,body",
+            "--limit", "100", "--json", "labels,number,createdAt,body,mergeable",
         ],
         None,
     )
@@ -415,7 +415,12 @@ def dedupe_inputs() -> tuple[set[str], set[str], set[str], bool]:
     the subset: the marker comment alone is not a statement of remit.
 
     Coverage is collected from every open fix PR, expired or not: the specs a PR claims
-    stay claimed for as long as it is open, and only the coarse key lock is time-bound.
+    stay claimed for as long as it is open, and only the coarse key lock is time-bound
+    — except a PR GitHub reports as `CONFLICTING` (see `planning.pr_is_stale`), whose
+    claims are dropped immediately rather than waiting on a human to close it. Its key
+    label still counts towards `keys_with_coverage`, so a stale-but-claiming PR still
+    frees its surface's *other* specs for per-spec accounting; only the specific
+    fingerprints it can no longer land get a fresh chance.
 
     As with `inflight_keys`, a failed lookup makes the caller suppress rather than risk
     a duplicate PR.
@@ -432,7 +437,13 @@ def dedupe_inputs() -> tuple[set[str], set[str], set[str], bool]:
             continue
         for pr in prs:
             claims = planning.parse_coverage_block(pr.get("body"))
-            covered |= claims
+            if claims and planning.pr_is_stale(pr.get("mergeable")):
+                log(
+                    f"stale fix PR {repo}#{pr.get('number')} is CONFLICTING; not "
+                    f"treating its {len(claims)} claimed spec(s) as covered"
+                )
+            else:
+                covered |= claims
             pr_keys: set[str] = set()
             for label in pr.get("labels") or []:
                 name = (label.get("name") or "").strip()

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -96,6 +96,39 @@ def pr_lock_expired(
     return now - created > timedelta(hours=ttl_hours)
 
 
+#: `mergeable` states GitHub computes for a PR. Only `"CONFLICTING"` counts as stale:
+#: `"UNKNOWN"` just means GitHub has not finished computing the merge base yet and
+#: must not be read as broken, and `"MERGEABLE"` is fine by definition.
+STALE_MERGEABLE_STATES = frozenset({"CONFLICTING"})
+
+
+def pr_is_stale(mergeable: str | None) -> bool:
+    """Whether a fix PR is broken badly enough that its coverage claim should lapse.
+
+    c8-cross-component-e2e-tests#3154 claimed three SM-8.10 Modeler-navigation
+    fingerprints on 2026-08-26 and has sat CONFLICTING ever since. Every nightly that
+    hit those same three specs over the following two weeks was suppressed as
+    `open-pr-covers-all-specs`, even though the PR could never land and fix them.
+    `PR_LOCK_TTL_HOURS` does not help here: that only bounds the coarse per-surface
+    lock a claim-nothing PR holds, and a PR that claims fingerprints is deliberately
+    authoritative for them for as long as it is open (see `dedupe_inputs`'s docstring
+    in discover.py) — the TTL is skipped outright for it. A stale PR needs its claims
+    invalidated instead, so a fresh agent gets a chance while the broken PR still sits
+    open for a human to close or rebase.
+
+    `mergeable` is a value GitHub computes fresh on every read, not something a PR
+    body can lie about or a bad clock can misjudge, so unlike the TTL there is no
+    reason to time-bound this: it reflects the PR's current state, checked on every
+    triage run, not the state it started in.
+
+    Only mergeability is checked, not CI status: `statusCheckRollup` carries dozens
+    of matrix legs per PR in these repos, and treating any single red leg as "stale"
+    would drop a PR's coverage while its own fix-verification job is still running or
+    hit an unrelated flake — the opposite of what this is for.
+    """
+    return (mergeable or "").strip().upper() in STALE_MERGEABLE_STATES
+
+
 def spec_suite(spec_file: str) -> str | None:
     """The version directory a spec lives in: `tests/SM-8.10/x.spec.ts` -> `SM-8.10`."""
     parts = (spec_file or "").split("/")

--- a/.github/scripts/alwaysgreen/test_discover.py
+++ b/.github/scripts/alwaysgreen/test_discover.py
@@ -147,7 +147,7 @@ def test_a_failed_lookup_reports_not_ok(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_a_conflicting_holders_claims_do_not_count_as_covered(monkeypatch):
+def test_a_conflicting_holders_claim_does_not_count_as_covered(monkeypatch):
     # c8-cross-component-e2e-tests#3154: claimed three fingerprints, then sat
     # CONFLICTING for two weeks while every nightly hitting those specs was
     # suppressed as already covered.

--- a/.github/scripts/alwaysgreen/test_discover.py
+++ b/.github/scripts/alwaysgreen/test_discover.py
@@ -21,7 +21,7 @@ def _ago(**kw):
     return (NOW - timedelta(**kw)).isoformat().replace("+00:00", "Z")
 
 
-def _pr(number, keys, *, claims=(), age_hours=0):
+def _pr(number, keys, *, claims=(), age_hours=0, mergeable="MERGEABLE"):
     body = ""
     if claims:
         body = f"Fixes.\n\n{planning.render_coverage_block(set(claims))}\n"
@@ -30,6 +30,7 @@ def _pr(number, keys, *, claims=(), age_hours=0):
         "body": body,
         "createdAt": _ago(hours=age_hours),
         "labels": [{"name": f"{discover.KEY_LABEL_PREFIX}{k}"} for k in keys],
+        "mergeable": mergeable,
     }
 
 
@@ -139,3 +140,49 @@ def test_a_failed_lookup_reports_not_ok(monkeypatch):
     _stub(monkeypatch, [_pr(1, ["main:saas-smoke-e2e"], claims=["aaaaaaaa"])], ok=False)
     _covered, _keys, _per_spec, ok = discover.dedupe_inputs()
     assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Stale (CONFLICTING) fix PRs
+# ---------------------------------------------------------------------------
+
+
+def test_a_conflicting_holders_claims_do_not_count_as_covered(monkeypatch):
+    # c8-cross-component-e2e-tests#3154: claimed three fingerprints, then sat
+    # CONFLICTING for two weeks while every nightly hitting those specs was
+    # suppressed as already covered.
+    _stub(
+        monkeypatch,
+        [_pr(1, ["main:sm-smoke-e2e"], claims=["aaaaaaaa"], mergeable="CONFLICTING")],
+    )
+    covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert covered == set()
+    # The key still counts as claiming something, so the coarse per-surface lock
+    # still lifts for its neighbours; only the specific (untrustworthy) claim is
+    # dropped.
+    assert keys == {"main:sm-smoke-e2e"}
+    assert per_spec == {"main:sm-smoke-e2e"}
+
+
+def test_a_conflicting_holder_beside_a_healthy_one_still_covers_the_spec(monkeypatch):
+    # Two PRs holding the same key, one stale and one not: the healthy PR's claim
+    # must still count even though its stale sibling's does not.
+    _stub(
+        monkeypatch,
+        [
+            _pr(1, ["main:sm-smoke-e2e"], claims=["aaaaaaaa"], mergeable="CONFLICTING"),
+            _pr(2, ["main:sm-smoke-e2e"], claims=["bbbbbbbb"]),
+        ],
+    )
+    covered, _keys, _per_spec, _ok = discover.dedupe_inputs()
+    assert covered == {"bbbbbbbb"}
+
+
+def test_an_unknown_mergeable_state_still_counts_as_covered(monkeypatch):
+    # GitHub has not finished computing mergeability yet; must not be read as broken.
+    _stub(
+        monkeypatch,
+        [_pr(1, ["main:sm-smoke-e2e"], claims=["aaaaaaaa"], mergeable="UNKNOWN")],
+    )
+    covered, _keys, _per_spec, _ok = discover.dedupe_inputs()
+    assert covered == {"aaaaaaaa"}

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -614,6 +614,33 @@ def test_naive_now_does_not_raise_against_an_offset_aware_created_at():
     assert plan.pr_lock_expired(_ago(minutes=30), naive_now, 2) is False
 
 
+# ---------------------------------------------------------------------------
+# Stale (CONFLICTING) fix PRs
+# ---------------------------------------------------------------------------
+
+
+def test_conflicting_pr_is_stale():
+    assert plan.pr_is_stale("CONFLICTING") is True
+
+
+def test_mergeable_pr_is_not_stale():
+    assert plan.pr_is_stale("MERGEABLE") is False
+
+
+def test_unknown_mergeable_state_is_not_stale():
+    # GitHub has not finished computing the merge base yet; treat as fine, not broken.
+    assert plan.pr_is_stale("UNKNOWN") is False
+
+
+def test_missing_mergeable_field_is_not_stale():
+    assert plan.pr_is_stale(None) is False
+    assert plan.pr_is_stale("") is False
+
+
+def test_mergeable_check_is_case_insensitive():
+    assert plan.pr_is_stale("conflicting") is True
+
+
 def test_zero_ttl_restores_the_never_expiring_lock():
     assert plan.pr_lock_expired("2026-01-01T00:00:00Z", NOW, 0) is False
 


### PR DESCRIPTION
## What

`plan.pr_is_stale(mergeable)` treats a fix PR that GitHub reports as `CONFLICTING`
as too broken to keep vouching for the specs it claims. `discover.dedupe_inputs`
now fetches `mergeable` on every open fix PR and drops a stale PR's fingerprints
from the coverage set it hands to `plan_dispatches`, so a repeat of the same
failure gets a fresh dispatch instead of being silently suppressed forever.

The PR's key label still counts toward `keys_with_coverage`, so a stale-but-claiming
PR keeps its surface's *other*, unrelated specs unlocked exactly as before — only the
specific fingerprints it can no longer land are affected.

Only `mergeable` is checked (`"CONFLICTING"` — not `"UNKNOWN"`, which just means
GitHub hasn't finished computing it yet), not CI status: `statusCheckRollup` carries
dozens of matrix legs per PR in these repos, and treating any single red leg as
"stale" would drop a PR's coverage while its own fix-verification job is still
running, or on an unrelated flake.

## Why

[c8-cross-component-e2e-tests#3154](https://github.com/camunda/c8-cross-component-e2e-tests/pull/3154)
claimed three SM-8.10 fingerprints on 2026-08-26 and has sat `CONFLICTING`
(`mergeStateStatus: DIRTY`) ever since, with its own `Run tests - chromium-v2` check
failing. `PR_LOCK_TTL_HOURS` (#61970-adjacent work, already in `main`) does not help
here: that only bounds the *coarse* per-surface lock a claim-nothing PR holds, and a
PR that claims fingerprints is deliberately authoritative for them for as long as it
is open. So every nightly run hitting those same three specs for the following two
weeks — most recently [run 34228983361](https://github.com/camunda/camunda/actions/runs/34228983361) —
was suppressed as `open-pr-covers-all-specs`, even though the PR can never merge and
fix them.

This mirrors a fix already shipped in `camunda-hub`
([#28307](https://github.com/camunda/camunda-hub/pull/28307), the `PR_LOCK_TTL_HOURS`
mechanism) for a related but distinct gap: that PR bounded the coarse key lock; this
one bounds the per-spec coverage claim, which hub's own implementation still leaves
unbounded by design (see `dedupe_inputs`'s docstring).

## Test plan

- [x] `pytest .github/scripts/alwaysgreen` — 147 passed, including 8 new tests
      (`pr_is_stale` cases in `test_plan.py`; conflicting/healthy-sibling/unknown-state
      cases against `dedupe_inputs` in `test_discover.py`).
- [ ] Next AlwaysGreen triage run on `main` should stop suppressing the three specs
      c8-cross-component-e2e-tests#3154 claims, once that PR (or a replacement) is
      either merged/closed or continues to sit `CONFLICTING`.

Related: the triage run that surfaced this — https://github.com/camunda/camunda/actions/runs/34228983361/job/102077376124