### PR TITLE
test: wait for Elasticsearch security before exporter auth tests

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -19,8 +19,10 @@ import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.io.IOException;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -28,13 +30,27 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 public class CamundaExporterAuthenticationIT {
 
+  private static final String ELASTIC_USER = "elastic";
   private static final String ELASTIC_PASSWORD = "PASSWORD";
 
+  /**
+   * The default wait strategy only waits for the node to log {@code started}, which Elasticsearch
+   * does before the {@code .security} index is allocated. Until that index is available the
+   * reserved realm cannot read the {@code elastic} user's password hash and rejects valid
+   * credentials with a {@code 401}, so wait for an authenticated request to succeed instead.
+   */
   @Container
   private static final ElasticsearchContainer CONTAINER =
       TestSearchContainers.createDefaultElasticsearchContainer()
           .withPassword(ELASTIC_PASSWORD)
-          .withEnv("xpack.security.enabled", "true");
+          .withEnv("xpack.security.enabled", "true")
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(9200)
+                  .forPath("/_cluster/health")
+                  .withBasicCredentials(ELASTIC_USER, ELASTIC_PASSWORD)
+                  .forStatusCode(200)
+                  .withStartupTimeout(Duration.ofMinutes(5)));
 
   private final ExporterConfiguration config = new ExporterConfiguration();
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -42,7 +58,7 @@ public class CamundaExporterAuthenticationIT {
 
   @BeforeEach
   void beforeEach() throws IOException {
-    config.getConnect().setUsername("elastic");
+    config.getConnect().setUsername(ELASTIC_USER);
     config.getConnect().setPassword(ELASTIC_PASSWORD);
     config.getConnect().setUrl(CONTAINER.getHttpHostAddress());
     createSchemas(config);


### PR DESCRIPTION
## Description

`CamundaExporterAuthenticationIT` was flaking 57–114 times a day, failing with a 401 in the shared `@BeforeEach`.

### Root cause
Testcontainers' `ElasticsearchContainer` only waits for the node's "started" log line, but Elasticsearch creates and allocates the `.security` index *after* that point. While the index exists in cluster state without an allocated primary shard, the reserved realm can't read the `elastic` user's password hash and rejects otherwise-valid credentials — logging "failed to retrieve password hash for reserved user [elastic]". Because `indexExists()` issues a HEAD request (and Elasticsearch sends no body for HEAD responses), the client surfaced the misleading "Expecting a response body, but none was sent" instead of the underlying security exception.

The realm caches successful authentications, so the failure window is only observable when the very first authenticated request lands inside it — roughly 300ms locally, but stretching past 4.5s on a contended CI runner, which is why this only reproduced in CI. It became visible once `createSchemas` moved from `startup()` to `startupOnce()`, removing the retry loop that had been unintentionally absorbing this race.

### Fix
Instead of waiting on the container's log line, wait on an authenticated `GET /_cluster/health` returning `200`. This ties readiness to the actual condition the tests depend on — that the credentials used by the tests work — rather than an incidental log message. Retrying `createSchemas` was considered but rejected, since it would only mask the gap while leaving every future test against a secured container exposed to the same race.

## Checklist

- [x] Enable backports when necessary (e.g. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #62397 
