### PR TITLE
Fix Optimize deserialization failure for agent-instance history and limits

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -163,8 +163,11 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
   }
 
   // Not tracked — Optimize's import doesn't need the embedded history batch, only the
-  // instance-level fields above.
+  // instance-level fields above. Ignored by Jackson: with no backing field, a List-typed
+  // getter is otherwise treated as a setterless collection property and deserialization
+  // fails trying to populate the null this returns (#62414).
   @Override
+  @JsonIgnore
   public List<AgentHistoryRecordValue> getHistory() {
     return null;
   }
@@ -196,7 +199,10 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     this.definition = definition;
   }
 
+  // Not tracked — Optimize's import doesn't need the configured limits. Ignored by Jackson so
+  // a real exporter record carrying this field doesn't fail as an unrecognized property (#62414).
   @Override
+  @JsonIgnore
   public AgentInstanceLimitsValue getLimits() {
     return null;
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDtoTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDtoTest.java
@@ -17,6 +17,52 @@ import org.junit.jupiter.api.Test;
 
 class ZeebeAgentInstanceDataDtoTest {
 
+  // ── history/limits deserialization (regression for #62414) ────────────────
+
+  @Test
+  void shouldDeserializeRealExporterRecordWithEmptyHistoryAndLimits() throws Exception {
+    // given — a record shaped like the one the Elasticsearch exporter actually writes:
+    // value.history
+    // present as an empty array, value.limits present as an object, alongside the other fields
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final String json =
+        "{"
+            + "\"agentInstanceKey\":1,"
+            + "\"elementInstanceKey\":2,"
+            + "\"elementInstanceKeys\":[2],"
+            + "\"elementId\":\"agent\","
+            + "\"processInstanceKey\":3,"
+            + "\"rootProcessInstanceKey\":3,"
+            + "\"bpmnProcessId\":\"myProcess\","
+            + "\"processDefinitionKey\":4,"
+            + "\"processDefinitionVersion\":1,"
+            + "\"tenantId\":\"<default>\","
+            + "\"jobKey\":5,"
+            + "\"jobLease\":\"lease-1\","
+            + "\"status\":\"COMPLETED\","
+            + "\"definition\":{\"model\":\"gpt\",\"provider\":\"openai\"},"
+            + "\"limits\":{\"maxTokens\":1000,\"maxModelCalls\":10,\"maxToolCalls\":10},"
+            + "\"metrics\":{\"inputTokens\":100,\"outputTokens\":50},"
+            + "\"tools\":[{\"name\":\"my-tool\",\"description\":\"does something\",\"elementId\":\"tool1\"}],"
+            + "\"changedAttributes\":[],"
+            + "\"history\":[]"
+            + "}";
+
+    // when — deserialization must not fail on the setterless 'history' getter
+    final ZeebeAgentInstanceDataDto dto =
+        objectMapper.readValue(json, ZeebeAgentInstanceDataDto.class);
+
+    // then — the fields Optimize actually consumes are correctly mapped
+    assertThat(dto.getAgentInstanceKey()).isEqualTo(1L);
+    assertThat(dto.getDefinition().getModel()).isEqualTo("gpt");
+    assertThat(dto.getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(dto.getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(dto.getMetrics().getOutputTokens()).isEqualTo(50L);
+    assertThat(dto.getTools()).hasSize(1);
+    assertThat(dto.getTools().get(0).getName()).isEqualTo("my-tool");
+    assertThat(dto.getHistory()).isNull();
+  }
+
   // ── changedAttributes deserialization ─────────────────────────────────────
 
   @Test


### PR DESCRIPTION
## Summary

Optimize's `ZeebeAgentInstanceDataDto` implements `AgentInstanceRecordValue` but inherits `getHistory()` and `getLimits()` from the interface without a backing field. Jackson treats the `List`-typed `getHistory()` as a setterless collection property and fails trying to populate the `null` it returns; `getLimits()` (a non-collection, non-field-backed getter) isn't recognized as a deserializable property at all, so a JSON payload carrying that key fails as unrecognized. Since the Elasticsearch exporter always writes both fields, every `agent-instance` record fails to deserialize and the Agentic Control Plane dashboard stays empty.

This applies the smaller of the two fixes proposed in the issue: annotate both inherited getters with `@JsonIgnore`, since Optimize's import only reads `value.metrics`, `value.definition`, and `value.tools`.

## Changes

- Added a regression test that deserializes a record shaped like a real exporter payload, including `history: []` and a populated `limits` object, reproducing both failure modes.
- Added `@JsonIgnore` to `ZeebeAgentInstanceDataDto.getHistory()` and `getLimits()`.

## Test plan

- [x] New unit test `ZeebeAgentInstanceDataDtoTest#shouldDeserializeRealExporterRecordWithEmptyHistoryAndLimits` fails before the fix, passes after.
- [x] Existing `ZeebeAgentInstanceDataDtoTest` and `ZeebeAgentInstanceImportServiceTest` suites pass.

## Related issues

Closes camunda/camunda#62414