### PR TITLE
test: use ASCII arrow as locale in CI is ASCII not UTF8

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DuplicateExtensionElementDeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DuplicateExtensionElementDeploymentRejectionTest.java
@@ -77,7 +77,7 @@ public class DuplicateExtensionElementDeploymentRejectionTest {
       this.extensionName = extensionName;
     }
 
-    @Parameterized.Parameters(name = "{1} → zeebe:{2}")
+    @Parameterized.Parameters(name = "{1} -> zeebe:{2}")
     public static Collection<Object[]> data() {
       return Arrays.asList(
           new Object[][] {


### PR DESCRIPTION
## Description
In gradle (PR #52869) , the machine locale is used to render the test names and using an UTF8 codepoint creates problems

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

