### PR TITLE
fix: resolve additional-jwk-set-uris when issuer-uri is not configured

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -874,9 +874,10 @@ public class WebSecurityConfig {
 
       if (clientRegistrations.size() == 1) {
         final var clientRegistration = clientRegistrations.getFirst();
-        final var additionalUris =
-            additionalJwkSetUrisByIssuer.get(
-                clientRegistration.getProviderDetails().getIssuerUri());
+        final var oidcConfig =
+            oidcProviderRepository.getOidcAuthenticationConfigurationById(
+                clientRegistration.getRegistrationId());
+        final var additionalUris = oidcConfig != null ? oidcConfig.getAdditionalJwkSetUris() : null;
         LOG.info(
             "Create Access Token JWT Decoder for OIDC Provider: {}",
             clientRegistration.getRegistrationId());

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -869,18 +869,12 @@ public class WebSecurityConfig {
         final OidcAuthenticationConfigurationRepository oidcProviderRepository) {
       final var clientRegistrations = extractClientRegistrations(clientRegistrationRepository);
 
-      final var additionalJwkSetUrisByIssuer =
-          buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository);
-
       if (clientRegistrations.size() == 1) {
         final var clientRegistration = clientRegistrations.getFirst();
         final var oidcConfig =
             oidcProviderRepository.getOidcAuthenticationConfigurationById(
                 clientRegistration.getRegistrationId());
-        final var additionalUris =
-            oidcConfig != null && oidcConfig.getAdditionalJwkSetUris() != null
-                ? List.copyOf(oidcConfig.getAdditionalJwkSetUris())
-                : null;
+        final var additionalUris = oidcConfig != null ? oidcConfig.getAdditionalJwkSetUris() : null;
         LOG.info(
             "Create Access Token JWT Decoder for OIDC Provider: {}",
             clientRegistration.getRegistrationId());
@@ -889,6 +883,8 @@ public class WebSecurityConfig {
                 oidcAccessTokenDecoderFactory.createAccessTokenDecoder(
                     clientRegistration, additionalUris));
       } else {
+        final var additionalJwkSetUrisByIssuer =
+            buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository);
         LOG.info(
             "Create Issuer Aware JWT Decoder for multiple OIDC Providers: [{}]",
             clientRegistrations.stream()

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -877,7 +877,10 @@ public class WebSecurityConfig {
         final var oidcConfig =
             oidcProviderRepository.getOidcAuthenticationConfigurationById(
                 clientRegistration.getRegistrationId());
-        final var additionalUris = oidcConfig != null ? oidcConfig.getAdditionalJwkSetUris() : null;
+        final var additionalUris =
+            oidcConfig != null && oidcConfig.getAdditionalJwkSetUris() != null
+                ? List.copyOf(oidcConfig.getAdditionalJwkSetUris())
+                : null;
         LOG.info(
             "Create Access Token JWT Decoder for OIDC Provider: {}",
             clientRegistration.getRegistrationId());

--- a/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
@@ -617,6 +617,105 @@ public class JwtDecoderTest extends AbstractWebSecurityConfigTest {
     }
   }
 
+  /**
+   * Regression test for <a href="https://github.com/camunda/camunda/issues/50801">#50801</a>:
+   * additional-jwk-set-uris must work when issuer-uri is NOT configured (explicit endpoints only).
+   */
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.authentication.unprotected-api=false",
+        "camunda.security.authentication.method=oidc",
+        "camunda.security.authentication.oidc.client-id=example",
+        "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+        "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+        "camunda.security.authentication.oidc.token-uri=token.example.com",
+      })
+  class SingleOidcProviderWithAdditionalJwksWithoutIssuerUri {
+
+    @RegisterExtension
+    static WireMockExtension wireMock =
+        WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+    @Autowired private JwtDecoder decoder;
+
+    @DynamicPropertySource
+    static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+      // No issuer-uri — only explicit jwk-set-uri and additional-jwk-set-uris
+      registry.add(
+          "camunda.security.authentication.oidc.jwk-set-uri",
+          () -> "http://localhost:" + wireMock.getPort() + "/primary/jwks");
+      registry.add(
+          "camunda.security.authentication.oidc.additional-jwk-set-uris[0]",
+          () -> "http://localhost:" + wireMock.getPort() + "/additional/jwks");
+    }
+
+    @Test
+    void shouldDecodeTokenSignedWithAdditionalJwksKeyWithoutIssuerUri() throws JOSEException {
+      // given
+      final var additionalKey =
+          new RSAKeyGenerator(2048)
+              .keyID("additional-no-issuer")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", "{\"keys\":[]}");
+      mockJwksEndpoint("/additional/jwks", additionalKey.toPublicJWK().toJSONString());
+
+      final var jwt = signAndSerialize(additionalKey, "additional-no-issuer");
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldDecodeTokenSignedWithPrimaryJwksKeyWithoutIssuerUri() throws JOSEException {
+      // given
+      final var primaryKey =
+          new RSAKeyGenerator(2048)
+              .keyID("primary-no-issuer")
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .generate();
+
+      mockJwksEndpoint("/primary/jwks", primaryKey.toPublicJWK().toJSONString());
+      mockJwksEndpoint("/additional/jwks", "{\"keys\":[]}");
+
+      final var jwt = signAndSerialize(primaryKey, "primary-no-issuer");
+
+      // when // then
+      assertThatCode(() -> decoder.decode(jwt)).doesNotThrowAnyException();
+    }
+
+    private void mockJwksEndpoint(final String path, final String keyJson) {
+      final String body;
+      if (keyJson.startsWith("{\"keys\"")) {
+        body = keyJson;
+      } else {
+        body = "{\"keys\":[" + keyJson + "]}";
+      }
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(WireMock.urlEqualTo(path))
+                  .willReturn(WireMock.jsonResponse(body, HttpStatus.OK.value())));
+    }
+
+    private String signAndSerialize(final RSAKey key, final String kid) throws JOSEException {
+      final var jwt =
+          new SignedJWT(
+              new JWSHeader.Builder(JWSAlgorithm.RS256).type(JWT).keyID(kid).build(),
+              new Builder()
+                  .subject("alice")
+                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                  .build());
+      jwt.sign(new RSASSASigner(key));
+      return jwt.serialize();
+    }
+  }
+
   @Nested
   @TestPropertySource(
       properties = {


### PR DESCRIPTION
## Description

The single-provider `jwtDecoder` bean looked up additional JWKS URIs from a
map keyed by issuer URI. When `issuer-uri` was not configured (explicit
`jwk-set-uri`/`authorization-uri`/`token-uri` instead), the config was
filtered out and additional endpoints were silently ignored.

Look up directly from the `OidcAuthenticationConfigurationRepository` by
registration ID instead, removing the issuer-uri dependency.

This is a manual backport of #50804 to `stable/8.9`. #50804 could not be
merged to `main` as-is or backported automatically: by the time it was
reviewed, this code path had been migrated onto the `camunda-security-library`
JAR, where the same bug had already been independently fixed. `stable/8.9`
predates that migration and still has the original bug, so the fix is applied
here directly.

## Related issues

relates to #50801