### PR TITLE
feat: missing features from design system migration

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/route.tsx
@@ -7,8 +7,13 @@
  */
 
 import {createFileRoute, Outlet, redirect} from '@tanstack/react-router';
+import {useSessionHeartbeat} from '@camunda/session-heartbeat/react';
 import {SessionWatcher} from '#/shared/auth/shadcn.components/SessionWatcher';
+import {authenticationStore} from '#/shared/auth/authentication.store';
+import {endpoints} from '#/shared/http/endpoints';
+import {getCsrfTokenFromStorage} from '#/shared/http/request';
 import {queries} from '#/shared/http/queries';
+import {reactQueryClient} from '#/shared/http/reactQueryClient';
 import {storeSessionState} from '#/shared/browser-storage/session-storage';
 import {Header} from '#/shared/header/shadcn.components/Header';
 import {NotFoundPage} from '#/shared/pages/shadcn.components/NotFoundPage';
@@ -40,7 +45,16 @@ export const Route = createFileRoute('/shadcn/_auth')({
 			<NotFoundPage />
 		</PageLayout>
 	),
-	component() {
+	component: function RouteComponent() {
+		useSessionHeartbeat({
+			url: endpoints.sessionHeartbeatUrl(),
+			csrfToken: getCsrfTokenFromStorage,
+			onUnauthorized: () => {
+				authenticationStore.disableSession();
+				reactQueryClient.clear();
+			},
+		});
+
 		return (
 			<>
 				<SessionWatcher />

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/$userTaskKey/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/$userTaskKey/route.tsx
@@ -65,7 +65,7 @@ export const Route = createFileRoute('/shadcn/_auth/tasklist/_tasks/$userTaskKey
 				toast.info(t('tasklist.processInstanceCancelledNotification'), {
 					description: `${task.processName ?? task.processDefinitionId} (${task.processInstanceKey})`,
 				});
-navigate({to: '/shadcn/tasklist', search: true, replace: true});
+				navigate({to: '/shadcn/tasklist', search: true, replace: true});
 			}
 		}, [navigate, task.processDefinitionId, task.processInstanceKey, task.processName, task.state]);
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/$userTaskKey/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/$userTaskKey/route.tsx
@@ -9,8 +9,9 @@
 import type {UserTask} from '@camunda/camunda-api-zod-schemas/8.10';
 import {toast} from '@camunda/design-system';
 import {useSuspenseQuery} from '@tanstack/react-query';
-import {createFileRoute, type ErrorComponentProps, notFound, Outlet, redirect} from '@tanstack/react-router';
+import {createFileRoute, type ErrorComponentProps, notFound, Outlet, useNavigate} from '@tanstack/react-router';
 import {t} from 'i18next';
+import {useEffect} from 'react';
 import {ForbiddenError} from '#/shared/errors';
 import {queries} from '#/shared/http/queries';
 import {requestErrorSchema} from '#/shared/http/request';
@@ -24,16 +25,9 @@ import {NotFoundPage} from '#/shared/pages/shadcn.components/NotFoundPage';
 const POLLING_STATES: UserTask['state'][] = ['CANCELING', 'UPDATING', 'COMPLETING', 'ASSIGNING'];
 
 export const Route = createFileRoute('/shadcn/_auth/tasklist/_tasks/$userTaskKey')({
-	loaderDeps: ({search}) => ({search}),
-	loader: async ({context: {queryClient}, params: {userTaskKey}, deps: {search}}) => {
+	loader: async ({context: {queryClient}, params: {userTaskKey}}) => {
 		try {
-			const task = await queryClient.query(queries.getUserTask(userTaskKey));
-			if (task.state === 'CANCELED') {
-				toast.info(t('tasklist.processInstanceCancelledNotification'), {
-					description: `${task.processName ?? task.processDefinitionId} (${task.processInstanceKey})`,
-				});
-				throw redirect({to: '/shadcn/tasklist', search});
-			}
+			await queryClient.query(queries.getUserTask(userTaskKey));
 		} catch (error) {
 			const result = requestErrorSchema.safeParse(error);
 
@@ -55,6 +49,7 @@ export const Route = createFileRoute('/shadcn/_auth/tasklist/_tasks/$userTaskKey
 	},
 	component: function TaskDetailRoute() {
 		const {userTaskKey} = Route.useParams();
+		const navigate = useNavigate();
 		const {data: task} = useSuspenseQuery({
 			...queries.getUserTask(userTaskKey),
 			refetchInterval(query) {
@@ -64,6 +59,19 @@ export const Route = createFileRoute('/shadcn/_auth/tasklist/_tasks/$userTaskKey
 			},
 		});
 		const {data: currentUser} = useSuspenseQuery(queries.getCurrentUser());
+
+		useEffect(() => {
+			if (task.state === 'CANCELED') {
+				toast.info(t('tasklist.processInstanceCancelledNotification'), {
+					description: `${task.processName ?? task.processDefinitionId} (${task.processInstanceKey})`,
+				});
+				navigate({to: '/shadcn/tasklist', search: true});
+			}
+		}, [navigate, task.processDefinitionId, task.processInstanceKey, task.processName, task.state]);
+
+		if (task.state === 'CANCELED') {
+			return null;
+		}
 
 		return (
 			<TaskDetailPage

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/$userTaskKey/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/$userTaskKey/route.tsx
@@ -24,14 +24,15 @@ import {NotFoundPage} from '#/shared/pages/shadcn.components/NotFoundPage';
 const POLLING_STATES: UserTask['state'][] = ['CANCELING', 'UPDATING', 'COMPLETING', 'ASSIGNING'];
 
 export const Route = createFileRoute('/shadcn/_auth/tasklist/_tasks/$userTaskKey')({
-	loader: async ({context: {queryClient}, params: {userTaskKey}}) => {
+	loaderDeps: ({search}) => ({search}),
+	loader: async ({context: {queryClient}, params: {userTaskKey}, deps: {search}}) => {
 		try {
 			const task = await queryClient.query(queries.getUserTask(userTaskKey));
 			if (task.state === 'CANCELED') {
 				toast.info(t('tasklist.processInstanceCancelledNotification'), {
 					description: `${task.processName ?? task.processDefinitionId} (${task.processInstanceKey})`,
 				});
-				throw redirect({to: '/shadcn/tasklist'});
+				throw redirect({to: '/shadcn/tasklist', search});
 			}
 		} catch (error) {
 			const result = requestErrorSchema.safeParse(error);

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/$userTaskKey/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/$userTaskKey/route.tsx
@@ -65,7 +65,7 @@ export const Route = createFileRoute('/shadcn/_auth/tasklist/_tasks/$userTaskKey
 				toast.info(t('tasklist.processInstanceCancelledNotification'), {
 					description: `${task.processName ?? task.processDefinitionId} (${task.processInstanceKey})`,
 				});
-				navigate({to: '/shadcn/tasklist', search: true});
+navigate({to: '/shadcn/tasklist', search: true, replace: true});
 			}
 		}, [navigate, task.processDefinitionId, task.processInstanceKey, task.processName, task.state]);
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/route.tsx
@@ -12,11 +12,13 @@ import {createFileRoute, Outlet} from '@tanstack/react-router';
 import {ThemeProvider} from '#/shared/theme/shadcn.components/ThemeProvider';
 import {NotFoundPage} from '#/shared/pages/shadcn.components/NotFoundPage';
 import {GenericErrorPage} from '#/shared/pages/shadcn.components/GenericErrorPage';
+import {NetworkStatusWatcher} from '#/shared/notifications/shadcn.components/NetworkStatusWatcher';
 
 const Route = createFileRoute('/shadcn')({
 	component: function RouteComponent() {
 		return (
 			<ThemeProvider>
+				<NetworkStatusWatcher />
 				<Outlet />
 			</ThemeProvider>
 		);

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/shadcn.components/NetworkStatusWatcher.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/shadcn.components/NetworkStatusWatcher.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {describe, expect, vi} from 'vitest';
+import {afterEach, describe, expect, vi} from 'vitest';
 import {render} from 'vitest-browser-react';
 import {Toaster} from '@camunda/design-system';
 import {it} from '#/vitest-modules/test-extend';
@@ -20,6 +20,10 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
 );
 
 describe('<NetworkStatusWatcher />', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('should display a persistent notification when initially offline', async () => {
 		vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false);
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/shadcn.components/NetworkStatusWatcher.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/shadcn.components/NetworkStatusWatcher.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect, vi} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {Toaster} from '@camunda/design-system';
+import {it} from '#/vitest-modules/test-extend';
+import {NetworkStatusWatcher} from './NetworkStatusWatcher';
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+	<>
+		<Toaster />
+		{children}
+	</>
+);
+
+describe('<NetworkStatusWatcher />', () => {
+	it('should display a persistent notification when initially offline', async () => {
+		vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false);
+
+		const screen = await render(<NetworkStatusWatcher />, {wrapper: Wrapper});
+
+		await expect.element(screen.getByText('Internet connection lost')).toBeVisible();
+	});
+
+	it('should display one notification while offline and remove it after reconnecting', async () => {
+		vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(true);
+		const screen = await render(<NetworkStatusWatcher />, {wrapper: Wrapper});
+
+		expect(screen.getByText('Internet connection lost').elements()).toHaveLength(0);
+
+		window.dispatchEvent(new Event('offline'));
+		window.dispatchEvent(new Event('offline'));
+
+		await expect.element(screen.getByText('Internet connection lost')).toBeVisible();
+		expect(screen.getByText('Internet connection lost').elements()).toHaveLength(1);
+
+		window.dispatchEvent(new Event('online'));
+
+		await expect.element(screen.getByText('Internet connection lost')).not.toBeInTheDocument();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/shadcn.components/NetworkStatusWatcher.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/shadcn.components/NetworkStatusWatcher.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect, useRef} from 'react';
+import {useTranslation} from 'react-i18next';
+import {toast} from '@camunda/design-system';
+
+const NetworkStatusWatcher: React.FC = () => {
+	const notificationId = useRef<string | number | null>(null);
+	const {t} = useTranslation();
+
+	useEffect(() => {
+		function handleDisconnection() {
+			if (notificationId.current !== null) {
+				return;
+			}
+
+			notificationId.current = toast.info(t('networkStatusOfflineTitle'), {
+				duration: Infinity,
+			});
+		}
+
+		function handleReconnection() {
+			if (notificationId.current !== null) {
+				toast.dismiss(notificationId.current);
+				notificationId.current = null;
+			}
+		}
+
+		if (!window.navigator.onLine) {
+			handleDisconnection();
+		}
+
+		window.addEventListener('offline', handleDisconnection);
+		window.addEventListener('online', handleReconnection);
+
+		return () => {
+			window.removeEventListener('offline', handleDisconnection);
+			window.removeEventListener('online', handleReconnection);
+			handleReconnection();
+		};
+	}, [t]);
+
+	return null;
+};
+
+export {NetworkStatusWatcher};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/shadcn.components/TaskDetailsHeader.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/shadcn.components/TaskDetailsHeader.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render} from 'vitest-browser-react';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
 import {describe, expect} from 'vitest';
 import {it} from '#/vitest-modules/test-extend';
 import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
@@ -25,15 +25,19 @@ const baseProps = {
 
 describe('<TaskDetailsHeader />', () => {
 	it('should render task name and process name', async () => {
-		const screen = await render(<TaskDetailsHeader {...baseProps} />);
+		const screen = await renderWithRouter(() => <TaskDetailsHeader {...baseProps} />, {
+			path: '/shadcn/tasklist/$userTaskKey',
+			initialEntry: '/shadcn/tasklist/2251799813685281',
+		});
 
 		await expect.element(screen.getByText('Review invoice')).toBeVisible();
 		await expect.element(screen.getByText('Invoice process')).toBeVisible();
 	});
 
 	it('should render completion label with assignee for COMPLETED task', async () => {
-		const screen = await render(
-			<TaskDetailsHeader {...baseProps} taskState="COMPLETED" assignee={currentUser.username} />,
+		const screen = await renderWithRouter(
+			() => <TaskDetailsHeader {...baseProps} taskState="COMPLETED" assignee={currentUser.username} />,
+			{path: '/shadcn/tasklist/$userTaskKey', initialEntry: '/shadcn/tasklist/2251799813685281'},
 		);
 
 		await expect.element(screen.getByText(/Completed by/)).toBeVisible();
@@ -42,7 +46,10 @@ describe('<TaskDetailsHeader />', () => {
 	});
 
 	it('should render "Completed" without assignee for COMPLETED task', async () => {
-		const screen = await render(<TaskDetailsHeader {...baseProps} taskState="COMPLETED" assignee={null} />);
+		const screen = await renderWithRouter(
+			() => <TaskDetailsHeader {...baseProps} taskState="COMPLETED" assignee={null} />,
+			{path: '/shadcn/tasklist/$userTaskKey', initialEntry: '/shadcn/tasklist/2251799813685281'},
+		);
 
 		await expect.element(screen.getByText('Completed')).toBeVisible();
 		await expect.element(screen.getByTestId('completion-label')).toBeVisible();
@@ -51,7 +58,10 @@ describe('<TaskDetailsHeader />', () => {
 	it.for([{taskState: 'CREATED'}, {taskState: 'CANCELED'}, {taskState: 'FAILED'}] as const)(
 		'should render assignee tag and assign button for $taskState task',
 		async ({taskState}) => {
-			const screen = await render(<TaskDetailsHeader {...baseProps} taskState={taskState} assignee={null} />);
+			const screen = await renderWithRouter(
+				() => <TaskDetailsHeader {...baseProps} taskState={taskState} assignee={null} />,
+				{path: '/shadcn/tasklist/$userTaskKey', initialEntry: '/shadcn/tasklist/2251799813685281'},
+			);
 
 			await expect.element(screen.getByTestId('assignee')).toBeVisible();
 			await expect.element(screen.getByRole('button', {name: 'Assign to me'})).toBeVisible();
@@ -61,7 +71,10 @@ describe('<TaskDetailsHeader />', () => {
 	it.for([{taskState: 'UPDATING'}, {taskState: 'CANCELING'}] as const)(
 		'should render transition loading text and assignee for $taskState task',
 		async ({taskState}) => {
-			const screen = await render(<TaskDetailsHeader {...baseProps} taskState={taskState} assignee="john.doe" />);
+			const screen = await renderWithRouter(
+				() => <TaskDetailsHeader {...baseProps} taskState={taskState} assignee="john.doe" />,
+				{path: '/shadcn/tasklist/$userTaskKey', initialEntry: '/shadcn/tasklist/2251799813685281'},
+			);
 
 			await expect.element(screen.getByTestId('assignee')).toBeVisible();
 			await expect.element(screen.getByRole('button', {name: 'Assign to me'})).not.toBeInTheDocument();
@@ -69,8 +82,9 @@ describe('<TaskDetailsHeader />', () => {
 	);
 
 	it('should render only assignee for COMPLETING task', async () => {
-		const screen = await render(
-			<TaskDetailsHeader {...baseProps} taskState="COMPLETING" assignee={currentUser.username} />,
+		const screen = await renderWithRouter(
+			() => <TaskDetailsHeader {...baseProps} taskState="COMPLETING" assignee={currentUser.username} />,
+			{path: '/shadcn/tasklist/$userTaskKey', initialEntry: '/shadcn/tasklist/2251799813685281'},
 		);
 
 		await expect.element(screen.getByTestId('assignee')).toBeVisible();
@@ -78,13 +92,19 @@ describe('<TaskDetailsHeader />', () => {
 	});
 
 	it('should render only the assign button for ASSIGNING task', async () => {
-		const screen = await render(<TaskDetailsHeader {...baseProps} taskState="ASSIGNING" />);
+		const screen = await renderWithRouter(() => <TaskDetailsHeader {...baseProps} taskState="ASSIGNING" />, {
+			path: '/shadcn/tasklist/$userTaskKey',
+			initialEntry: '/shadcn/tasklist/2251799813685281',
+		});
 
 		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).toBeVisible();
 	});
 
 	it('should render only transition loading text for CREATING task', async () => {
-		const screen = await render(<TaskDetailsHeader {...baseProps} taskState="CREATING" />);
+		const screen = await renderWithRouter(() => <TaskDetailsHeader {...baseProps} taskState="CREATING" />, {
+			path: '/shadcn/tasklist/$userTaskKey',
+			initialEntry: '/shadcn/tasklist/2251799813685281',
+		});
 
 		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).not.toBeInTheDocument();
 	});

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/header.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/header.test.ts
@@ -70,6 +70,22 @@ test.describe('logout', () => {
 	});
 });
 
+test.describe('network status', () => {
+	test('should show a persistent notification when going offline and remove it when reconnecting', async ({
+		shadcnTasklistIndexPage,
+		page,
+	}) => {
+		await shadcnTasklistIndexPage.goto();
+		await expect(shadcnTasklistIndexPage.tasksPanel).toBeVisible();
+
+		await page.context().setOffline(true);
+		await expect(shadcnTasklistIndexPage.header.offlineNotification).toBeVisible();
+
+		await page.context().setOffline(false);
+		await expect(shadcnTasklistIndexPage.header.offlineNotification).not.toBeVisible();
+	});
+});
+
 test.describe('user sidebar', () => {
 	test('should display user details and update header text when language is changed', async ({
 		shadcnTasklistIndexPage,

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/task-details.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/task-details.test.ts
@@ -85,6 +85,31 @@ test.describe('Task details page', () => {
 		await expect(shadcnTaskDetailPage.taskTab).toHaveAttribute('aria-selected', 'true');
 	});
 
+	test('should navigate to initial page preserving search params when task is cancelled', async ({
+		network,
+		shadcnTaskDetailPage,
+		page,
+	}) => {
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(
+					createUserTask({
+						state: 'CANCELED',
+						processName: 'Invoice process',
+						processInstanceKey: '2251799813685280',
+					}),
+				),
+			}),
+		);
+
+		await shadcnTaskDetailPage.goto('2251799813685281', '?filter=assigned-to-me');
+
+		await expect(page).toHaveURL('/shadcn/tasklist?filter=assigned-to-me');
+		const notification = shadcnTaskDetailPage.header.notifications.getByNotificationTitle('Process instance cancelled');
+		await expect(notification).toBeVisible();
+		await expect(notification).toContainText('Invoice process (2251799813685280)');
+	});
+
 	test('should switch tabs and update the URL', async ({network, shadcnTaskDetailPage: taskDetailPage, page}) => {
 		network.use(
 			mockGetProcessDefinitionXmlEndpoint({

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/ShadcnHeader.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/ShadcnHeader.ts
@@ -40,6 +40,10 @@ class ShadcnHeader extends View {
 		return this.page.getByRole('menuitem', {name: /log out/i});
 	}
 
+	get offlineNotification() {
+		return this.notifications.getByNotificationTitle('Internet connection lost');
+	}
+
 	get documentationLink() {
 		return this.page.getByRole('menuitem', {name: 'Documentation'});
 	}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

These are small features and tests that were missed during the design system migration

- Session heartbeat support
- Live canceled-task handling
- Offline status notification
- Test coverage updates for canceled-task redirects

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

relates #59208

- [ ] This PR does not need a linked issue

