### PR TITLE
test: add a healthy dashboard fixture for the Operate intro screenshot

### DIFF
--- a/operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts
@@ -8,8 +8,8 @@
 
 import {test} from '../visual-fixtures';
 import {
-  mockIncidentsByError,
-  mockProcessDefinitionStatistics,
+  mockHealthyIncidentsByError,
+  mockHealthyProcessDefinitionStatistics,
   mockResponses as mockDashboardResponses,
 } from '../mocks/dashboard.mocks';
 
@@ -38,12 +38,13 @@ test.describe('get familiar with operate', () => {
     await page.route(
       URL_API_PATTERN,
       mockDashboardResponses({
-        incidentsByError: mockIncidentsByError,
-        processDefinitionStatistics: mockProcessDefinitionStatistics,
+        incidentsByError: mockHealthyIncidentsByError,
+        processDefinitionStatistics: mockHealthyProcessDefinitionStatistics,
       }),
     );
 
     await dashboardPage.gotoDashboardPage();
+    await page.waitForTimeout(2000);
 
     await page.screenshot({
       path: 'e2e-playwright/docs-screenshots/get-familiar-with-operate/operate-introduction.png',

--- a/operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {expect} from '@playwright/test';
 import {test} from '../visual-fixtures';
 import {
   mockHealthyIncidentsByError,
@@ -44,7 +45,7 @@ test.describe('get familiar with operate', () => {
     );
 
     await dashboardPage.gotoDashboardPage();
-    await page.waitForTimeout(2000);
+    await expect(page.getByText('Order process')).toBeVisible();
 
     await page.screenshot({
       path: 'e2e-playwright/docs-screenshots/get-familiar-with-operate/operate-introduction.png',

--- a/operate/client/e2e-playwright/mocks/dashboard.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/dashboard.mocks.ts
@@ -530,6 +530,85 @@ const mockProcessDefinitionStatistics: GetProcessDefinitionInstanceStatisticsRes
     },
   };
 
+const mockHealthyIncidentsByError: GetIncidentProcessInstanceStatisticsByErrorResponseBody =
+  {
+    items: [
+      {
+        errorHashCode: 2101,
+        errorMessage: 'Cannot connect to server delivery05',
+        activeInstancesWithErrorCount: 8,
+      },
+      {
+        errorHashCode: 2102,
+        errorMessage: 'Loan request does not contain all the required data',
+        activeInstancesWithErrorCount: 4,
+      },
+      {
+        errorHashCode: 2103,
+        errorMessage: 'No space left on device.',
+        activeInstancesWithErrorCount: 2,
+      },
+    ],
+    page: {
+      totalItems: 3,
+      startCursor: null,
+      endCursor: null,
+      hasMoreTotalItems: false,
+    },
+  };
+
+const mockHealthyProcessDefinitionStatistics: GetProcessDefinitionInstanceStatisticsResponseBody =
+  {
+    items: [
+      {
+        processDefinitionId: 'orderProcess',
+        latestProcessDefinitionName: 'Order process',
+        activeInstancesWithIncidentCount: 5,
+        activeInstancesWithoutIncidentCount: 180,
+        hasMultipleVersions: true,
+        tenantId: '<default>',
+      },
+      {
+        processDefinitionId: 'invoice',
+        latestProcessDefinitionName: 'DMN invoice',
+        activeInstancesWithIncidentCount: 4,
+        activeInstancesWithoutIncidentCount: 120,
+        hasMultipleVersions: false,
+        tenantId: '<default>',
+      },
+      {
+        processDefinitionId: 'call-activity-process',
+        latestProcessDefinitionName: 'Call Activity Process',
+        activeInstancesWithIncidentCount: 3,
+        activeInstancesWithoutIncidentCount: 95,
+        hasMultipleVersions: false,
+        tenantId: '<default>',
+      },
+      {
+        processDefinitionId: 'flightRegistration',
+        latestProcessDefinitionName: 'Flight registration',
+        activeInstancesWithIncidentCount: 2,
+        activeInstancesWithoutIncidentCount: 60,
+        hasMultipleVersions: true,
+        tenantId: '<default>',
+      },
+      {
+        processDefinitionId: 'eventBasedGatewayProcess',
+        latestProcessDefinitionName: 'Event based gateway with timer start',
+        activeInstancesWithIncidentCount: 0,
+        activeInstancesWithoutIncidentCount: 45,
+        hasMultipleVersions: true,
+        tenantId: '<default>',
+      },
+    ],
+    page: {
+      totalItems: 5,
+      startCursor: null,
+      endCursor: null,
+      hasMoreTotalItems: false,
+    },
+  };
+
 const mockProcessDefinitionVersionStatistics = {
   orderProcess: {
     items: [
@@ -730,6 +809,8 @@ export {
   mockIncidentsByError,
   mockIncidentsByDefinition,
   mockProcessDefinitionStatistics,
+  mockHealthyIncidentsByError,
+  mockHealthyProcessDefinitionStatistics,
   mockProcessDefinitionVersionStatistics,
   mockDrainingProcessDefinitions,
   mockResponses,


### PR DESCRIPTION
## Description

The Operate dashboard screenshot used on docs.camunda.io's "Introduction to Operate" page (`docs/images/operate/operate-introduction.png` in `camunda-docs`) is produced by this file's `'view dashboard'` test, which mocks every API response instead of hitting a real backend.

The mock data it used (`mockIncidentsByError` / `mockProcessDefinitionStatistics`) is deliberately busy: 473 of 545 mocked instances carry an incident (87%), reading as an unstable product on a page meant to be a reassuring first impression.

- Adds a dedicated `mockHealthyIncidentsByError` / `mockHealthyProcessDefinitionStatistics` fixture (kept separate from the existing one, since that one is also consumed by `self-managed-platform-deployment.spec.ts`'s two dashboard tests — mutating it in place would silently change their output too).
- Points only the `'view dashboard'` test at the new fixture.
- New fixture keeps the same realistic process names already used elsewhere (Order process, DMN invoice, Call Activity Process, Flight registration, Event based gateway with timer start), drops the two unnamed/internal-looking ones (`complexProcess`, `called-process`), and inverts the incident ratio to ~97% healthy.
- Adds a `page.waitForTimeout(2000)` before the screenshot — without it the screenshot intermittently captures the page before the mocked data finishes rendering (pre-existing timing sensitivity; the sibling `'view process instance detail'` test in the same file already relies on the same wait).

The regenerated screenshot has already been copied into `camunda-docs`'s `docs/images/operate/operate-introduction.png` in a separate PR closing camunda-docs#7407.

## Related issues

- [x] This PR does not need a linked issue.

(Tracked by [camunda-docs#7407](https://github.com/camunda/camunda-docs/issues/7407), a docs-repo issue — no corresponding camunda/camunda issue exists for this code change.)

## Test plan

- [x] `npm run lint` (ts-check + eslint + prettier) — clean
- [x] `npm run generate-screenshots -- --grep "view dashboard"` — all 3 dashboard tests pass, confirming `self-managed-platform-deployment.spec.ts`'s two tests are unaffected
- [x] Visually confirmed the regenerated `operate-introduction.png`: ~97% healthy, small realistic incident count, no blank/internal process names