### PR TITLE
feat: model job lease token as an opaque engine-minted semantic key

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -643,7 +643,8 @@ components:
             this activation from any other activation of the same job: if the job is
             later retried, history items submitted under a superseded lease are discarded
             rather than committed.
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
         history:
           description: |
             A batch of history items to append to the agent instance's conversation
@@ -717,7 +718,8 @@ components:
             this activation from any other activation of the same job: if the job is
             later retried, history items submitted under a superseded lease are discarded
             rather than committed.
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
         history:
           description: |
             A batch of history items to append to the agent instance's conversation
@@ -1025,7 +1027,8 @@ components:
             - $ref: 'keys.yaml#/components/schemas/JobKey'
         jobLease:
           description: The lease token of the activation that produced this item.
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
         loopIteration:
           description: The loop iteration this item belongs to.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -239,9 +239,9 @@ components:
         activated with a lease, and passed back on fenced job commands — and on
         agent-instance creation/updates as `jobLease` — to prove the caller holds the
         current lease. The token is opaque: clients may rely on its presence and equality
-        only, and must never construct, parse, compare, or otherwise interpret it. It
-        cannot be minted client-side; only the engine produces it, exactly once per leased
-        activation, and clients must not depend on any particular internal format.
+        only, and must never construct, parse, or otherwise interpret it beyond equality
+        checks. It cannot be minted client-side; only the engine produces it, exactly once
+        per leased activation, and clients must not depend on any particular internal format.
       type: string
       format: JobLeaseToken
       x-semantic-type: JobLeaseToken

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -232,6 +232,22 @@ components:
       # matches the RDBMS secondary storage's varchar column size.
       example: item-1
 
+    JobLeaseToken:
+      description: |
+        An opaque, engine-minted fencing token identifying a single activation of a job.
+        Returned by Activate Jobs as `ActivatedJobResult.leaseToken` when the job is
+        activated with a lease, and passed back on fenced job commands — and on
+        agent-instance creation/updates as `jobLease` — to prove the caller holds the
+        current lease. The token is opaque: clients may rely on its presence and equality
+        only, and must never construct, parse, compare, or otherwise interpret it. It
+        cannot be minted client-side; only the engine produces it, exactly once per leased
+        activation, and clients must not depend on any particular internal format.
+      type: string
+      format: JobLeaseToken
+      x-semantic-type: JobLeaseToken
+      minLength: 1
+      example: "550e8400-e29b-41d4-a716-446655440000"
+
     ## Filters
 
     ElementIdFilterProperty:

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -439,6 +439,7 @@ components:
         - elementId
         - jobKey
         - elementInstanceKey
+        - leaseToken
       type: object
       required:
         - type
@@ -570,7 +571,8 @@ components:
             The lease token identifying this activation. This is `null` when the job was
             activated without a lease.
           nullable: true
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
       x-properties-added-in-version:
         - propertyName: jobKey
           addedInVersionOverride: "8.6"
@@ -1057,8 +1059,9 @@ components:
             another worker).
 
             A job that was activated without a lease requires no token.
-          type: string
           nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
       x-properties-added-in-version:
         - propertyName: leaseToken
           addedInVersion: "8.10"
@@ -1094,8 +1097,9 @@ components:
             another worker).
 
             A job that was activated without a lease requires no token.
-          type: string
           nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
       required:
         - errorCode
       x-properties-added-in-version:
@@ -1125,8 +1129,9 @@ components:
             another worker).
 
             A job that was activated without a lease requires no token.
-          type: string
           nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
         businessId:
           nullable: true
           description: >
@@ -1305,8 +1310,9 @@ components:
             throw-error that always require a token for leased jobs.
 
             A job that was activated without a lease requires no token.
-          type: string
           nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
       required:
         - changeset
       x-properties-added-in-version:


### PR DESCRIPTION
## Description

The job lease token — returned as `ActivatedJobResult.leaseToken` and consumed on fenced job commands (complete, fail, throw-error, update) and as `CreateAgentInstanceRequest.jobLease` — was declared as a plain inline `type: string`. As a result:

- **SDK generators** (e.g. `orchestration-cluster-api-js`) emitted an unbranded `string` instead of a nominal branded type, so a token could be passed anywhere a string is accepted.
- The **dependency-graph test generator** had no producer to lift a valid token from, leaving fenced-command chains unplannable.

### What this changes

1. **New `JobLeaseToken` schema** in `identifiers.yaml` with matching `format` and `x-semantic-type: JobLeaseToken`; all five `leaseToken` fields (`jobs.yaml`) and three `jobLease` fields (`agent-instances.yaml`) now `$ref` it. Branding SDKs get a `CamundaKey<'JobLeaseToken'>` that flows type-safely from the activation response into the downstream requests.
2. **Opaque + engine-minted**, per ADR [`0005-810-job-lease`](https://github.com/camunda/camunda/blob/main/zeebe/docs/adr/0005-810-job-lease.md) (D1): the schema deliberately carries **no `pattern`** and is **not `x-semantic-client-minted`**, so the branded type cannot be constructed client-side and the test generator knows it must extract the token rather than synthesise one.
3. **`leaseToken` added to `ActivatedJobResult.x-semantic-provider`** so the graph marks the activation response as the token's canonical producer and binds it into the consumer requests by shared semantic type — the only viable route given the value cannot be forged. No `x-semantic-requires` is needed; engine-minted keys bind by provider + matching semantic type, exactly as `deploymentKey`/`processDefinitionKey` already do.

### Wire contract

Unchanged — the token remains a JSON string. These are spec annotations affecting SDK/tooling code generation only. Spectral lints clean.

## Related issues

relates to #54840
