### PR TITLE
feat: model agent-instance and message elementId as the semantic ElementId

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -527,9 +527,10 @@ components:
           nullable: true
           description: A human-readable description of the tool.
         elementId:
-          type: string
-          nullable: true
           description: The BPMN element ID of the tool element within the ad-hoc sub-process.
+          nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ElementId'
 
     AgentInstanceMetrics:
       description: Aggregated metrics for an agent instance across all model calls.
@@ -1207,8 +1208,9 @@ components:
           type: string
         elementId:
           description: The BPMN element ID handling this tool.
-          type: string
           nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ElementId'
         arguments:
           description: |
             The tool call arguments as provided by the LLM. May be null or populated on

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -663,7 +663,8 @@ components:
           format: date-time
         elementId:
           description: The element ID that received the message.
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ElementId'
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'


### PR DESCRIPTION
## Description

Three response fields that carry a BPMN element ID were declared as plain inline `type: string`, so branding SDK generators (e.g. `orchestration-cluster-api-js`) emitted an unbranded `string` for them — while the same element-ID concept is a nominal `CamundaKey<'ElementId'>` everywhere else in the API.

The semantic `ElementId` type is already referenced in ~18 value fields across the spec (including `agent-instances.yaml` itself, a few lines above one of these), so these are a plain inconsistency rather than a real modelling gap — the target type already exists.

### What this changes

Point the three fields at `identifiers.yaml#/components/schemas/ElementId`:

- `agent-instances.yaml` — AgentInstance tool element result (ad-hoc sub-process element ID)
- `agent-instances.yaml` — agent history tool item (element ID handling the tool)
- `messages.yaml` — `CorrelatedMessageSubscriptionResult` (element ID that received the message)

Nullable fields keep their `nullable: true` alongside the `allOf` reference, matching the existing convention for nullable semantic-typed properties.

### Out of scope

A handful of **search filters** use the generic `filters.yaml#/StringFilterProperty` instead of the semantic `ElementIdFilterProperty` (`incidents`, `jobs`, `messages`, `process-instances`). That is a pre-existing, separate filter-side inconsistency and is intentionally not touched here.

### Wire contract

Unchanged — the value stays a JSON string. These are spec annotations affecting SDK/tooling code generation only. Spectral lints clean.

## Related issues

relates to #54840
