### PR TITLE
build: remove unused `maven.compiler.source/target` overridden by `release` in parent pom

### DIFF
--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -19,8 +19,6 @@
   </modules>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit-jupiter-api.version>5.10.2</junit-jupiter-api.version>
   </properties>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -22,9 +22,6 @@
   </modules>
 
   <properties>
-    <maven.compiler.target>21</maven.compiler.target>
-    <maven.compiler.source>21</maven.compiler.source>
-
     <skipSurefire>false</skipSurefire>
     <testForkCount>${env.LIMITS_CPU}</testForkCount>
     <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -88,8 +88,6 @@
     <skip.docker>false</skip.docker>
     <docker.compose.file>docker-compose.yml</docker.compose.file>
 
-    <maven.compiler.target>21</maven.compiler.target>
-    <maven.compiler.source>21</maven.compiler.source>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
@@ -454,7 +452,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.16.0</version>
         <configuration>
-          <release>${maven.compiler.target}</release>
+          <release>${version.java}</release>
         </configuration>
       </plugin>
 

--- a/qa/testcontainer/pom.xml
+++ b/qa/testcontainer/pom.xml
@@ -15,8 +15,6 @@
   <name>Camunda TestContainer</name>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -22,9 +22,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <maven.compiler.target>21</maven.compiler.target>
-    <maven.compiler.source>21</maven.compiler.source>
-
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 

--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -19,8 +19,6 @@
   <packaging>jar</packaging>
   <name>Dynamic NodeId Provider</name>
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>

--- a/zeebe/journal/pom.xml
+++ b/zeebe/journal/pom.xml
@@ -16,8 +16,6 @@
   <name>Zeebe Journal</name>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
   </properties>
 


### PR DESCRIPTION
## Description

Removes unused properties for java source/target version:
- in zeebe/journal it was wrong (java 11)
- in all the other modules matched the `-release 21` defined in po.xml

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

