### PR TITLE
docs: add instructions to AGENTS.md to persist session in STATE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ load-tests/setup/c8-*
 
 # python caches from scripts in skills
 **/__pycache__/**
+
+# Used by agents to persist session state
+STATE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ https://raw.githubusercontent.com/camunda/.github/refs/heads/main/AGENTS.md
 Treat the central file's contents as if they were written directly in this file.
 Instructions below extend those guidelines and take precedence if there is any conflict.
 
+## Quick start
+
+If the user prompts you to persist/save/output session state do the following:
+- Read `STATE.md` at repo root if it exists (session continuity file, gitignored). Record discoveries and remaining work there as you go, under `## Goal / Instructions / Discoveries / Accomplished / Not Yet Done / Relevant Files` — keep it useful to a fresh session.
+
 ## Repo-specific instructions
 
 ### Role & boundary


### PR DESCRIPTION

## Description

Inspired by `camunda-platform-helm/AGENTS.md`, it instructs the agent to persist anything useful from the session into STATE.md (gitignored).

I added a preamble mentioning to do this only if the user requests the agent to do this (or it's saved in its memory files) so it's not done for ephemeral sessions (like copilot)


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

