### PR TITLE
Fix flaky AgentInstanceMigrationIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -38,9 +39,14 @@ import org.junit.jupiter.api.Test;
 @MultiDbTest
 public class AgentInstanceMigrationIT {
 
-  private static final String AGENT_JOB_TYPE = "agent-task";
-
   private static CamundaClient client;
+
+  private String agentJobType;
+
+  @BeforeEach
+  void setUp() {
+    agentJobType = uniqueAgentJobType();
+  }
 
   @Test
   void shouldMigrateOrphanedButActiveAgentInstanceOfServiceTask() {
@@ -57,8 +63,7 @@ public class AgentInstanceMigrationIT {
             Bpmn.createExecutableProcess("migration-agent-service-task_v1")
                 .startEvent()
                 .serviceTask(
-                    sourceElementId,
-                    t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    sourceElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
                 .userTask(sourceNextElementId)
                 .endEvent()
                 .done(),
@@ -69,8 +74,7 @@ public class AgentInstanceMigrationIT {
             Bpmn.createExecutableProcess("migration-agent-service-task_v2")
                 .startEvent()
                 .serviceTask(
-                    targetElementId,
-                    t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    targetElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
                 .userTask(targetNextElementId)
                 .endEvent()
                 .done(),
@@ -82,7 +86,7 @@ public class AgentInstanceMigrationIT {
     final long sourceAgentDefinitionKey =
         client.newAgentInstanceGetRequest(agentInstanceKey).execute().getAgentDefinitionKey();
 
-    activateAndCompleteJobs(client, AGENT_JOB_TYPE, "test-worker", 1);
+    activateAndCompleteJobs(client, agentJobType, "test-worker", 1);
     waitForElementInstances(
         client, f -> f.elementId(sourceNextElementId).processInstanceKey(processInstanceKey), 1);
 
@@ -115,7 +119,7 @@ public class AgentInstanceMigrationIT {
             Bpmn.createExecutableProcess("migration-agent-ahsp_v1")
                 .startEvent()
                 .adHocSubProcess(sourceElementId, p -> p.task("agentTask"))
-                .zeebeJobType(AGENT_JOB_TYPE)
+                .zeebeJobType(agentJobType)
                 .zeebeAiAgentSubProcessDefinition()
                 .endEvent()
                 .done(),
@@ -126,7 +130,7 @@ public class AgentInstanceMigrationIT {
             Bpmn.createExecutableProcess("migration-agent-ahsp_v2")
                 .startEvent()
                 .adHocSubProcess(targetElementId, p -> p.task("agentTask2"))
-                .zeebeJobType(AGENT_JOB_TYPE)
+                .zeebeJobType(agentJobType)
                 .zeebeAiAgentSubProcessDefinition()
                 .endEvent()
                 .done(),
@@ -172,7 +176,7 @@ public class AgentInstanceMigrationIT {
     final var activatedJob =
         client
             .newActivateJobsCommand()
-            .jobType(AGENT_JOB_TYPE)
+            .jobType(agentJobType)
             .maxJobsToActivate(1)
             .timeout(Duration.ofMinutes(5))
             .send()
@@ -200,6 +204,10 @@ public class AgentInstanceMigrationIT {
 
     waitForAgentInstanceToBeIndexed(client, agentInstanceKey);
     return agentInstanceKey;
+  }
+
+  private static String uniqueAgentJobType() {
+    return "agent-task-" + UUID.randomUUID();
   }
 
   private static AgentInstanceHistoryItem configurationHistoryItem(


### PR DESCRIPTION
## Description

`AgentInstanceMigrationIT.shouldMigrateAgentInstanceOfAdHocSubProcess` flaked because its `createAgentInstance` helper activated one agentic job by type and assumed it belonged to the element instance it had just looked up. The class constant `AGENT_JOB_TYPE` (`"agent-task"`) was shared by both tests in this file, and by several other IT classes running against the same cluster. Job activation is scoped to the job type, not to an element instance, so under contention the `CREATE` agent-instance command could land on a job that belongs to a different element instance than the one requested, and gets rejected.

Rather than reconciling which job belongs to which element instance after the fact, each test now generates its own job type (`"agent-task-<random UUID>"`). This removes the contention at its source: no other test, in this class or any other, can ever activate a job meant for a different test, so activation always returns the right job on the first try.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #62483
