### PR TITLE
test: fix resource leak because of Junit 4 rule not set up correctly

### DIFF
--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -319,6 +319,12 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -319,12 +319,6 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -61,15 +61,18 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
+import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ZeebeIntegration
+@EnableRuleMigrationSupport
 class BackupMultiPartitionTest {
   @Container private static final MinioContainer S3 = new MinioContainer();
   private static final String JOB_TYPE = "test";
@@ -88,7 +91,6 @@ class BackupMultiPartitionTest {
   private BackupStore s3BackupStore;
   private S3BackupConfig s3ClientConfig;
   private String bucketName = null;
-  private GrpcClientRule client;
   private BackupRequestHandler backupRequestHandler;
   private BackupActuator backupActuator;
 
@@ -100,6 +102,14 @@ class BackupMultiPartitionTest {
           .withReplicationFactor(1)
           .withBrokerConfig(b -> b.withUnifiedConfig(this::configureBackupStore))
           .build();
+
+  @Rule
+  public final GrpcClientRule client =
+      new GrpcClientRule(
+          builder -> {
+            final var gateway = cluster.availableGateway();
+            builder.restAddress(gateway.restAddress()).grpcAddress(gateway.grpcAddress());
+          });
 
   private void configureBackupStore(final Camunda config) {
 
@@ -144,7 +154,6 @@ class BackupMultiPartitionTest {
 
   @BeforeEach
   void setup() {
-    client = new GrpcClientRule(cluster.newClientBuilder().build());
     backupActuator = BackupActuator.of(cluster.anyGateway());
     backupRequestHandler = new BackupRequestHandler(cluster.anyGateway().bean(BrokerClient.class));
     createBackupStoreForTest();
@@ -152,8 +161,7 @@ class BackupMultiPartitionTest {
 
   @AfterEach
   void close() {
-    // Create bucket before for storing backups
-    s3BackupStore.closeAsync();
+    s3BackupStore.closeAsync().join();
     // reset so that each test can use a different bucket name
     bucketName = null;
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -11,6 +11,7 @@ import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static java.util.function.Predicate.isEqual;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
@@ -25,8 +26,8 @@ import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationUtil;
-import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.it.util.RecordingJobHandler;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
@@ -61,18 +62,16 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
-import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ZeebeIntegration
-@EnableRuleMigrationSupport
 class BackupMultiPartitionTest {
   @Container private static final MinioContainer S3 = new MinioContainer();
   private static final String JOB_TYPE = "test";
@@ -91,6 +90,8 @@ class BackupMultiPartitionTest {
   private BackupStore s3BackupStore;
   private S3BackupConfig s3ClientConfig;
   private String bucketName = null;
+  @AutoClose private CamundaClient client;
+  private ZeebeResourcesHelper resourcesHelper;
   private BackupRequestHandler backupRequestHandler;
   private BackupActuator backupActuator;
 
@@ -102,14 +103,6 @@ class BackupMultiPartitionTest {
           .withReplicationFactor(1)
           .withBrokerConfig(b -> b.withUnifiedConfig(this::configureBackupStore))
           .build();
-
-  @Rule
-  public final GrpcClientRule client =
-      new GrpcClientRule(
-          builder -> {
-            final var gateway = cluster.availableGateway();
-            builder.restAddress(gateway.restAddress()).grpcAddress(gateway.grpcAddress());
-          });
 
   private void configureBackupStore(final Camunda config) {
 
@@ -154,6 +147,8 @@ class BackupMultiPartitionTest {
 
   @BeforeEach
   void setup() {
+    client = cluster.newClientBuilder().build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
     backupActuator = BackupActuator.of(cluster.anyGateway());
     backupRequestHandler = new BackupRequestHandler(cluster.anyGateway().bean(BrokerClient.class));
     createBackupStoreForTest();
@@ -175,7 +170,7 @@ class BackupMultiPartitionTest {
     takeBackupOnPartition(backupId, 1);
 
     // when
-    client.deployProcess(SIMPLE_PROCESS);
+    resourcesHelper.deployProcess(SIMPLE_PROCESS);
 
     // then
     waitUntilBackupIsCompleted(backupId);
@@ -185,7 +180,7 @@ class BackupMultiPartitionTest {
   @Timeout(value = 120)
   void shouldTriggerBackupViaInterPartitionMessageSubscriptionCommands() {
     // given
-    final long processKey = client.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
+    final long processKey = resourcesHelper.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
 
     final long backupId = 2;
     // trigger backup only on partition 1
@@ -202,7 +197,7 @@ class BackupMultiPartitionTest {
   @Timeout(value = 120)
   void shouldTriggerBackupViaInterPartitionMessageCorrelationCommands() {
     // given
-    final long processKey = client.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
+    final long processKey = resourcesHelper.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
     createProcessInstanceOnPartitionOne(processKey);
 
     final long backupId = 3;
@@ -231,8 +226,7 @@ class BackupMultiPartitionTest {
 
     // then
     final var jobHandler = new RecordingJobHandler();
-    try (final var ignored =
-        client.getClient().newWorker().jobType(JOB_TYPE).handler(jobHandler).open()) {
+    try (final var ignored = client.newWorker().jobType(JOB_TYPE).handler(jobHandler).open()) {
       Awaitility.await("All jobs created before restoring the cluster are activated")
           .timeout(Duration.ofSeconds(30))
           .untilAsserted(
@@ -304,7 +298,7 @@ class BackupMultiPartitionTest {
   void canRetrieveCheckpointStateFromMultiplePartitions()
       throws ExecutionException, InterruptedException, TimeoutException {
     // given
-    final long processKey = client.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
+    final long processKey = resourcesHelper.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
     createProcessInstanceOnPartitionOne(processKey);
 
     final long backupId = 3;
@@ -366,7 +360,7 @@ class BackupMultiPartitionTest {
   void canRetrieveCheckpointStateFromPartialPartitions()
       throws ExecutionException, InterruptedException, TimeoutException {
     // given
-    final long processKey = client.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
+    final long processKey = resourcesHelper.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
     createProcessInstanceOnPartitionOne(processKey);
 
     final long backupId = 3;
@@ -402,7 +396,7 @@ class BackupMultiPartitionTest {
     final Set<Integer> partitions = new HashSet<>();
     final Set<Long> jobKeys = new HashSet<>();
     while (partitions.size() < cluster.partitionsCount()) {
-      final long jobKey = client.createSingleJob(JOB_TYPE);
+      final long jobKey = resourcesHelper.createSingleJob(JOB_TYPE);
       jobKeys.add(jobKey);
       partitions.addAll(
           RecordingExporter.jobRecords(JobIntent.CREATED)
@@ -474,7 +468,6 @@ class BackupMultiPartitionTest {
 
   private void publishMessageAndWaitUntilCorrelated() {
     client
-        .getClient()
         .newPublishMessageCommand()
         .messageName(MESSAGE_NAME)
         .correlationKey(CORRELATION_KEY_VALUE_FOR_PARTITION_2)
@@ -496,7 +489,6 @@ class BackupMultiPartitionTest {
             () -> {
               final var createInstanceResult =
                   client
-                      .getClient()
                       .newCreateInstanceCommand()
                       .processDefinitionKey(processKey)
                       .variables(Map.of(CORRELATION_KEY, CORRELATION_KEY_VALUE_FOR_PARTITION_2))


### PR DESCRIPTION
## Description
GrpcRule is a junit4 rule running a junit 5 test: as a result its resources where not released correctly at the end of the test case.

This was identified as a flaky test from the [daily report](https://camunda.slack.com/archives/C071KP5BTHB/p1788935446988789)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

