### PR TITLE
ci: stop fetching a retry wrapper at runtime to retry setup and build steps

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -120,7 +120,7 @@ runs:
     # above and what build-push-action already resolved this to: it splits build args on newlines,
     # so any further line was never a VERSION value to begin with.
     - name: Reduce a multi-valued version to the first value
-      id: get-build-inputs
+      id: get-version-build-arg
       shell: bash
       env:
         VERSION_INPUT: ${{ inputs.version }}
@@ -161,5 +161,5 @@ runs:
           DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}
           REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
-          VERSION=${{ steps.get-build-inputs.outputs.version }}
+          VERSION=${{ steps.get-version-build-arg.outputs.version }}
           ${{ steps.get-additional-build-args.outputs.result }}

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -83,49 +83,12 @@ runs:
         fi
 
     - name: Set up Docker Buildx
-      # Wrapped in Wandalen/wretry.action: booting the builder pulls moby/buildkit from Docker Hub,
-      # which answers 502 often enough to be the most frequent way an image build fails on healthy
-      # code. It's a `uses:` step, so nick-fields/retry (our usual retry action, shell-command only)
-      # can't wrap it.
-      #
-      # Pinned to `_js_action`, not the documented `v3.8.0` composite, so github_context/env_context/
-      # job_context/matrix_context below can be overridden -- see
-      # https://github.com/Wandalen/wretry.action/issues/182. Blanked out because
-      # docker/setup-buildx-action's action.yml has no `${{ }}` expressions of its own; re-check this
-      # if that's still true when its pin next bumps.
-      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
+      uses: ./.github/actions/setup-buildx-with-retry
       with:
-        action: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        # wretry cannot inspect the wrapped action's error -- `retry_condition` only sees contexts
-        # captured before the step ran -- so this retries any failure, not just a 5xx. A genuine
-        # error therefore costs up to 3 attempts before reporting red.
-        attempt_limit: 3
-        attempt_delay: 10000
-        # wretry clones the wrapped action at runtime; without a token that clone gets HTTP 403
-        github_token: ${{ github.token }}
-        github_context: '{}'
-        env_context: '{}'
-        job_context: '{}'
-        matrix_context: '{}'
-        with: |
-          # to be able to push to local registry, which we use in our tests, we need to use host network
-          driver-opts: network=host
-          buildkitd-flags: ${{ inputs.debug == 'true' && '--debug' || '' }}
-          endpoint: zeebe-context
-
-    # wretry passes the wrapped action's inputs by exporting them into GITHUB_ENV, so all of
-    # setup-buildx-action's INPUT_* variables stay set for the rest of the job -- well past this
-    # composite action. A later step that does not declare one of these inputs itself would read the
-    # stale value instead of that action's own default; `version`, `name` and `platforms` are common
-    # enough input names to collide. GITHUB_ENV cannot unset, so blank them out.
-    # Runs even when the step above exhausted its attempts: that is exactly when the variables have
-    # been exported and no later step will overwrite them, so any `always()` or post step in the job
-    # would otherwise inherit them.
-    - name: Clear buildx inputs leaked into the job environment by wretry
-      if: always()
-      shell: bash
-      run: |
-        env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
+        # to be able to push to local registry, which we use in our tests, we need to use host network
+        driver-opts: network=host
+        buildkitd-flags: ${{ inputs.debug == 'true' && '--debug' || '' }}
+        endpoint: zeebe-context
 
     - name: Set semantic version from Maven project
       id: get-version
@@ -153,23 +116,16 @@ runs:
       run: echo "result=$(echo '${{ steps.get-image.outputs.tags }}' | head -n 1)" >> $GITHUB_OUTPUT
 
     # The `version` input accepts a list, and the snapshot deploy jobs in ci.yml pass two versions.
-    # Both values derived from it reach the wrapped build step, whose inputs wretry re-parses as
-    # YAML: a second line would land at column 0 and break the block before build-push-action ever
-    # runs. Both are reduced to a single line here.
-    - name: Reduce the multi-valued build inputs to a single line
+    # The VERSION build arg takes a single one. Keeping the first matches both the image name output
+    # above and what build-push-action already resolved this to: it splits build args on newlines,
+    # so any further line was never a VERSION value to begin with.
+    - name: Reduce a multi-valued version to the first value
       id: get-build-inputs
       shell: bash
       env:
-        TAGS: ${{ steps.get-image.outputs.tags }}
         VERSION_INPUT: ${{ inputs.version }}
         MAVEN_VERSION: ${{ steps.get-version.outputs.result }}
       run: |
-        # build-push-action parses `tags` with the same list helper as `platforms`, which this action
-        # already passes comma-separated, so joining is equivalent to the newline-separated form.
-        echo "tags=$(echo "$TAGS" | paste -sd, -)" >> "$GITHUB_OUTPUT"
-        # The VERSION build arg takes a single version. Keeping the first one matches both the image
-        # name output above and what build-push-action already resolved this to: it splits build args
-        # on newlines, so any further line was never a VERSION value to begin with.
         version="${VERSION_INPUT:-$MAVEN_VERSION}"
         echo "version=$(echo "$version" | head -n 1)" >> "$GITHUB_OUTPUT"
 
@@ -195,55 +151,15 @@ runs:
         fi
 
     - name: Build Docker image
-      # Wrapped for the same reason as the buildx setup above: BuildKit resolves the Dockerfile
-      # frontend and the base images through Docker Hub, whose token endpoint answers 5xx or drops
-      # the connection often enough to fail the build before a single layer is built.
-      #
-      # Pinned to `_js_action` for the same reason as the buildx step above. build-push-action's only
-      # `${{ }}` expression is its `github-token` default, set explicitly below instead since the
-      # context that would resolve it is blanked out; re-check on future version bumps.
-      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
-      env:
-        DOCKER_BUILD_SUMMARY: false
-        DOCKER_BUILD_RECORD_UPLOAD: false
+      uses: ./.github/actions/docker-build-with-retry
       with:
-        action: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        # As above, wretry cannot classify the failure, so a broken Dockerfile or a 4xx from the
-        # registry is retried just like a 5xx. Layers already built are cached in the builder, which
-        # persists across attempts, so a replay is cheap up to the point that failed -- but a failing
-        # RUN re-executes on every attempt.
-        attempt_limit: 3
-        attempt_delay: 10000
-        # wretry clones the wrapped action at runtime; without a token that clone gets HTTP 403
-        github_token: ${{ github.token }}
-        github_context: '{}'
-        env_context: '{}'
-        job_context: '{}'
-        matrix_context: '{}'
-        # wretry re-parses this block as YAML, so the indentation below is significant: it has to
-        # stay valid after the expressions expand. Keep every interpolated value single-line -- a
-        # multi-line one would have its later lines land at column 0 and break the nested scalar.
-        with: |
-          context: .
-          file: ${{ inputs.dockerfile }}
-          tags: ${{ steps.get-build-inputs.outputs.tags }}
-          load: ${{ inputs.push != 'true' }}
-          push: false
-          platforms: ${{ inputs.platforms }}
-          provenance: false
-          outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false,push=true' || '' }}
-          github-token: ${{ github.token }}
-          build-args: |
-            DISTBALL=${{ steps.get-distball.outputs.result }}
-            DATE=${{ steps.get-date.outputs.result }}
-            REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
-            VERSION=${{ steps.get-build-inputs.outputs.version }}
-            ${{ steps.get-additional-build-args.outputs.result }}
-          target: app
-
-    # As above: a build that fails every attempt is the case where this matters most.
-    - name: Clear build-push inputs leaked into the job environment by wretry
-      if: always()
-      shell: bash
-      run: |
-        env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
+        dockerfile: ${{ inputs.dockerfile }}
+        tags: ${{ steps.get-image.outputs.tags }}
+        platforms: ${{ inputs.platforms }}
+        push: ${{ inputs.push }}
+        build-args: |
+          DISTBALL=${{ steps.get-distball.outputs.result }}
+          DATE=${{ steps.get-date.outputs.result }}
+          REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
+          VERSION=${{ steps.get-build-inputs.outputs.version }}
+          ${{ steps.get-additional-build-args.outputs.result }}

--- a/.github/actions/docker-build-with-retry/README.md
+++ b/.github/actions/docker-build-with-retry/README.md
@@ -1,0 +1,105 @@
+# Build Docker Image With Retry Action
+
+## Intro
+
+Builds a platform Docker image via
+[`docker/build-push-action`](https://github.com/docker/build-push-action), retrying up to three
+times. BuildKit resolves the Dockerfile frontend and the base images through Docker Hub, whose token
+endpoint answers 5xx or drops the connection often enough to fail the build before a single layer is
+built.
+
+Retries in a workflow are normally shell-command-only
+([`nick-fields/retry`](https://github.com/nick-fields/retry), as used by
+[`npm-ci-with-retry`](../npm-ci-with-retry)), and GitHub Actions has no retry primitive for a `uses:`
+step. So each attempt here is a literal copy of the step, gated on the previous attempt's `outcome`.
+See [Notes](#notes) for what that means when you edit this action.
+
+This action is **not general-purpose.** It exists so that the three repeated attempt blocks live here
+rather than in [`build-platform-docker`](../build-platform-docker), its only caller. Values that
+caller passes identically for every image — `context: .`, `provenance: false`, `push: false`,
+`target: app` — are fixed in the action rather than exposed as inputs. Adding a second caller means
+promoting whichever of those it needs.
+
+## Prerequisites
+
+- The repository must be checked out first (e.g. `actions/checkout`), since this action is referenced
+  by local path.
+- A Buildx builder must already be active — see [`setup-buildx-with-retry`](../setup-buildx-with-retry).
+- When `push` is `true`, the job must already be logged into the target registry.
+
+## Usage
+
+### Inputs
+
+|   Input    |                                              Description                                               | Required | Default |
+|------------|--------------------------------------------------------------------------------------------------------|----------|---------|
+| dockerfile | Path to the Dockerfile to build                                                                        | true     |         |
+| tags       | Image tags to apply, newline- or comma-separated                                                       | true     |         |
+| platforms  | Comma-separated list of target platforms                                                               | true     |         |
+| push       | Whether to push the built image; when `false` the image is loaded into the local Docker daemon instead | true     |         |
+| build-args | Build arguments, one `NAME=value` per line                                                             | false    | `""`    |
+
+### Outputs
+
+None. `build-push-action`'s `imageid`/`digest`/`metadata` outputs are not forwarded — the caller
+derives the image name from `docker/metadata-action` instead. Forwarding them would mean picking
+which attempt's outputs to return, since only one attempt's step id is knowable at author time.
+
+## Notes
+
+- **The push goes through `outputs:`, not through `push:`.** `build-push-action`'s own `push:` input
+  is pinned to `false` in all three attempts. A pushing build instead sets
+  `outputs: type=image,oci-mediatypes=false,push=true` — the `oci-mediatypes=false` is what the
+  registries in use here need — and a non-pushing build sets `load: true` to leave the image in the
+  local Docker daemon. Both are derived from this action's single `push` input. This is carried over
+  from `build-platform-docker` unchanged; if you are changing it, establish why it was written this
+  way first.
+- **Three attempts, 10s apart, hard-coded.** Retry-by-repetition cannot be parameterised: a
+  composite action has no loop, so `max_attempts` would have to change the number of steps in the
+  file. Change the count by adding or removing an attempt block.
+- **Editing one attempt means editing all three.** The `env:` and `with:` blocks must stay identical,
+  including the pinned `docker/build-push-action` SHA. A mismatch means an attempt silently builds
+  something different from its predecessor — the worst possible failure mode here, because the
+  divergent build is the one that gets pushed.
+- **The last attempt deliberately omits `continue-on-error`**, so an exhausted retry fails the job.
+  Attempts 1 and 2 carry it, which is what lets the next attempt run.
+- **Gating on the immediate predecessor is enough.** A skipped step reports `outcome: skipped`, never
+  `failure`, so attempt 3 can only run if attempt 2 ran and failed — which in turn required attempt 1
+  to fail. No cumulative `&&` chain is needed.
+- **A retry is cheap up to the point that failed, but not free.** Layers already built are cached in
+  the builder, which persists across attempts, so a replay resumes near where it broke — except that
+  a failing `RUN` re-executes on every attempt.
+- **A failed attempt still emits its error annotations.** They stay in the job log even when a later
+  attempt succeeds, so a green job can contain red annotations from this action.
+- No failure classification: a broken Dockerfile or a 4xx from the registry is retried just like a
+  5xx, and costs all three attempts before the job reports red.
+- `tags` may be multi-line. It is passed through as a plain string and only interpreted by
+  `build-push-action`, which splits on newlines and commas alike.
+
+This replaced `Wandalen/wretry.action`, which fetched the action it wrapped with an anonymous runtime
+`git clone` — outside its own retry loop, and the single point of failure behind INC-7723. Dropping
+it also removed two workarounds from the caller: the `Clear build-push inputs leaked into the job
+environment` step (wretry passed inputs by exporting `INPUT_*` into `GITHUB_ENV`, where they outlived
+the step) and the tags-to-single-line reduction (wretry re-parsed its `with:` block as YAML, so a
+multi-line value broke the nested scalar). See
+[#62493](https://github.com/camunda/camunda/pull/62493).
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/setup-buildx-with-retry
+  - uses: ./.github/actions/docker-build-with-retry
+    with:
+      dockerfile: camunda.Dockerfile
+      tags: ${{ steps.get-image.outputs.tags }}
+      platforms: linux/amd64
+      push: "false"
+      build-args: |
+        DISTBALL=camunda-zeebe.tar.gz
+        VERSION=8.9.0-SNAPSHOT
+```
+
+Most jobs should not call this directly — [`build-platform-docker`](../build-platform-docker) already
+does, together with the builder setup and the image naming.

--- a/.github/actions/docker-build-with-retry/README.md
+++ b/.github/actions/docker-build-with-retry/README.md
@@ -57,6 +57,15 @@ which attempt's outputs to return, since only one attempt's step id is knowable 
 - **Three attempts, 10s apart, hard-coded.** Retry-by-repetition cannot be parameterised: a
   composite action has no loop, so `max_attempts` would have to change the number of steps in the
   file. Change the count by adding or removing an attempt block.
+- **The retry window is ~24 seconds for a fast-failing build.** Measured in
+  [run 34333710709](https://github.com/camunda/camunda/actions/runs/34333710709), where the build
+  failed in ~1s per attempt: three attempts plus two 10s gaps gave up 24s after the step started. A
+  build that fails *slowly* (a long `RUN` that dies near the end) stretches this, since the window is
+  attempt duration plus the fixed 20s of sleep — but a build that fails fast gets barely more than
+  20s of protection. That is a blip, **not an outage.** The throttling window behind INC-7723 lasted
+  30 minutes; neither this configuration nor the `Wandalen/wretry.action` one it replaced (identical
+  `attempt_limit: 3` / `attempt_delay: 10000`) would have saved a single one of those jobs. What
+  fixes that failure mode is that nothing is fetched at runtime any more — see below.
 - **Editing one attempt means editing all three.** The `env:` and `with:` blocks must stay identical,
   including the pinned `docker/build-push-action` SHA. A mismatch means an attempt silently builds
   something different from its predecessor — the worst possible failure mode here, because the
@@ -69,8 +78,13 @@ which attempt's outputs to return, since only one attempt's step id is knowable 
 - **A retry is cheap up to the point that failed, but not free.** Layers already built are cached in
   the builder, which persists across attempts, so a replay resumes near where it broke — except that
   a failing `RUN` re-executes on every attempt.
-- **A failed attempt still emits its error annotations.** They stay in the job log even when a later
-  attempt succeeds, so a green job can contain red annotations from this action.
+- **A failed attempt still emits its error annotations.** `continue-on-error` absorbs the *step*, but
+  the annotation is already published to the check run and annotations have no notion of being
+  absorbed — so a green job can carry red annotations from this action.
+  [`post-ci-failure-reasons`](../post-ci-failure-reasons) filters on job conclusion before it reads
+  annotations, so a job that recovered produces no PR comment. The residual effect: if the job later
+  fails for an unrelated reason, that comment will list these already-retried errors alongside the
+  real one.
 - No failure classification: a broken Dockerfile or a 4xx from the registry is retried just like a
   5xx, and costs all three attempts before the job reports red.
 - `tags` may be multi-line. It is passed through as a plain string and only interpreted by

--- a/.github/actions/docker-build-with-retry/action.yml
+++ b/.github/actions/docker-build-with-retry/action.yml
@@ -1,7 +1,6 @@
 ---
-name: Build Docker image with retry
-
 # owner: @camunda/engineering-operations
+name: Build Docker image with retry
 
 description: >
   Runs `docker/build-push-action` with retries: BuildKit resolves the Dockerfile
@@ -49,8 +48,9 @@ runs:
   #
   # `context`, `provenance`, `push` and `target` are fixed rather than inputs:
   # `build-platform-docker` is the only caller and passes the same values for
-  # all images. `push: false` with an explicit `outputs:` is what makes a
-  # multi-platform build pushable without loading it locally first.
+  # all images. Note that build-push-action's own `push:` stays false even when
+  # pushing -- the push is expressed through `outputs:` instead. That is carried
+  # over from the caller unchanged; see this action's README.
   steps:
     - name: Build Docker image (attempt 1 of 3)
       id: attempt-1

--- a/.github/actions/docker-build-with-retry/action.yml
+++ b/.github/actions/docker-build-with-retry/action.yml
@@ -1,0 +1,123 @@
+---
+name: Build Docker image with retry
+
+# owner: @camunda/engineering-operations
+
+description: >
+  Runs `docker/build-push-action` with retries: BuildKit resolves the Dockerfile
+  frontend and the base images through Docker Hub, whose token endpoint answers
+  5xx or drops the connection often enough to fail the build before a single
+  layer is built.
+
+inputs:
+  dockerfile:
+    description: Path to the Dockerfile to build.
+    required: true
+  tags:
+    description: Image tags to apply, newline- or comma-separated.
+    required: true
+  platforms:
+    description: Comma-separated list of target platforms.
+    required: true
+  push:
+    description: >
+      Whether to push the built image. When false the image is loaded into the
+      local Docker daemon instead.
+    required: true
+  build-args:
+    description: Build arguments, one `NAME=value` per line.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  # GitHub Actions has no retry primitive for a `uses:` step, so each attempt is
+  # a literal copy of the step gated on the previous attempt's outcome. Editing
+  # one attempt means editing all of them -- keep the `env:` and `with:` blocks
+  # identical.
+  #
+  # A skipped step reports `outcome: skipped`, never `failure`, so gating each
+  # attempt on its immediate predecessor is enough: attempt 3 can only run if
+  # attempt 2 ran and failed, which in turn required attempt 1 to fail.
+  #
+  # The last attempt deliberately omits `continue-on-error` so an exhausted
+  # retry fails the job. Nothing here classifies the failure, so a broken
+  # Dockerfile or a 4xx from the registry is retried just like a 5xx. Layers
+  # already built are cached in the builder, which persists across attempts, so
+  # a replay is cheap up to the point that failed -- but a failing `RUN`
+  # re-executes on every attempt.
+  #
+  # `context`, `provenance`, `push` and `target` are fixed rather than inputs:
+  # `build-platform-docker` is the only caller and passes the same values for
+  # all images. `push: false` with an explicit `outputs:` is what makes a
+  # multi-platform build pushable without loading it locally first.
+  steps:
+    - name: Build Docker image (attempt 1 of 3)
+      id: attempt-1
+      continue-on-error: true
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      env:
+        DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_RECORD_UPLOAD: false
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ inputs.tags }}
+        load: ${{ inputs.push != 'true' }}
+        push: false
+        platforms: ${{ inputs.platforms }}
+        provenance: false
+        outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false,push=true' || '' }}
+        github-token: ${{ github.token }}
+        build-args: ${{ inputs.build-args }}
+        target: app
+
+    - name: Wait before attempt 2
+      if: steps.attempt-1.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
+    - name: Build Docker image (attempt 2 of 3)
+      id: attempt-2
+      if: steps.attempt-1.outcome == 'failure'
+      continue-on-error: true
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      env:
+        DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_RECORD_UPLOAD: false
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ inputs.tags }}
+        load: ${{ inputs.push != 'true' }}
+        push: false
+        platforms: ${{ inputs.platforms }}
+        provenance: false
+        outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false,push=true' || '' }}
+        github-token: ${{ github.token }}
+        build-args: ${{ inputs.build-args }}
+        target: app
+
+    - name: Wait before attempt 3
+      if: steps.attempt-2.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
+    - name: Build Docker image (attempt 3 of 3)
+      if: steps.attempt-2.outcome == 'failure'
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      env:
+        DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_RECORD_UPLOAD: false
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ inputs.tags }}
+        load: ${{ inputs.push != 'true' }}
+        push: false
+        platforms: ${{ inputs.platforms }}
+        provenance: false
+        outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false,push=true' || '' }}
+        github-token: ${{ github.token }}
+        build-args: ${{ inputs.build-args }}
+        target: app

--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -35,8 +35,10 @@ runs:
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
     - name: Authenticate to GCS via WIF
-      # Not wrapped in wretry: it blanks INPUT_SERVICE_ACCOUNT before auth reads it, dropping SA
-      # impersonation so gcloud runs as the bare WIF identity and every storage call 403s (INC-7417).
+      # Not retried. An earlier attempt to wrap this in Wandalen/wretry.action broke SA
+      # impersonation -- gcloud ran as the bare WIF identity and every storage call 403'd
+      # (INC-7417). That specific defect is gone now that retries are plain repeated steps, so if
+      # this step ever turns flaky it can be given the same treatment as setup-java.
       if: steps.is-fork.outputs.is-fork != 'true'
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -152,29 +152,12 @@ runs:
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
-    # wretry retries setup-java through transient network/setup failures (INC-7417). Same pattern
-    # as build-platform-docker; `_js_action` pin lets the *_context inputs be overridden.
-    # `token` is passed explicitly since github_context is blanked (setup-java defaults it from it).
-    uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
+    # Retries setup-java through transient network/setup failures (INC-7417). The pin for
+    # setup-java itself lives in that action, not here.
+    uses: ./.github/actions/setup-java-with-retry
     with:
-      action: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-      attempt_limit: 3
-      attempt_delay: 10000
-      github_token: ${{ github.token }}
-      github_context: '{}'
-      env_context: '{}'
-      job_context: '{}'
-      matrix_context: '{}'
-      with: |
-        distribution: ${{ inputs.java-distribution }}
-        java-version: ${{ inputs.java-version }}
-        token: ${{ github.token }}
-  # wretry leaks the wrapped action's INPUT_* vars into GITHUB_ENV; blank them (cannot unset).
-  - name: Clear setup-java inputs leaked into the job environment by wretry
-    if: always()
-    shell: bash
-    run: |
-      env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
+      distribution: ${{ inputs.java-distribution }}
+      java-version: ${{ inputs.java-version }}
   - name: Register Maven problem matcher
     shell: bash
     run: echo "::add-matcher::.github/maven-matcher.json"

--- a/.github/actions/setup-buildx-with-retry/README.md
+++ b/.github/actions/setup-buildx-with-retry/README.md
@@ -1,0 +1,83 @@
+# Set Up Docker Buildx With Retry Action
+
+## Intro
+
+Boots a Buildx builder via
+[`docker/setup-buildx-action`](https://github.com/docker/setup-buildx-action), retrying up to three
+times. Booting the builder pulls `moby/buildkit` from Docker Hub, which answers 5xx often enough to
+be the most frequent way an image build fails on healthy code.
+
+Retries in a workflow are normally shell-command-only
+([`nick-fields/retry`](https://github.com/nick-fields/retry), as used by
+[`npm-ci-with-retry`](../npm-ci-with-retry)), and GitHub Actions has no retry primitive for a `uses:`
+step. So each attempt here is a literal copy of the step, gated on the previous attempt's `outcome`.
+See [Notes](#notes) for what that means when you edit this action.
+
+## Prerequisites
+
+- The repository must be checked out first (e.g. `actions/checkout`), since this action is referenced
+  by local path.
+- If you pass an `endpoint`, that Docker context must already exist — this action does not create
+  one. [`build-platform-docker`](../build-platform-docker) creates `zeebe-context` in the step before
+  it calls this.
+
+## Usage
+
+### Inputs
+
+|      Input      |                 Description                 | Required | Default |
+|-----------------|---------------------------------------------|----------|---------|
+| driver-opts     | Driver options passed to the builder        | false    | `""`    |
+| buildkitd-flags | Flags passed to the buildkit daemon         | false    | `""`    |
+| endpoint        | Docker context or endpoint to build against | false    | `""`    |
+
+### Outputs
+
+None. `setup-buildx-action`'s outputs (`name`, `driver`, `endpoint`, …) are not forwarded — no caller
+needs them. The builder it creates becomes the active one for the job, which is how later
+`docker/build-push-action` steps pick it up.
+
+## Notes
+
+- **Three attempts, 10s apart, hard-coded.** Retry-by-repetition cannot be parameterised: a
+  composite action has no loop, so `max_attempts` would have to change the number of steps in the
+  file. Change the count by adding or removing an attempt block.
+- **Editing one attempt means editing all three.** The `with:` blocks must stay identical, including
+  the pinned `docker/setup-buildx-action` SHA. A mismatch means an attempt silently boots a different
+  builder from its predecessor.
+- **The last attempt deliberately omits `continue-on-error`**, so an exhausted retry fails the job.
+  Attempts 1 and 2 carry it, which is what lets the next attempt run.
+- **Gating on the immediate predecessor is enough.** A skipped step reports `outcome: skipped`, never
+  `failure`, so attempt 3 can only run if attempt 2 ran and failed — which in turn required attempt 1
+  to fail. No cumulative `&&` chain is needed.
+- **What a retried boot leaves behind is not fully characterised.** `setup-buildx-action` names its
+  builder itself and registers a `post:` teardown; whether a partly-booted builder from a failed
+  attempt is cleaned up, and whether the retry leaves more than one registered, has not been probed.
+  It has not caused a problem, but do not assume the state is clean if you are debugging a builder
+  that behaves oddly after a retry.
+- **A failed attempt still emits its error annotations.** They stay in the job log even when a later
+  attempt succeeds, so a green job can contain red annotations from this action.
+- No failure classification: a genuine error (bad `driver-opts`, a missing `endpoint` context) costs
+  all three attempts before the job reports red.
+
+This replaced `Wandalen/wretry.action`, which fetched the action it wrapped with an anonymous runtime
+`git clone` — outside its own retry loop, and the single point of failure behind INC-7723. Dropping
+it also removed the `Clear buildx inputs leaked into the job environment` workaround: wretry passed
+inputs by exporting `INPUT_*` into `GITHUB_ENV`, where `version`, `name` and `platforms` outlived the
+step and shadowed later steps' own defaults. See
+[#62493](https://github.com/camunda/camunda/pull/62493).
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/setup-buildx-with-retry
+    with:
+      # host network is needed to push to the local registry used by our tests
+      driver-opts: network=host
+      endpoint: zeebe-context
+```
+
+Most jobs should not call this directly — [`build-platform-docker`](../build-platform-docker) already
+does, together with the image build itself.

--- a/.github/actions/setup-buildx-with-retry/README.md
+++ b/.github/actions/setup-buildx-with-retry/README.md
@@ -42,6 +42,15 @@ needs them. The builder it creates becomes the active one for the job, which is 
 - **Three attempts, 10s apart, hard-coded.** Retry-by-repetition cannot be parameterised: a
   composite action has no loop, so `max_attempts` would have to change the number of steps in the
   file. Change the count by adding or removing an attempt block.
+- **The whole retry window is ~22 seconds, and almost all of it is sleep.** Measured in
+  [run 34330823597](https://github.com/camunda/camunda/actions/runs/34330823597): an unreachable
+  registry fails the boot in 0.7–0.9s, so three attempts plus two 10s gaps gave up 22.3s after the
+  step started. This is the narrowest window of the three retry actions, because this is the
+  fastest-failing wrapped action. It protects against a blip, **not an outage.** The throttling
+  window behind INC-7723 lasted 30 minutes; neither this configuration nor the
+  `Wandalen/wretry.action` one it replaced (identical `attempt_limit: 3` / `attempt_delay: 10000`)
+  would have saved a single one of those jobs. What fixes that failure mode is that nothing is
+  fetched at runtime any more — see below.
 - **Editing one attempt means editing all three.** The `with:` blocks must stay identical, including
   the pinned `docker/setup-buildx-action` SHA. A mismatch means an attempt silently boots a different
   builder from its predecessor.
@@ -50,13 +59,30 @@ needs them. The builder it creates becomes the active one for the job, which is 
 - **Gating on the immediate predecessor is enough.** A skipped step reports `outcome: skipped`, never
   `failure`, so attempt 3 can only run if attempt 2 ran and failed — which in turn required attempt 1
   to fail. No cumulative `&&` chain is needed.
-- **What a retried boot leaves behind is not fully characterised.** `setup-buildx-action` names its
-  builder itself and registers a `post:` teardown; whether a partly-booted builder from a failed
-  attempt is cleaned up, and whether the retry leaves more than one registered, has not been probed.
-  It has not caused a problem, but do not assume the state is clean if you are debugging a builder
-  that behaves oddly after a retry.
-- **A failed attempt still emits its error annotations.** They stay in the job log even when a later
-  attempt succeeds, so a green job can contain red annotations from this action.
+- **A retry leaves one builder per attempt registered for the rest of the job, and all of them are
+  torn down.** Each attempt calls `docker buildx create` with its own generated name, and each
+  registers its own `post:` hook — including attempts that failed. Observed in
+  [run 34330823597](https://github.com/camunda/camunda/actions/runs/34330823597), where three
+  attempts produced three builders and post-job cleanup removed all three:
+
+  ```
+  docker buildx rm builder-c05196a0-…  removed   (attempt 3)
+  docker buildx rm builder-8c43ea87-…  removed   (attempt 2)
+  docker buildx rm builder-cb0753dc-…  removed   (attempt 1)
+  ```
+
+  So nothing leaks, but `docker buildx ls` is not a reliable way to identify *which* builder a
+  later step used after a retry — the last successful attempt's builder is the active one, and the
+  dead ones from earlier attempts are still listed alongside it.
+
+- **A failed attempt still emits its error annotations.** `continue-on-error` absorbs the *step*, but
+  the annotation is already published to the check run and annotations have no notion of being
+  absorbed — so a green job can carry red annotations from this action.
+  [`post-ci-failure-reasons`](../post-ci-failure-reasons) filters on job conclusion before it reads
+  annotations, so a job that recovered produces no PR comment. The residual effect: if the job later
+  fails for an unrelated reason, that comment will list these already-retried errors alongside the
+  real one.
+
 - No failure classification: a genuine error (bad `driver-opts`, a missing `endpoint` context) costs
   all three attempts before the job reports red.
 

--- a/.github/actions/setup-buildx-with-retry/action.yml
+++ b/.github/actions/setup-buildx-with-retry/action.yml
@@ -1,7 +1,6 @@
 ---
-name: Set up Docker Buildx with retry
-
 # owner: @camunda/engineering-operations
+name: Set up Docker Buildx with retry
 
 description: >
   Runs `docker/setup-buildx-action` with retries: booting the builder pulls

--- a/.github/actions/setup-buildx-with-retry/action.yml
+++ b/.github/actions/setup-buildx-with-retry/action.yml
@@ -1,0 +1,74 @@
+---
+name: Set up Docker Buildx with retry
+
+# owner: @camunda/engineering-operations
+
+description: >
+  Runs `docker/setup-buildx-action` with retries: booting the builder pulls
+  moby/buildkit from Docker Hub, which answers 5xx often enough to be the most
+  frequent way an image build fails on healthy code.
+
+inputs:
+  driver-opts:
+    description: Driver options passed to the builder.
+    required: false
+    default: ""
+  buildkitd-flags:
+    description: Flags passed to the buildkit daemon.
+    required: false
+    default: ""
+  endpoint:
+    description: Docker context or endpoint to build against.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  # GitHub Actions has no retry primitive for a `uses:` step, so each attempt is
+  # a literal copy of the step gated on the previous attempt's outcome. Editing
+  # one attempt means editing all of them -- keep the `with:` blocks identical.
+  #
+  # A skipped step reports `outcome: skipped`, never `failure`, so gating each
+  # attempt on its immediate predecessor is enough: attempt 3 can only run if
+  # attempt 2 ran and failed, which in turn required attempt 1 to fail.
+  #
+  # The last attempt deliberately omits `continue-on-error` so an exhausted
+  # retry fails the job. Nothing here classifies the failure, so a genuine
+  # configuration error also costs three attempts before reporting red.
+  steps:
+    - name: Set up Docker Buildx (attempt 1 of 3)
+      id: attempt-1
+      continue-on-error: true
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      with:
+        driver-opts: ${{ inputs.driver-opts }}
+        buildkitd-flags: ${{ inputs.buildkitd-flags }}
+        endpoint: ${{ inputs.endpoint }}
+
+    - name: Wait before attempt 2
+      if: steps.attempt-1.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
+    - name: Set up Docker Buildx (attempt 2 of 3)
+      id: attempt-2
+      if: steps.attempt-1.outcome == 'failure'
+      continue-on-error: true
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      with:
+        driver-opts: ${{ inputs.driver-opts }}
+        buildkitd-flags: ${{ inputs.buildkitd-flags }}
+        endpoint: ${{ inputs.endpoint }}
+
+    - name: Wait before attempt 3
+      if: steps.attempt-2.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
+    - name: Set up Docker Buildx (attempt 3 of 3)
+      if: steps.attempt-2.outcome == 'failure'
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      with:
+        driver-opts: ${{ inputs.driver-opts }}
+        buildkitd-flags: ${{ inputs.buildkitd-flags }}
+        endpoint: ${{ inputs.endpoint }}

--- a/.github/actions/setup-java-with-retry/README.md
+++ b/.github/actions/setup-java-with-retry/README.md
@@ -1,0 +1,69 @@
+# Setup Java With Retry Action
+
+## Intro
+
+Installs the JDK via [`actions/setup-java`](https://github.com/actions/setup-java), retrying up to
+three times. Resolving the release metadata and downloading the JDK both go over the network, and a
+transient failure there used to fail the whole job (INC-7417).
+
+Retries in a workflow are normally shell-command-only
+([`nick-fields/retry`](https://github.com/nick-fields/retry), as used by
+[`npm-ci-with-retry`](../npm-ci-with-retry)), and GitHub Actions has no retry primitive for a `uses:`
+step. So each attempt here is a literal copy of the step, gated on the previous attempt's `outcome`.
+See [Notes](#notes) for what that means when you edit this action.
+
+## Prerequisites
+
+- The repository must be checked out first (e.g. `actions/checkout`), since this action is referenced
+  by local path.
+
+## Usage
+
+### Inputs
+
+|    Input     |         Description          | Required | Default |
+|--------------|------------------------------|----------|---------|
+| distribution | Java distribution to install | true     |         |
+| java-version | Java version to install      | true     |         |
+
+### Outputs
+
+None. `setup-java`'s own outputs are not forwarded — no caller needs them. `JAVA_HOME` and `PATH` are
+exported to the job as usual, since the runner applies `GITHUB_ENV`/`GITHUB_PATH` writes from a
+nested composite action exactly as it does for a top-level step.
+
+## Notes
+
+- **Three attempts, 10s apart, hard-coded.** Retry-by-repetition cannot be parameterised: a
+  composite action has no loop, so `max_attempts` would have to change the number of steps in the
+  file. Change the count by adding or removing an attempt block.
+- **Editing one attempt means editing all three.** The `with:` blocks must stay identical, including
+  the pinned `actions/setup-java` SHA. A mismatch means an attempt silently installs something
+  different from its predecessor.
+- **The last attempt deliberately omits `continue-on-error`**, so an exhausted retry fails the job.
+  Attempts 1 and 2 carry it, which is what lets the next attempt run.
+- **Gating on the immediate predecessor is enough.** A skipped step reports `outcome: skipped`, never
+  `failure`, so attempt 3 can only run if attempt 2 ran and failed — which in turn required attempt 1
+  to fail. No cumulative `&&` chain is needed.
+- **A failed attempt still emits its error annotations.** They stay in the job log even when a later
+  attempt succeeds, so a green job can contain red annotations from this action.
+- No failure classification: a genuine error (a bad `java-version`, say) costs all three attempts
+  before the job reports red.
+
+This replaced `Wandalen/wretry.action`, which fetched the action it wrapped with an anonymous runtime
+`git clone` — outside its own retry loop, and the single point of failure behind INC-7723. See
+[#62493](https://github.com/camunda/camunda/pull/62493).
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/setup-java-with-retry
+    with:
+      distribution: temurin
+      java-version: "21"
+```
+
+Most jobs should not call this directly — [`setup-build`](../setup-build) already does, along with
+the rest of the build bootstrap.

--- a/.github/actions/setup-java-with-retry/README.md
+++ b/.github/actions/setup-java-with-retry/README.md
@@ -37,6 +37,14 @@ nested composite action exactly as it does for a top-level step.
 - **Three attempts, 10s apart, hard-coded.** Retry-by-repetition cannot be parameterised: a
   composite action has no loop, so `max_attempts` would have to change the number of steps in the
   file. Change the count by adding or removing an attempt block.
+- **The whole retry window is ~39 seconds.** Measured in
+  [run 34333710709](https://github.com/camunda/camunda/actions/runs/34333710709): a failing
+  `setup-java` takes ~6.2s per attempt, so three attempts plus two 10s gaps give up 39s after the
+  step started. This protects against a blip, **not an outage.** The throttling window behind
+  INC-7723 lasted 30 minutes; neither this configuration nor the `Wandalen/wretry.action` one it
+  replaced (identical `attempt_limit: 3` / `attempt_delay: 10000`) would have saved a single one of
+  those jobs. What fixes that failure mode is that nothing is fetched at runtime any more — see
+  below. Do not reach for these actions expecting them to absorb a sustained outage.
 - **Editing one attempt means editing all three.** The `with:` blocks must stay identical, including
   the pinned `actions/setup-java` SHA. A mismatch means an attempt silently installs something
   different from its predecessor.
@@ -45,8 +53,13 @@ nested composite action exactly as it does for a top-level step.
 - **Gating on the immediate predecessor is enough.** A skipped step reports `outcome: skipped`, never
   `failure`, so attempt 3 can only run if attempt 2 ran and failed — which in turn required attempt 1
   to fail. No cumulative `&&` chain is needed.
-- **A failed attempt still emits its error annotations.** They stay in the job log even when a later
-  attempt succeeds, so a green job can contain red annotations from this action.
+- **A failed attempt still emits its error annotations.** `continue-on-error` absorbs the *step*, but
+  the annotation is already published to the check run and annotations have no notion of being
+  absorbed — so a green job can carry red annotations from this action.
+  [`post-ci-failure-reasons`](../post-ci-failure-reasons) filters on job conclusion before it reads
+  annotations, so a job that recovered produces no PR comment. The residual effect: if the job later
+  fails for an unrelated reason, that comment will list these already-retried errors alongside the
+  real one.
 - No failure classification: a genuine error (a bad `java-version`, say) costs all three attempts
   before the job reports red.
 

--- a/.github/actions/setup-java-with-retry/action.yml
+++ b/.github/actions/setup-java-with-retry/action.yml
@@ -1,7 +1,6 @@
 ---
-name: Setup Java with retry
-
 # owner: @camunda/engineering-operations
+name: Setup Java with retry
 
 description: >
   Runs `actions/setup-java` with retries so a transient failure while resolving

--- a/.github/actions/setup-java-with-retry/action.yml
+++ b/.github/actions/setup-java-with-retry/action.yml
@@ -1,0 +1,66 @@
+---
+name: Setup Java with retry
+
+# owner: @camunda/engineering-operations
+
+description: >
+  Runs `actions/setup-java` with retries so a transient failure while resolving
+  or downloading the JDK does not fail the whole job (INC-7417).
+
+inputs:
+  distribution:
+    description: Java distribution to install.
+    required: true
+  java-version:
+    description: Java version to install.
+    required: true
+
+runs:
+  using: composite
+  # GitHub Actions has no retry primitive for a `uses:` step, so each attempt is
+  # a literal copy of the step gated on the previous attempt's outcome. Editing
+  # one attempt means editing all of them -- keep the `with:` blocks identical.
+  #
+  # A skipped step reports `outcome: skipped`, never `failure`, so gating each
+  # attempt on its immediate predecessor is enough: attempt 3 can only run if
+  # attempt 2 ran and failed, which in turn required attempt 1 to fail.
+  #
+  # The last attempt deliberately omits `continue-on-error` so an exhausted
+  # retry fails the job.
+  steps:
+    - name: Setup Java (attempt 1 of 3)
+      id: attempt-1
+      continue-on-error: true
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+      with:
+        distribution: ${{ inputs.distribution }}
+        java-version: ${{ inputs.java-version }}
+        token: ${{ github.token }}
+
+    - name: Wait before attempt 2
+      if: steps.attempt-1.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
+    - name: Setup Java (attempt 2 of 3)
+      id: attempt-2
+      if: steps.attempt-1.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+      with:
+        distribution: ${{ inputs.distribution }}
+        java-version: ${{ inputs.java-version }}
+        token: ${{ github.token }}
+
+    - name: Wait before attempt 3
+      if: steps.attempt-2.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
+    - name: Setup Java (attempt 3 of 3)
+      if: steps.attempt-2.outcome == 'failure'
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+      with:
+        distribution: ${{ inputs.distribution }}
+        java-version: ${{ inputs.java-version }}
+        token: ${{ github.token }}

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -631,7 +631,6 @@ teleport-actions/setup@*,
 test-summary/action@*,
 tibdex/github-app-token@*,
 wagoid/commitlint-github-action@*,
-Wandalen/wretry.action@*,
 </details>
 
 ## Preview Environments


### PR DESCRIPTION
## Description

Addresses [INC-7723](https://app.incident.io/camunda/incidents/7723) — 33 CI
incidents on 2026-09-03, where builds failed because GitHub rate-limited
**anonymous** downloads.

`Wandalen/wretry.action` fetches the action it wraps with a runtime `git clone`.
That clone is anonymous — git never sends credentials for a public repo, because
GitHub answers the first unauthenticated `info/refs` probe with 200 and never
challenges. GitHub said so itself, from
[the failing job](https://github.com/camunda/camunda/actions/runs/33727957863/job/100561709516#step:8:463):

```
##[error]Process returned exit code 128
Launched as "git clone ***github.com/docker/setup-buildx-action . --config core.autocrlf=false"
Launched at "/home/runner/_work/_actions/Wandalen/setup-buildx-action"
-> Stderr
-  Cloning into '.'...
-  fatal: remote error: GitHub is temporarily limiting some unauthenticated downloads
   to protect the stability of the platform. Please retry later or authenticate.
```

Anonymous requests get **60/hour counted per source IP**; ~40 matrix jobs on shared
self-hosted runners behind one NAT egress exhausted that immediately. The clone also
happens before `attempt_limit` is read, so it sits *outside* wretry's own retry loop —
that step died in **1.2s** despite `attempt_delay: 10000`. 63 of 65 affected jobs made
exactly one attempt. All 120 failure lines in the incident came from this clone. The
wrapper added for resilience was itself the single point of failure, and no external
config can reach it (it overrides `HOME`/`GIT_CONFIG_GLOBAL` and sets its own
`GIT_CONFIG_COUNT`).

Retries stay, because the failure classes they cover (Docker Hub 5xx booting
buildkit or resolving base images, transient JDK setup) do occur on healthy code.
Only the mechanism changes: each wrapped action is now a plain `uses:` step,
repeated 3× inside a composite action and gated on the previous attempt's
`outcome`. Nothing is fetched at runtime.

**To be clear about what the retries are and are not worth.** Forcing real
failures (see below) measured the full retry window at **22s for buildx, 24s for
the image build, 39s for setup-java** — three attempts plus two fixed 10s sleeps,
which for a fast-failing step is almost entirely sleep. INC-7723's throttling
window lasted 30 minutes, so this retry configuration would not have saved those
jobs, and neither did wretry's — it used the identical `attempt_limit: 3` /
`attempt_delay: 10000`. The retries protect against short blips. **The thing that
actually fixes INC-7723 is removing the runtime clone**; preserving the retries is
a secondary, smaller benefit. Whether 3 attempts / 10s is the right shape is now a
question with measured numbers behind it, but changing it is a behaviour change and
deliberately out of scope here.

Three new composites, so the call sites shrink rather than grow:

- `.github/actions/setup-java-with-retry`
- `.github/actions/setup-buildx-with-retry`
- `.github/actions/docker-build-with-retry`

Existing files: **−129/+29**.

### Alternatives considered

- **An in-house generic retry action.** Rejected: a composite action cannot take
  an action reference dynamically — exactly the capability that forced wretry to
  clone. Building it means re-implementing that fetch, i.e. re-creating the
  defect with our name on it.
- **A patched fork, bundled with `@vercel/ncc`.** Measured and rejected. `ncc`
  exits 0 with no warnings, but all three bundles die at module load (exit 255,
  `Cant resolve module::wCopyable`): the wTools blob wretry depends on runs its
  own `__filename`-keyed module registry, which webpack rewrites out from under
  it. The bundles would also be larger (3 × 7.9 MB) than the `node_modules/` they
  replace.

### Workarounds deleted with the wrapper

| Removed | Existed because |
|---|---|
| 3× `Clear <action> inputs leaked into the job environment` | wretry exported `INPUT_*` into `GITHUB_ENV`, where they outlived the step and shadowed later steps' defaults |
| `*_context: '{}'` blanking + the `_js_action` pin it required | [wretry#182](https://github.com/Wandalen/wretry.action/issues/182) |
| tags → comma join | wretry re-parsed its `with:` block as YAML, so multi-line values broke the nested scalar. Tags now pass multi-line as metadata-action emits them. The VERSION `head -1` stays: that build arg genuinely takes one value |

Also: `gcs-build-cache-auth`'s comment corrected (its reason for staying unretried
was wretry-specific), and `Wandalen/wretry.action@*` dropped from the documented
allowlist in `docs/monorepo-docs/ci.md`. The org-level allowlist still needs a
separate infra change.

### Behaviour

Unchanged in the success path, in attempt count (3) and delay (10s). As before
nothing classifies the failure, so a genuine error still costs 3 attempts before
reporting red.

**A green CI run on this PR does not validate the retry behaviour.** With the
throttling window closed, an anonymous clone succeeds too, and a retry that never
fires looks identical to one that works. CI here validates that the migrated call
sites still build and push — [run
34334185459](https://github.com/camunda/camunda/actions/runs/34334185459): 123
jobs green, 38 skipped, 0 failures, with all three composites observed executing in
a real build-and-push path (`attempt 1 of 3` ×6, `attempt 2 of 3` ×3, `attempt 3 of
3` ×3 — first attempts succeeded, later ones correctly skipped).

### Verification: no anonymous GitHub request remains

The incident and this PR happen to share a job name, so there is a direct
before/after on the same job:

| | `Zeebe / Smoke - linux with amd64` |
|---|---|
| **Before** — [run 33727957863](https://github.com/camunda/camunda/actions/runs/33727957863/job/100561709516#step:8:463), 2026-09-03 | ❌ `exit code 128`, `git clone` of `docker/setup-buildx-action`, `GitHub is temporarily limiting some unauthenticated downloads`, dead in 1.2s |
| **After** — [run 34334185459](https://github.com/camunda/camunda/actions/runs/34334185459), 2026-09-09 | ✅ green; no clone anywhere in 22,031 log lines; `setup-buildx-action` arrives via the runner's authenticated `Download action repository` |

This is the claim the PR rests on, so the rest was checked against that same job
rather than argued from the mechanism —
[`Zeebe / Smoke - linux with amd64`](https://github.com/camunda/camunda/actions/runs/34334185459),
green, which runs `setup-build` and `build-platform-docker` end to end:

| GitHub fetch in the changed path | How it happens now | Pool |
|---|---|---|
| `actions/setup-java`, `docker/setup-buildx-action`, `docker/build-push-action` | runner's `Download action repository` (16 in that job) | **authenticated**, 15,000/hr per installation |
| The three new composites | local path from the checkout — not fetched at all | n/a |
| buildx binary | not fetched; uses the runner's preinstalled `/usr/bin/docker buildx` | n/a |
| setup-java's GitHub-side lookups | `token: ***` still passed | authenticated |
| build-push-action's GitHub calls | `github-token: ***` still passed | authenticated |
| An action `git clone` | **none** — 0 hits across 22,031 log lines | gone |

Before, wretry's clone was anonymous: **60 requests/hour counted per source IP**,
with ~40 matrix jobs sharing one NAT egress on the self-hosted runners. That is
what got throttled. The point is not that those requests are now retried better —
there is no anonymous request left to throttle.

Both token pass-throughs wretry was forwarding survive the migration, verified in
the same log:

```
Run actions/setup-java@b6effb05e…      Run docker/build-push-action@53b7df96…
  distribution: temurin                  tags: camunda/camunda:current-test
  java-version: 21                       load: true
  token: ***                             push: false
                                         github-token: ***
```

One thing to know for later: `setup-buildx-action` *would* fetch buildx from GitHub
releases if given a `version:` input. None is passed, so the preinstalled binary is
used. Pinning a buildx version in future reintroduces a GitHub fetch whose auth
handling has not been traced.

### Forced-failure verification

So the retries were tested by breaking them on purpose, on a throwaway branch
(`tmp/retry-composite-proof`), against the real composite actions unmodified —
[run 34333710709](https://github.com/camunda/camunda/actions/runs/34333710709), all
five jobs green:

| Job | Breakage | attempt 1 | attempt 2 | attempt 3 | Total |
|---|---|---|---|---|---|
| R1 setup-java | `api.adoptium.net` → 127.0.0.1, healed at 12s | `failure` 6.2s | **`success`** 5.7s | skipped | 23s |
| R2 buildx | `registry-1.docker.io` → 127.0.0.1, healed at 6s | `failure` 4.7s | **`success`** 10.4s | skipped | 26s |
| R3 image build | Dockerfile withheld, provided at 8s | `failure` 1.0s | **`success`** | skipped | ≥10s |
| X1 setup-java | never healed | `failure` | `failure` | `failure` | 39s |
| X2 image build | Dockerfile never appears | `failure` 1.6s | `failure` 0.6s | `failure` 1.0s | 24s |

The X jobs are the ones guarding the silent regression: if `continue-on-error` were
ever left on the last attempt block, every failure in these actions would be
swallowed and CI would go green on broken builds. They set `continue-on-error` on
the *caller's* step, which is what lets them read the composite's own verdict, and
assert both `outcome == 'failure'` and elapsed ≥ 20s — the elapsed check is what
proves three attempts ran rather than one. The observed asymmetry:

```
attempt-1  outcome=failure  conclusion=success   ← absorbed, next attempt runs
attempt-2  outcome=failure  conclusion=success
attempt-3  outcome=failure  conclusion=failure   ← reaches the caller
```

The R jobs additionally assert elapsed ≥ 10s. An earlier run had R1 pass
vacuously: its heal fired while attempt 1 was still running, so the step simply
succeeded and no retry was exercised. Reaching attempt 2 costs a 10s sleep, so
anything faster is reported as INVALID rather than PASS.

Two incidental findings, both now documented in the action READMEs: a retried buildx
boot registers one builder per attempt and **all** of them are torn down by the post
hook (nothing leaks, but `docker buildx ls` shows the dead ones alongside the live
one), and a failed attempt's `##[error]` annotations remain on the check run even
when a later attempt succeeds. The latter is harmless to `post-ci-failure-reasons`,
which filters on job conclusion before reading annotations, so a recovered job
produces no PR comment.

## Related issues

Tracked as an incident rather than a GitHub issue:
[INC-7723](https://app.incident.io/camunda/incidents/7723) (umbrella — 31 of the 33
were merged into it).

- [x] This PR does not need a linked issue
