### PR TITLE
feat: add create-rt-issue skill for RT/load-test issue creation

### DIFF
--- a/.claude/skills/create-rt-issue
+++ b/.claude/skills/create-rt-issue
@@ -1,0 +1,1 @@
+../../load-tests/skills/create-rt-issue

--- a/load-tests/skills/create-rt-issue/SKILL.md
+++ b/load-tests/skills/create-rt-issue/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: create-rt-issue
+description: Create a GitHub issue in camunda/camunda for load-test/Reliability Testing (RT) work, extending create-issue with the component/load-tests label and an rt/foundation, rt/coverage, or rt/enablement classification. Use when asked to create, file, or open an RT/load-test issue.
+---
+
+# Create RT Issue
+
+Extends the `create-issue` skill for Reliability Testing (RT) work. Reuses its template selection,
+duplicate check, field inference, body composition, and creation flow, and layers on two RT-specific
+overrides.
+
+## Procedure
+
+Invoke the `create-issue` skill and follow its procedure, with these two overrides:
+
+### Override 1 — Component label (replaces `create-issue` Step 3)
+
+Skip `create-issue`'s component auto-detection entirely. Always apply `component/load-tests`,
+regardless of which files are touched or what the issue is about — this skill is only invoked for
+RT/load-test work.
+
+### Override 2 — RT focus-area label (new step, alongside `create-issue` Step 2's field inference)
+
+Every RT issue gets exactly one of the following labels, based on the team's focus-area model
+(foundation → enablement → coverage):
+
+| Label            | Meaning                                                                                          |
+|-------------------|--------------------------------------------------------------------------------------------------|
+| `rt/foundation`   | Tools, automation, or infrastructure investment for reliability testing (test, investigate, validate) |
+| `rt/enablement`   | Onboards other teams to run reliability tests proactively on their own                           |
+| `rt/coverage`     | Increases reliability-testing coverage of the orchestration cluster or an environment/deployment |
+
+Infer the label from the issue description:
+- Building/extending the load-test framework, harness, CI tooling, or dashboards → `rt/foundation`
+- Documentation, onboarding, or self-service tooling aimed at other teams running tests themselves →
+  `rt/enablement`
+- Adding/extending a load-test scenario, or covering a previously-untested feature/environment →
+  `rt/coverage`
+
+If the description doesn't clearly fit one category, ask the user to pick one before proceeding —
+do not guess or apply more than one.
+
+Additionally, infer the existing `discovered-by/load-tests` label when the description states the
+issue was found during a load-test run. This is optional (not every RT issue is discovery-sourced);
+leave it off if the description doesn't say so.
+
+### Labels passed at creation
+
+Pass all applicable labels explicitly on `gh issue create` (unlike plain `create-issue`, where most
+labels come from the body labeler): `kind/<type>`, `component/load-tests`, the chosen `rt/*` label,
+and `discovered-by/load-tests` if applicable.


### PR DESCRIPTION
## Description

`create-issue` auto-detects a component label from changed files, which never resolves to `component/load-tests` for RT-owned work, and has no concept of the team's foundation/enablement/coverage focus-area model. Every RT issue needed manual relabeling after creation.

`create-rt-issue` wraps `create-issue` (invoked via the `Skill` tool for template selection, duplicate check, field inference, body composition, and creation), overriding the component step to always apply `component/load-tests` and adding a new step that classifies the issue into exactly one of three new labels based on the team's focus-area model:

- `rt/foundation` - tools, automation, or infrastructure investment
- `rt/coverage` - increases reliability-testing coverage
- `rt/enablement` - onboards other teams to run tests on their own

These three labels were created in `camunda/camunda` as part of this change. The skill lives at `load-tests/skills/create-rt-issue/SKILL.md`, symlinked into `.claude/skills/create-rt-issue`, following the existing `load-test-ops`/`new-stable-load-test` pattern.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #

- [x] This PR does not need a linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)