### PR TITLE
test: ensure we wait for ES container to be fully healthy

### DIFF
--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -66,6 +66,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- TEST CONTAINERS -->
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.es;
 
-import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -24,10 +23,10 @@ import io.camunda.tasklist.qa.util.TestElasticsearchSchemaManager;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.TestApplication;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Locale;
 import java.util.Map;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -49,7 +48,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 @ExtendWith(SpringExtension.class)
@@ -76,17 +74,12 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
   private static final String TASKLIST_ES_PASSWORD = "tasklist_pwd";
 
   private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER =
-      new ElasticsearchContainer(
-              "docker.elastic.co/elasticsearch/elasticsearch:" + SUPPORTED_ELASTICSEARCH_VERSION)
+      TestSearchContainers.createDefeaultElasticsearchContainer()
           .withEnv(Map.of("xpack.security.enabled", "true", "ELASTIC_PASSWORD", ES_ADMIN_PASSWORD))
           .withExposedPorts(9200)
           .waitingFor(
-              Wait.forHttp("/_cluster/health?wait_for_status=yellow")
-                  .forPort(9200)
-                  .withBasicCredentials(ES_ADMIN_USER, ES_ADMIN_PASSWORD)
-                  .forStatusCode(200)
-                  .forResponsePredicate(
-                      response -> !response.toLowerCase(Locale.ROOT).contains("\"red\"")));
+              TestSearchContainers.waitForClusterHealth()
+                  .withBasicCredentials(ES_ADMIN_USER, ES_ADMIN_PASSWORD));
 
   @Autowired
   @Qualifier("tasklistEsClient")

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
@@ -27,6 +27,7 @@ import io.camunda.tasklist.util.TestApplication;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -48,6 +49,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 @ExtendWith(SpringExtension.class)
@@ -77,7 +79,14 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
       new ElasticsearchContainer(
               "docker.elastic.co/elasticsearch/elasticsearch:" + SUPPORTED_ELASTICSEARCH_VERSION)
           .withEnv(Map.of("xpack.security.enabled", "true", "ELASTIC_PASSWORD", ES_ADMIN_PASSWORD))
-          .withExposedPorts(9200);
+          .withExposedPorts(9200)
+          .waitingFor(
+              Wait.forHttp("/_cluster/health?wait_for_status=yellow")
+                  .forPort(9200)
+                  .withBasicCredentials(ES_ADMIN_USER, ES_ADMIN_PASSWORD)
+                  .forStatusCode(200)
+                  .forResponsePredicate(
+                      response -> !response.toLowerCase(Locale.ROOT).contains("\"red\"")));
 
   @Autowired
   @Qualifier("tasklistEsClient")

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -19,10 +19,8 @@ import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.io.IOException;
-import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -45,12 +43,8 @@ public class CamundaExporterAuthenticationIT {
           .withPassword(ELASTIC_PASSWORD)
           .withEnv("xpack.security.enabled", "true")
           .waitingFor(
-              new HttpWaitStrategy()
-                  .forPort(9200)
-                  .forPath("/_cluster/health")
-                  .withBasicCredentials(ELASTIC_USER, ELASTIC_PASSWORD)
-                  .forStatusCode(200)
-                  .withStartupTimeout(Duration.ofMinutes(5)));
+              TestSearchContainers.waitForClusterHealth()
+                  .withBasicCredentials(ELASTIC_USER, ELASTIC_PASSWORD));
 
   private final ExporterConfiguration config = new ExporterConfiguration();
   private final ProtocolFactory factory = new ProtocolFactory();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -8,12 +8,15 @@
 package io.camunda.zeebe.test.util.testcontainers;
 
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Objects;
 import org.opensearch.testcontainers.OpenSearchContainer;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.oracle.OracleContainer;
@@ -24,7 +27,8 @@ public final class TestSearchContainers {
   public static final String CAMUNDA_DATABASE = "camunda";
   public static final String CAMUNDA_USER = "camunda";
   public static final String CAMUNDA_PASSWORD = "Camunda_Pass123!";
-
+  // startup can be slow in CI
+  private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(5);
   private static final DockerImageName ELASTIC_IMAGE =
       DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
           .withTag(
@@ -90,8 +94,7 @@ public final class TestSearchContainers {
             "elasticsearch-fast-startup.options",
             "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
             BindMode.READ_ONLY)
-        // can be slow in CI
-        .withStartupTimeout(Duration.ofMinutes(5))
+        .withStartupTimeout(STARTUP_TIMEOUT)
         .withEnv("action.auto_create_index", "true")
         .withEnv("xpack.security.enabled", "false")
         .withEnv("xpack.watcher.enabled", "false")
@@ -99,12 +102,24 @@ public final class TestSearchContainers {
         .withEnv("action.destructive_requires_name", "false");
   }
 
+  public static HttpWaitStrategy waitForClusterHealth() {
+    // only waiting for yellow as that means we should be able to start
+    // using the cluster - even if not all replicas are ready
+    return (HttpWaitStrategy)
+        Wait.forHttp("/_cluster/health?wait_for_status=yellow")
+            .forPort(9200)
+            .forStatusCode(200)
+            .forResponsePredicate(
+                response -> !response.toLowerCase(Locale.ROOT).contains("\"red\""))
+            .withStartupTimeout(STARTUP_TIMEOUT);
+  }
+
   public static PostgreSQLContainer<?> createDefaultPostgresContainer() {
     return new PostgreSQLContainer<>(POSTGRES_IMAGE)
         .withDatabaseName(CAMUNDA_DATABASE)
         .withUsername(CAMUNDA_USER)
         .withPassword(CAMUNDA_PASSWORD)
-        .withStartupTimeout(Duration.ofMinutes(5));
+        .withStartupTimeout(STARTUP_TIMEOUT);
   }
 
   public static PostgreSQLContainer<?> createManualPostgresContainer() {
@@ -115,7 +130,7 @@ public final class TestSearchContainers {
         .withInitScripts(
             "db-init-scripts/postgres-manual-user.sql",
             "liquibase/sql/create/postgresql/postgresql_master.sql")
-        .withStartupTimeout(Duration.ofMinutes(5));
+        .withStartupTimeout(STARTUP_TIMEOUT);
   }
 
   public static OracleContainer createDefaultOracleContainer() {
@@ -123,7 +138,7 @@ public final class TestSearchContainers {
         .withDatabaseName(CAMUNDA_DATABASE)
         .withUsername(CAMUNDA_USER)
         .withPassword(CAMUNDA_PASSWORD)
-        .withStartupTimeout(Duration.ofMinutes(5));
+        .withStartupTimeout(STARTUP_TIMEOUT);
   }
 
   /**
@@ -138,7 +153,7 @@ public final class TestSearchContainers {
         .withUsername(CAMUNDA_USER)
         .withPassword(CAMUNDA_PASSWORD)
         .withInitScripts("liquibase/sql/create/oracle/oracle_master.sql")
-        .withStartupTimeout(Duration.ofMinutes(5));
+        .withStartupTimeout(STARTUP_TIMEOUT);
   }
 
   public static MariaDBContainer<?> createDefaultMariaDBContainer() {
@@ -146,7 +161,7 @@ public final class TestSearchContainers {
         .withDatabaseName(CAMUNDA_DATABASE)
         .withUsername(CAMUNDA_USER)
         .withPassword(CAMUNDA_PASSWORD)
-        .withStartupTimeout(Duration.ofMinutes(5));
+        .withStartupTimeout(STARTUP_TIMEOUT);
   }
 
   public static MariaDBContainer<?> createManualMariaDBContainer() {
@@ -162,7 +177,7 @@ public final class TestSearchContainers {
             "/docker-entrypoint-initdb.d/mariadb-manual-user.sql",
             BindMode.READ_ONLY)
         .withInitScripts("liquibase/sql/create/mariadb/mariadb_master.sql")
-        .withStartupTimeout(Duration.ofMinutes(5));
+        .withStartupTimeout(STARTUP_TIMEOUT);
   }
 
   public static MySQLContainer<?> createDefaultMySQLContainer() {
@@ -170,7 +185,7 @@ public final class TestSearchContainers {
         .withDatabaseName(CAMUNDA_DATABASE)
         .withUsername(CAMUNDA_USER)
         .withPassword(CAMUNDA_PASSWORD)
-        .withStartupTimeout(Duration.ofMinutes(5));
+        .withStartupTimeout(STARTUP_TIMEOUT);
   }
 
   public static MySQLContainer<?> createManualMySQLContainer() {
@@ -186,13 +201,13 @@ public final class TestSearchContainers {
             "/docker-entrypoint-initdb.d/mysql-manual-user.sql",
             BindMode.READ_ONLY)
         .withInitScripts("liquibase/sql/create/mysql/mysql_master.sql")
-        .withStartupTimeout(Duration.ofMinutes(5));
+        .withStartupTimeout(STARTUP_TIMEOUT);
   }
 
   public static MSSQLServerContainer createDefaultMSSQLServerContainer() {
     return new MSSQLServerContainer(MSSQLSERVER_IMAGE)
         .withPassword(CAMUNDA_PASSWORD)
-        .withStartupTimeout(Duration.ofMinutes(5))
+        .withStartupTimeout(STARTUP_TIMEOUT)
         .acceptLicense();
   }
 
@@ -200,7 +215,7 @@ public final class TestSearchContainers {
     return new MSSQLServerContainer(MSSQLSERVER_IMAGE)
         .withInitScripts(
             "db-init-scripts/mssql-manual-user.sql", "liquibase/sql/create/mssql/mssql_master.sql")
-        .withStartupTimeout(Duration.ofMinutes(5))
+        .withStartupTimeout(STARTUP_TIMEOUT)
         .acceptLicense();
   }
 }


### PR DESCRIPTION
## Description

otherwise the test can fail on startup when we try to write to ES before it's fully ready.

## Related issues

- [x] This PR does not need a linked issue

