### PR TITLE
test: migrate from GrpcClientRule to CamundaClient in Junit5 test

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupReplicatedPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupReplicatedPartitionTest.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.it.cluster.clustering.ClusteringRuleExtension;
-import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.test.testcontainers.MinioContainer;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
@@ -39,7 +39,7 @@ class BackupReplicatedPartitionTest {
   @Container private static final MinioContainer S3 = new MinioContainer();
   private static final String JOB_TYPE = "test";
   private String bucketName = null;
-  private GrpcClientRule client;
+  private ZeebeResourcesHelper resourcesHelper;
   private BackupRequestHandler backupRequestHandler;
 
   @RegisterExtension
@@ -72,7 +72,7 @@ class BackupReplicatedPartitionTest {
 
   @BeforeEach
   void setup() {
-    client = new GrpcClientRule(clusteringRule.getClient());
+    resourcesHelper = new ZeebeResourcesHelper(clusteringRule.getClient());
     backupRequestHandler = new BackupRequestHandler(clusteringRule.getGateway().getBrokerClient());
     // Create bucket before for storing backups
     final var s3ClientConfig =
@@ -100,7 +100,7 @@ class BackupReplicatedPartitionTest {
   void shouldQueryStatusOfBackupAfterLeaderChange()
       throws ExecutionException, InterruptedException, TimeoutException {
     // given
-    client.createSingleJob(JOB_TYPE);
+    resourcesHelper.createSingleJob(JOB_TYPE);
     final long backupId = 1;
     backup(backupId);
     waitUntilBackupIsCompleted(backupId);
@@ -123,7 +123,7 @@ class BackupReplicatedPartitionTest {
   @Timeout(value = 120)
   void shouldTakeNewBackupAfterLeaderChange() {
     // given
-    client.createSingleJob(JOB_TYPE);
+    resourcesHelper.createSingleJob(JOB_TYPE);
     final long backupId = 1;
     backup(backupId);
     waitUntilBackupIsCompleted(backupId);
@@ -138,7 +138,7 @@ class BackupReplicatedPartitionTest {
             .orElseThrow();
     clusteringRule.forceNewLeaderForPartition(anyFollower, 1);
 
-    client.createSingleJob(JOB_TYPE);
+    resourcesHelper.createSingleJob(JOB_TYPE);
 
     // then
     final var newBackupId = 2;


### PR DESCRIPTION
## Description
In Junit5 it's simpler to just use `@AutoClose CamundaClient` rather then the Junit4 GrpcClientRule w/ manual cleanups

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

