### PR TITLE
test: set test owner for Aurora Async Replication Test

### DIFF
--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -62,6 +62,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/data-layer'
   AWS_REGION: eu-west-1
   TF_DIR: .github/terraform/aurora-replication-it
   TF_IN_AUTOMATION: 'true'


### PR DESCRIPTION
## Description

Just set the TEST_OWNER to data layer for this workflow.

## Related issues

- [x] This PR does not need a linked issue

