### PR TITLE
test: ensure secondary storage enabled in test

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
@@ -30,8 +30,9 @@ public class ResourceAccessControllerConfigurationTest {
             UnifiedConfiguration.class,
             UnifiedConfigurationHelper.class)
         .withBean(AuthorizationChecker.class, () -> mock(AuthorizationChecker.class))
-        // make REST gateway condition pass
+        // make REST gateway and secondary storage conditions pass
         .withPropertyValues(
+            "camunda.data.secondary-storage.type=elasticsearch",
             "zeebe.broker.gateway.enable=true",
             "camunda.rest.enabled=true",
             // avoid needing AuthorizationChecker by disabling authorizations


### PR DESCRIPTION
so we don't accidentally set is as disabled (e.g. from env var set by different test), which causes the test to fail.

when secondary storage is disabled we don't create any TenantAccessProvider beans, which this test assumes exist.

## Related issues

- [x] This PR does not need a linked issue

