### PR TITLE
feat: update Camunda design system in Admin

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -18,7 +18,6 @@
         "@tanstack/react-query": "^5.100.14",
         "date-fns": "4.4.0",
         "i18next": "26.4.2",
-        "lucide-react": "1.35.0",
         "mobx": "7.0.3",
         "mobx-react-lite": "5.0.3",
         "react": "19.2.8",

--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@camunda/camunda-api-zod-schemas": "0.0.93",
         "@camunda/camunda-composite-components": "0.25.4",
-        "@camunda/design-system": "0.48.0",
+        "@camunda/design-system": "0.53.0",
         "@camunda/session-heartbeat": "0.0.1",
         "@carbon/elements": "11.96.0",
         "@carbon/react": "1.112.0",
@@ -360,9 +360,9 @@
       }
     },
     "node_modules/@camunda/design-system": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@camunda/design-system/-/design-system-0.48.0.tgz",
-      "integrity": "sha512-ffCaGZOYfrWggY8kt2MdDTnc5ARMRdLDI9SOtXO7ugCx4FKPitAav5M2x6K97Pc626lWOz+IhAG30gaaZj72yQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@camunda/design-system/-/design-system-0.53.0.tgz",
+      "integrity": "sha512-3IjFEGJ8xefXmOyZbZMq9n9mG1t1s3gPeA8NGphoG+pvwIic/gxAVcxonYMNa7efbpIp3I5XXMZVOInSLOwg1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/react-table": "^8.20.5",
@@ -371,7 +371,7 @@
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
         "date-fns": "^4.4.0",
-        "lucide-react": "^1.25.0",
+        "lucide-react": "^1.34.0",
         "radix-ui": "1.4.3",
         "react-day-picker": "^10.0.1",
         "recharts": "^3.8.1",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@camunda/camunda-api-zod-schemas": "0.0.93",
     "@camunda/camunda-composite-components": "0.25.4",
-    "@camunda/design-system": "0.48.0",
+    "@camunda/design-system": "0.53.0",
     "@camunda/session-heartbeat": "0.0.1",
     "@carbon/elements": "11.96.0",
     "@carbon/react": "1.112.0",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -28,7 +28,6 @@
     "@tanstack/react-query": "^5.100.14",
     "date-fns": "4.4.0",
     "i18next": "26.4.2",
-    "lucide-react": "1.35.0",
     "mobx": "7.0.3",
     "mobx-react-lite": "5.0.3",
     "react": "19.2.8",

--- a/identity/client/src/components/documentationV2/index.tsx
+++ b/identity/client/src/components/documentationV2/index.tsx
@@ -9,7 +9,7 @@
 import { FC, ReactNode } from "react";
 import useTranslate from "../../utility/localization";
 import { useDocsUrl } from "../documentation/DocsUrlContext";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink } from "@camunda/design-system/icons";
 
 type DocumentationLinkProps = {
   children?: ReactNode;

--- a/identity/client/src/components/documentationV2/index.tsx
+++ b/identity/client/src/components/documentationV2/index.tsx
@@ -10,6 +10,7 @@ import { FC, ReactNode } from "react";
 import useTranslate from "../../utility/localization";
 import { useDocsUrl } from "../documentation/DocsUrlContext";
 import { ExternalLink } from "@camunda/design-system/icons";
+import { Link } from "@camunda/design-system";
 
 type DocumentationLinkProps = {
   children?: ReactNode;
@@ -31,12 +32,12 @@ export const DocumentationLink: FC<DocumentationLinkProps> = ({
   const docsUrl = useDocsUrl();
 
   return (
-    <a
+    <Link
       href={documentationHref(docsUrl, path)}
       data-test="documentation-link"
       target="_blank"
       rel="noreferrer noopener"
-      className="rounded-sm text-info-action-default underline-offset-2 hover:underline focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      inline
     >
       {children || <Translate>documentation</Translate>}
       {withIcon && (
@@ -45,6 +46,6 @@ export const DocumentationLink: FC<DocumentationLinkProps> = ({
           className="ms-1 inline size-4 align-text-bottom"
         />
       )}
-    </a>
+    </Link>
   );
 };

--- a/identity/client/src/components/entityListV2/EntityList.tsx
+++ b/identity/client/src/components/entityListV2/EntityList.tsx
@@ -19,7 +19,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@camunda/design-system";
-import { LucideIcon, Plus } from "lucide-react";
+import { LucideIcon, Plus } from "@camunda/design-system/icons";
 import { DocumentationLink } from "src/components/documentationV2";
 import useTranslate from "src/utility/localization";
 import { PageResult, SortConfig } from "src/utility/api";

--- a/identity/client/src/components/entityListV2/EntityList.tsx
+++ b/identity/client/src/components/entityListV2/EntityList.tsx
@@ -19,7 +19,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@camunda/design-system";
-import { LucideIcon, Plus } from "@camunda/design-system/icons";
+import { type LucideIcon, Plus } from "@camunda/design-system/icons";
 import { DocumentationLink } from "src/components/documentationV2";
 import useTranslate from "src/utility/localization";
 import { PageResult, SortConfig } from "src/utility/api";

--- a/identity/client/src/components/formV2/DateRangeField/index.tsx
+++ b/identity/client/src/components/formV2/DateRangeField/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { Calendar } from "lucide-react";
+import { Calendar } from "@camunda/design-system/icons";
 import TextField from "src/components/formV2/TextField";
 import { formatDate, formatTime } from "./formatDate";
 import { DateRangeModal } from "./DateRangeModal";

--- a/identity/client/src/components/formV2/DateRangeField/index.tsx
+++ b/identity/client/src/components/formV2/DateRangeField/index.tsx
@@ -65,7 +65,7 @@ const DateRangeField: React.FC<Props> = ({
         readOnly
         onClick={handleClick}
         actionButton={{
-          icon: <Calendar aria-hidden="true" />,
+          icon: Calendar,
           label: "Open date range modal",
           onClick: handleClick,
           ariaHasPopup: "dialog",

--- a/identity/client/src/components/formV2/DropdownSearch.tsx
+++ b/identity/client/src/components/formV2/DropdownSearch.tsx
@@ -8,12 +8,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
-  Button,
   cn,
   Command,
   CommandInput,
   CommandItem,
   CommandList,
+  IconButton,
   Popover,
   PopoverAnchor,
   PopoverContent,
@@ -122,16 +122,15 @@ const DropdownSearch = <Item extends Record<string, unknown>>({
               className={cn(search && "pr-8")}
             />
             {search && (
-              <Button
+              <IconButton
                 type="button"
                 variant="ghost"
-                size="icon-sm"
+                size="sm"
                 className="absolute inset-y-0 right-1 my-auto"
-                aria-label={t("clearSearch")}
+                label={t("clearSearch")}
+                icon={XIcon}
                 onClick={handleClear}
-              >
-                <XIcon aria-hidden="true" />
-              </Button>
+              />
             )}
           </div>
         </PopoverAnchor>

--- a/identity/client/src/components/formV2/DropdownSearch.tsx
+++ b/identity/client/src/components/formV2/DropdownSearch.tsx
@@ -19,7 +19,7 @@ import {
   PopoverContent,
   Text,
 } from "@camunda/design-system";
-import { XIcon } from "lucide-react";
+import { XIcon } from "@camunda/design-system/icons";
 import useDebounce from "react-debounced";
 import useTranslate from "src/utility/localization";
 

--- a/identity/client/src/components/formV2/EntitySearchDropdown.tsx
+++ b/identity/client/src/components/formV2/EntitySearchDropdown.tsx
@@ -9,7 +9,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Badge } from "@camunda/design-system";
-import { XIcon } from "lucide-react";
+import { XIcon } from "@camunda/design-system/icons";
 import DropdownSearch from "src/components/formV2/DropdownSearch";
 import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
 import useTranslate from "src/utility/localization";

--- a/identity/client/src/components/formV2/FormField.tsx
+++ b/identity/client/src/components/formV2/FormField.tsx
@@ -7,73 +7,38 @@
  */
 
 import { FC, ReactNode, useId } from "react";
-import { Label, Text } from "@camunda/design-system";
+import { Label } from "@camunda/design-system";
 
 export type FormFieldControlProps = {
   id: string;
-  "aria-invalid": true | undefined;
   "aria-describedby": string | undefined;
 };
 
 export type FormFieldProps = {
   label: string;
-  error?: ReactNode;
-  helperText?: ReactNode;
   /** Receives the id it has to carry, which is part of the control's `aria-describedby`. */
   footer?: (id: string) => ReactNode;
   children: (control: FormFieldControlProps) => ReactNode;
 };
 
 /**
- * Label, control, and error/helper text, with the `aria-*` wiring between
- * them. The design system ships the parts but no wrapper that connects them.
- *
- * The control is a render prop because only the caller knows which element the
- * generated id and `aria-*` attributes belong on. A control that accepts
- * neither `aria-invalid` nor `aria-describedby` — `MultiSelect` — can take the
- * `id` alone; its error still announces through `role="alert"` below.
+ * Label and control, with the id wiring between them. `Input`, `Textarea`,
+ * and `SelectTrigger` render their own error/helper text and `aria-*` wiring
+ * given `invalidText`/`helperText`/`aria-invalid` directly — pass those to
+ * the control instead of through this wrapper. `MultiSelect` has no such
+ * support, so its callers must render their own error text alongside it.
  */
-const FormField: FC<FormFieldProps> = ({
-  label,
-  error,
-  helperText,
-  footer,
-  children,
-}) => {
+const FormField: FC<FormFieldProps> = ({ label, footer, children }) => {
   const id = useId();
-  const errorId = `${id}-error`;
-  const helperId = `${id}-helper`;
   const footerId = `${id}-footer`;
-
-  const showHelperText = !error && Boolean(helperText);
-  const describedBy =
-    [
-      error ? errorId : undefined,
-      showHelperText ? helperId : undefined,
-      footer ? footerId : undefined,
-    ]
-      .filter(Boolean)
-      .join(" ") || undefined;
 
   return (
     <div className="flex flex-col gap-1.5">
       <Label htmlFor={id}>{label}</Label>
       {children({
         id,
-        "aria-invalid": error ? true : undefined,
-        "aria-describedby": describedBy,
+        "aria-describedby": footer ? footerId : undefined,
       })}
-      {error || showHelperText ? (
-        <Text
-          as="p"
-          variant="helper"
-          id={error ? errorId : helperId}
-          role={error ? "alert" : undefined}
-          className={error ? "text-danger-action-default" : undefined}
-        >
-          {error || helperText}
-        </Text>
-      ) : null}
       {footer?.(footerId)}
     </div>
   );

--- a/identity/client/src/components/formV2/JSONEditor.tsx
+++ b/identity/client/src/components/formV2/JSONEditor.tsx
@@ -10,7 +10,7 @@ import Editor from "@monaco-editor/react";
 import { Button, Label, Text } from "@camunda/design-system";
 import { observer } from "mobx-react-lite";
 import { ComponentProps, FC, useEffect, useRef, useState } from "react";
-import { Copy, Pencil } from "lucide-react";
+import { Copy, Pencil } from "@camunda/design-system/icons";
 import { beautify as beautifyJSON } from "src/utility/components/editor/jsonUtils.ts";
 import { options } from "src/utility/components/editor/options.ts";
 import useTranslate from "src/utility/localization";

--- a/identity/client/src/components/formV2/NumberField.tsx
+++ b/identity/client/src/components/formV2/NumberField.tsx
@@ -39,7 +39,7 @@ const NumberField: FC<NumberFieldProps> = ({
   const [draft, setDraft] = useState<string | null>(null);
 
   return (
-    <FormField label={label} error={error} helperText={helperText}>
+    <FormField label={label}>
       {(control) => (
         <Input
           {...control}
@@ -47,6 +47,9 @@ const NumberField: FC<NumberFieldProps> = ({
           title={label}
           min={min}
           step={step}
+          aria-invalid={error ? true : undefined}
+          invalidText={error}
+          helperText={helperText}
           value={draft ?? (value === undefined ? "" : String(value))}
           onChange={(event) => {
             const raw = event.currentTarget.value;

--- a/identity/client/src/components/formV2/TextField.tsx
+++ b/identity/client/src/components/formV2/TextField.tsx
@@ -20,7 +20,7 @@ import {
   Input,
   Textarea,
 } from "@camunda/design-system";
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import FormField from "./FormField";
 

--- a/identity/client/src/components/formV2/TextField.tsx
+++ b/identity/client/src/components/formV2/TextField.tsx
@@ -18,7 +18,7 @@ import {
   CharacterCount,
   IconButton,
   Input,
-  NavIcon,
+  type NavIcon,
   Textarea,
 } from "@camunda/design-system";
 import { Eye, EyeOff } from "@camunda/design-system/icons";

--- a/identity/client/src/components/formV2/TextField.tsx
+++ b/identity/client/src/components/formV2/TextField.tsx
@@ -15,9 +15,10 @@ import {
   useState,
 } from "react";
 import {
-  Button,
   CharacterCount,
+  IconButton,
   Input,
+  NavIcon,
   Textarea,
 } from "@camunda/design-system";
 import { Eye, EyeOff } from "@camunda/design-system/icons";
@@ -25,7 +26,7 @@ import useTranslate from "src/utility/localization";
 import FormField from "./FormField";
 
 type ActionButtonProps = {
-  icon: ReactNode;
+  icon: NavIcon;
   label: string;
   onClick: () => void;
   ariaHasPopup?: AriaAttributes["aria-haspopup"];
@@ -168,23 +169,16 @@ const TextField: FC<TextFieldProps> = ({
                 type={passwordVisible ? "text" : "password"}
                 className="pr-10"
               />
-              <Button
+              <IconButton
                 type="button"
                 variant="ghost"
-                size="icon-sm"
+                size="sm"
                 className="absolute top-0.5 right-0.5"
-                aria-label={
-                  passwordVisible ? t("hidePassword") : t("showPassword")
-                }
+                label={passwordVisible ? t("hidePassword") : t("showPassword")}
+                icon={passwordVisible ? EyeOff : Eye}
                 aria-pressed={passwordVisible}
                 onClick={() => setPasswordVisible((visible) => !visible)}
-              >
-                {passwordVisible ? (
-                  <EyeOff aria-hidden="true" />
-                ) : (
-                  <Eye aria-hidden="true" />
-                )}
-              </Button>
+              />
             </div>
           );
         }
@@ -210,18 +204,17 @@ const TextField: FC<TextFieldProps> = ({
           return (
             <div className="relative">
               <Input {...commonProps} type={type} className="pr-9" />
-              <Button
+              <IconButton
                 type="button"
                 variant="ghost"
-                size="icon-sm"
+                size="sm"
                 className="absolute top-0.5 right-0.5"
-                aria-label={actionButton.label}
+                label={actionButton.label}
+                icon={actionButton.icon}
                 aria-haspopup={actionButton.ariaHasPopup}
                 aria-expanded={actionButton.ariaExpanded}
                 onClick={actionButton.onClick}
-              >
-                {actionButton.icon}
-              </Button>
+              />
             </div>
           );
         }

--- a/identity/client/src/components/formV2/TextField.tsx
+++ b/identity/client/src/components/formV2/TextField.tsx
@@ -127,8 +127,6 @@ const TextField: FC<TextFieldProps> = ({
   return (
     <FormField
       label={label}
-      error={errorText}
-      helperText={helperText}
       footer={
         showCounter
           ? (id) => (
@@ -154,6 +152,9 @@ const TextField: FC<TextFieldProps> = ({
           autoFocus,
           name,
           autoComplete,
+          "aria-invalid": errorText ? (true as const) : undefined,
+          invalidText: errorText || undefined,
+          helperText,
           onChange: handleChange,
           onBlur: handleBlur,
           onClick,
@@ -171,7 +172,7 @@ const TextField: FC<TextFieldProps> = ({
                 type="button"
                 variant="ghost"
                 size="icon-sm"
-                className="absolute inset-y-0 right-0.5 my-auto"
+                className="absolute top-0.5 right-0.5"
                 aria-label={
                   passwordVisible ? t("hidePassword") : t("showPassword")
                 }
@@ -213,7 +214,7 @@ const TextField: FC<TextFieldProps> = ({
                 type="button"
                 variant="ghost"
                 size="icon-sm"
-                className="absolute inset-y-0 right-0.5 my-auto"
+                className="absolute top-0.5 right-0.5"
                 aria-label={actionButton.label}
                 aria-haspopup={actionButton.ariaHasPopup}
                 aria-expanded={actionButton.ariaExpanded}

--- a/identity/client/src/components/layout/AppHeaderV2/InfoMenu.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/InfoMenu.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { HelpCircle } from "lucide-react";
+import { HelpCircle } from "@camunda/design-system/icons";
 import {
   Button,
   DropdownMenu,

--- a/identity/client/src/components/layout/AppHeaderV2/InfoMenu.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/InfoMenu.tsx
@@ -8,12 +8,12 @@
 
 import { HelpCircle } from "@camunda/design-system/icons";
 import {
-  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
+  IconButton,
 } from "@camunda/design-system";
 
 import useTranslate from "src/utility/localization";
@@ -42,14 +42,12 @@ const InfoMenu = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
+        <IconButton
           type="button"
           variant="ghost"
-          size="icon"
-          aria-label={t("info")}
-        >
-          <HelpCircle aria-hidden className="size-4" />
-        </Button>
+          label={t("info")}
+          icon={HelpCircle}
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="end">
         <DropdownMenuLabel>{t("info")}</DropdownMenuLabel>

--- a/identity/client/src/components/layout/AppHeaderV2/useSidebarChildren.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/useSidebarChildren.tsx
@@ -18,7 +18,7 @@ import {
   Users,
   Waypoints,
   Zap,
-} from "lucide-react";
+} from "@camunda/design-system/icons";
 import type { NavIcon, SidebarNode } from "@camunda/design-system";
 
 import { useGlobalRoutes } from "src/components/global/useGlobalRoutes";

--- a/identity/client/src/components/layoutV2/PageEmptyState.tsx
+++ b/identity/client/src/components/layoutV2/PageEmptyState.tsx
@@ -7,7 +7,7 @@
  */
 
 import { Button, EmptyState } from "@camunda/design-system";
-import { Plus } from "lucide-react";
+import { Plus } from "@camunda/design-system/icons";
 import { FC } from "react";
 import { documentationHref } from "src/components/documentationV2";
 import { useDocsUrl } from "../documentation/DocsUrlContext";

--- a/identity/client/src/components/layoutV2/PageEmptyState.tsx
+++ b/identity/client/src/components/layoutV2/PageEmptyState.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { Button, EmptyState } from "@camunda/design-system";
+import { Button, EmptyState, Link } from "@camunda/design-system";
 import { Plus } from "@camunda/design-system/icons";
 import { FC } from "react";
 import { documentationHref } from "src/components/documentationV2";
@@ -44,15 +44,13 @@ const PageEmptyState: FC<PageEmptyStateProps> = ({
         </Button>
       }
       secondaryAction={
-        <Button variant="link" size="sm" asChild>
-          <a
-            href={documentationHref(docsUrl, docsLinkPath)}
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            {t("emptyStateLearnText", { resourceType: resourceTypeText })}
-          </a>
-        </Button>
+        <Link
+          href={documentationHref(docsUrl, docsLinkPath)}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {t("emptyStateLearnText", { resourceType: resourceTypeText })}
+        </Link>
       }
     />
   );

--- a/identity/client/src/components/layoutV2/TabEmptyState.tsx
+++ b/identity/client/src/components/layoutV2/TabEmptyState.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Button, EmptyState } from "@camunda/design-system";
+import { Button, EmptyState, Link } from "@camunda/design-system";
 import { Plus } from "@camunda/design-system/icons";
 import { useDocsUrl } from "../documentation/DocsUrlContext";
 import { documentationHref } from "src/components/documentationV2";
@@ -60,17 +60,15 @@ const TabEmptyState: FC<TabEmptyStateProps> = ({
         </Button>
       }
       secondaryAction={
-        <Button variant="link" size="sm" asChild>
-          <a
-            href={documentationHref(docsUrl, docsLinkPath)}
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            {t("emptyStateLearnText", {
-              resourceType: childResourceTypeText,
-            })}
-          </a>
-        </Button>
+        <Link
+          href={documentationHref(docsUrl, docsLinkPath)}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {t("emptyStateLearnText", {
+            resourceType: childResourceTypeText,
+          })}
+        </Link>
       }
     />
   );

--- a/identity/client/src/components/layoutV2/TabEmptyState.tsx
+++ b/identity/client/src/components/layoutV2/TabEmptyState.tsx
@@ -8,7 +8,7 @@
 
 import { FC } from "react";
 import { Button, EmptyState } from "@camunda/design-system";
-import { Plus } from "lucide-react";
+import { Plus } from "@camunda/design-system/icons";
 import { useDocsUrl } from "../documentation/DocsUrlContext";
 import { documentationHref } from "src/components/documentationV2";
 import useTranslate from "src/utility/localization";

--- a/identity/client/src/pages/authorizations/AuthorizationsListV2.tsx
+++ b/identity/client/src/pages/authorizations/AuthorizationsListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Plus, Trash2 } from "lucide-react";
+import { Plus, Trash2 } from "@camunda/design-system/icons";
 import { Button, EmptyState } from "@camunda/design-system";
 import { SearchResponse, usePagination } from "src/utility/api";
 import useTranslate from "src/utility/localization";

--- a/identity/client/src/pages/authorizations/modalsV2/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modalsV2/add-modal/AddModal.tsx
@@ -230,10 +230,7 @@ export const AddModal: FC<
             name="resourcePropertyName"
             control={control}
             render={({ field, fieldState }) => (
-              <FormField
-                label={t("resourcePropertyName")}
-                error={fieldState.error?.message}
-              >
+              <FormField label={t("resourcePropertyName")}>
                 {({ id, ...controlProps }) => (
                   <Select
                     value={field.value ?? ""}
@@ -241,7 +238,13 @@ export const AddModal: FC<
                       field.onChange(value as ResourcePropertyName)
                     }
                   >
-                    <SelectTrigger id={id} className="w-full" {...controlProps}>
+                    <SelectTrigger
+                      id={id}
+                      className="w-full"
+                      aria-invalid={fieldState.error ? true : undefined}
+                      invalidText={fieldState.error?.message}
+                      {...controlProps}
+                    >
                       <SelectValue
                         placeholder={t("selectResourcePropertyName")}
                       />

--- a/identity/client/src/pages/global-task-listeners/ListV2.tsx
+++ b/identity/client/src/pages/global-task-listeners/ListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";
 import { useQuery } from "@tanstack/react-query";

--- a/identity/client/src/pages/global-task-listeners/modalsV2/AddModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modalsV2/AddModal.tsx
@@ -15,6 +15,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Text,
 } from "@camunda/design-system";
 import { FormModal, UseModalProps } from "src/components/modalV2";
 import useTranslate from "src/utility/localization";
@@ -142,27 +143,40 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
           validate: (value) => value.length > 0 || t("eventTypeRequired"),
         }}
         render={({ field, fieldState }) => (
-          <FormField label={t("eventType")} error={fieldState.error?.message}>
+          <FormField label={t("eventType")}>
             {({ id }) => (
-              <MultiSelect
-                id={id}
-                placeholder={t("selectEventTypes")}
-                options={eventTypeOptions}
-                // "all" is a real API value listed next to the individual
-                // events, so the schema order carries meaning and the built-in
-                // select-all row would duplicate the "All events" option.
-                sorted={false}
-                hideSelectAll
-                searchable={false}
-                // Checking "All events" selects every type at once, and the
-                // default cap of 3 would collapse the rest into a "+N more"
-                // chip that hides what is about to be submitted.
-                maxCount={LISTENER_EVENT_TYPES.length}
-                value={field.value}
-                onValueChange={(value) =>
-                  field.onChange(syncAllEventType(value, field.value))
-                }
-              />
+              <>
+                <MultiSelect
+                  id={id}
+                  placeholder={t("selectEventTypes")}
+                  options={eventTypeOptions}
+                  // "all" is a real API value listed next to the individual
+                  // events, so the schema order carries meaning and the built-in
+                  // select-all row would duplicate the "All events" option.
+                  sorted={false}
+                  hideSelectAll
+                  searchable={false}
+                  // Checking "All events" selects every type at once, and the
+                  // default cap of 3 would collapse the rest into a "+N more"
+                  // chip that hides what is about to be submitted.
+                  maxCount={LISTENER_EVENT_TYPES.length}
+                  value={field.value}
+                  onValueChange={(value) =>
+                    field.onChange(syncAllEventType(value, field.value))
+                  }
+                  aria-invalid={!!fieldState.error}
+                />
+                {fieldState.error ? (
+                  <Text
+                    as="p"
+                    variant="helper"
+                    role="alert"
+                    className="text-danger-action-default"
+                  >
+                    {fieldState.error.message}
+                  </Text>
+                ) : null}
+              </>
             )}
           </FormField>
         )}

--- a/identity/client/src/pages/global-task-listeners/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modalsV2/EditModal.tsx
@@ -15,6 +15,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Text,
 } from "@camunda/design-system";
 import { FormModal, UseEntityModalProps } from "src/components/modalV2";
 import useTranslate from "src/utility/localization";
@@ -140,27 +141,40 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
           validate: (value) => value.length > 0 || t("eventTypeRequired"),
         }}
         render={({ field, fieldState }) => (
-          <FormField label={t("eventType")} error={fieldState.error?.message}>
+          <FormField label={t("eventType")}>
             {({ id }) => (
-              <MultiSelect
-                id={id}
-                placeholder={t("selectEventTypes")}
-                options={eventTypeOptions}
-                // "all" is a real API value listed next to the individual
-                // events, so the schema order carries meaning and the built-in
-                // select-all row would duplicate the "All events" option.
-                sorted={false}
-                hideSelectAll
-                searchable={false}
-                // An existing listener can already have every event type
-                // selected; the default cap of 3 would collapse the rest into a
-                // "+N more" chip and hide what is stored.
-                maxCount={LISTENER_EVENT_TYPES.length}
-                value={field.value}
-                onValueChange={(value) =>
-                  field.onChange(syncAllEventType(value, field.value))
-                }
-              />
+              <>
+                <MultiSelect
+                  id={id}
+                  placeholder={t("selectEventTypes")}
+                  options={eventTypeOptions}
+                  // "all" is a real API value listed next to the individual
+                  // events, so the schema order carries meaning and the built-in
+                  // select-all row would duplicate the "All events" option.
+                  sorted={false}
+                  hideSelectAll
+                  searchable={false}
+                  // An existing listener can already have every event type
+                  // selected; the default cap of 3 would collapse the rest into a
+                  // "+N more" chip and hide what is stored.
+                  maxCount={LISTENER_EVENT_TYPES.length}
+                  value={field.value}
+                  onValueChange={(value) =>
+                    field.onChange(syncAllEventType(value, field.value))
+                  }
+                  aria-invalid={!!fieldState.error}
+                />
+                {fieldState.error ? (
+                  <Text
+                    as="p"
+                    variant="helper"
+                    role="alert"
+                    className="text-danger-action-default"
+                  >
+                    {fieldState.error.message}
+                  </Text>
+                ) : null}
+              </>
             )}
           </FormField>
         )}

--- a/identity/client/src/pages/groups/ListV2.tsx
+++ b/identity/client/src/pages/groups/ListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/groups/detailV2/clients/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/clients/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { useQuery } from "@tanstack/react-query";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/groups/detailV2/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/index.tsx
@@ -9,7 +9,7 @@
 import { FC } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import { Button, PageHeader } from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { groupQueries } from "src/utility/api/groups/queries";

--- a/identity/client/src/pages/groups/detailV2/mapping-rules/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/mapping-rules/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/groups/detailV2/members/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/members/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { searchMembersByGroup } from "src/utility/api/membership";
 import EntityList from "src/components/entityListV2";

--- a/identity/client/src/pages/groups/detailV2/roles/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/roles/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/loginV2/LoginPage.tsx
+++ b/identity/client/src/pages/loginV2/LoginPage.tsx
@@ -8,7 +8,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Button, cn, Heading, Text } from "@camunda/design-system";
+import { Button, cn, Heading, Link, Text } from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { disableSession, isLoggedIn, login } from "src/utility/auth";
 import { getCopyrightNoticeText } from "src/utility/copyright.ts";
@@ -17,9 +17,6 @@ import { useLicense } from "src/utility/license.ts";
 import TextField from "src/components/formV2/TextField";
 import { ErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
 import Page from "src/components/layoutV2/Page";
-
-const textLinkClassName =
-  "text-info-action-default underline-offset-2 hover:underline focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 interface LoginFormProps {
   onSuccess: () => void;
@@ -150,23 +147,23 @@ export const LoginPage: React.FC<LoginPageProps> = ({ defaultRedirectUrl }) => {
             <Translate i18nKey="licenseInfo">
               Non-Production License. If you would like information on
               production usage, please refer to our{" "}
-              <a
+              <Link
                 href="https://legal.camunda.com/#self-managed-non-production-terms"
                 target="_blank"
                 rel="noreferrer noopener"
-                className={textLinkClassName}
+                inline
               >
                 terms & conditions page
-              </a>{" "}
+              </Link>{" "}
               or{" "}
-              <a
+              <Link
                 href="https://camunda.com/contact/"
                 target="_blank"
                 rel="noreferrer noopener"
-                className={textLinkClassName}
+                inline
               >
                 contact sales
-              </a>
+              </Link>
               .
             </Translate>
           </Text>

--- a/identity/client/src/pages/mapping-rules/ListV2.tsx
+++ b/identity/client/src/pages/mapping-rules/ListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";
 import { useQuery } from "@tanstack/react-query";

--- a/identity/client/src/pages/not-foundV2/index.tsx
+++ b/identity/client/src/pages/not-foundV2/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { Button } from "@camunda/design-system";
+import { Link } from "@camunda/design-system";
 import { FC } from "react";
 import useTranslate from "src/utility/localization";
 import ErrorPage from "src/components/globalV2/ErrorPage";
@@ -19,11 +19,9 @@ const NotFound: FC = () => {
       <Translate>
         What you&apos;re looking for isn&apos;t here, sorry!
       </Translate>
-      <Button variant="link" size="sm" asChild>
-        <a href="/">
-          <Translate>Click here to go back home</Translate>
-        </a>
-      </Button>
+      <Link href="/">
+        <Translate>Click here to go back home</Translate>
+      </Link>
     </ErrorPage>
   );
 };

--- a/identity/client/src/pages/operations-log/ListV2.tsx
+++ b/identity/client/src/pages/operations-log/ListV2.tsx
@@ -28,7 +28,7 @@ import TextField from "src/components/formV2/TextField";
 import useDebounce from "react-debounced";
 import { useForm, FieldPath, FieldPathValue } from "react-hook-form";
 import { CellProperty } from "src/pages/operations-log/CellPropertyV2";
-import { CircleCheck, Plug, User, XCircle } from "lucide-react";
+import { CircleCheck, Plug, User, XCircle } from "@camunda/design-system/icons";
 import AiAgentIcon from "src/assets/images/ai-agent.svg";
 import { DateRangeField } from "src/components/formV2/DateRangeField";
 import {

--- a/identity/client/src/pages/roles/ListV2.tsx
+++ b/identity/client/src/pages/roles/ListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";

--- a/identity/client/src/pages/roles/detailV2/clients/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/clients/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/roles/detailV2/groups/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { getGroupsByRoleId } from "src/utility/api/roles";
 import EntityList from "src/components/entityListV2";

--- a/identity/client/src/pages/roles/detailV2/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/index.tsx
@@ -9,7 +9,7 @@
 import { FC } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import { Button, PageHeader } from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { roleQueries } from "src/utility/api/roles/queries";

--- a/identity/client/src/pages/roles/detailV2/mapping-rules/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/mapping-rules/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/roles/detailV2/members/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { getMembersByRole } from "src/utility/api/membership";
 import EntityList from "src/components/entityListV2";

--- a/identity/client/src/pages/setupV2/SetupPage.tsx
+++ b/identity/client/src/pages/setupV2/SetupPage.tsx
@@ -9,7 +9,7 @@
 import React, { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button, Heading, Separator } from "@camunda/design-system";
-import { UserCog } from "lucide-react";
+import { UserCog } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import CamundaLogo from "src/assets/images/camunda.svg";
 import Page from "src/components/layoutV2/Page";

--- a/identity/client/src/pages/tenants/ListV2.tsx
+++ b/identity/client/src/pages/tenants/ListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";

--- a/identity/client/src/pages/tenants/detailV2/clients/index.tsx
+++ b/identity/client/src/pages/tenants/detailV2/clients/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { useQuery } from "@tanstack/react-query";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/tenants/detailV2/groups/index.tsx
+++ b/identity/client/src/pages/tenants/detailV2/groups/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { getGroupsByTenantId } from "src/utility/api/tenants";
 import EntityList from "src/components/entityListV2";

--- a/identity/client/src/pages/tenants/detailV2/index.tsx
+++ b/identity/client/src/pages/tenants/detailV2/index.tsx
@@ -9,7 +9,7 @@
 import { FC } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import { Button, PageHeader } from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { tenantQueries } from "src/utility/api/tenants/queries";

--- a/identity/client/src/pages/tenants/detailV2/mapping-rules/index.tsx
+++ b/identity/client/src/pages/tenants/detailV2/mapping-rules/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { useQuery } from "@tanstack/react-query";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/tenants/detailV2/members/index.tsx
+++ b/identity/client/src/pages/tenants/detailV2/members/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { getMembersByTenantId } from "src/utility/api/membership";
 import EntityList from "src/components/entityListV2";

--- a/identity/client/src/pages/tenants/detailV2/roles/index.tsx
+++ b/identity/client/src/pages/tenants/detailV2/roles/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@camunda/design-system/icons";
 import useTranslate from "src/utility/localization";
 import { useQuery } from "@tanstack/react-query";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/tenants/modalsV2/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modalsV2/AddModal.tsx
@@ -9,7 +9,7 @@
 import { FC, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
-import { Button, Heading, Text } from "@camunda/design-system";
+import { Heading, IconButton, Text } from "@camunda/design-system";
 import { ArrowRight, Info } from "@camunda/design-system/icons";
 import { DocumentationLink } from "src/components/documentationV2";
 import TextField from "src/components/formV2/TextField";
@@ -117,19 +117,17 @@ const AddTenantModal: FC<AddTenantModalProps> = ({
               <li key={item} className="border-b border-border py-1">
                 <div className="flex items-center justify-between gap-2">
                   <Text>{t(item)}</Text>
-                  <Button
+                  <IconButton
                     variant="ghost"
-                    size="icon"
-                    aria-label={t(item)}
+                    label={t(item)}
+                    icon={ArrowRight}
                     onClick={() => {
                       onClose?.();
                       void navigate(
                         `/tenants/${createdTenant.tenantId}/${ITEM_TO_TAB[item]}`,
                       );
                     }}
-                  >
-                    <ArrowRight aria-hidden="true" />
-                  </Button>
+                  />
                 </div>
                 {item === "assignClients" && (
                   <div className="flex items-start gap-2">

--- a/identity/client/src/pages/tenants/modalsV2/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modalsV2/AddModal.tsx
@@ -10,7 +10,7 @@ import { FC, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { Button, Heading, Text } from "@camunda/design-system";
-import { ArrowRight, Info } from "lucide-react";
+import { ArrowRight, Info } from "@camunda/design-system/icons";
 import { DocumentationLink } from "src/components/documentationV2";
 import TextField from "src/components/formV2/TextField";
 import { useMutation, useQueryClient } from "@tanstack/react-query";

--- a/identity/client/src/pages/users/ListV2.tsx
+++ b/identity/client/src/pages/users/ListV2.tsx
@@ -8,7 +8,7 @@
 
 import { FC } from "react";
 import { useNavigate } from "react-router-dom";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";

--- a/identity/client/src/pages/users/detailV2/index.tsx
+++ b/identity/client/src/pages/users/detailV2/index.tsx
@@ -9,7 +9,7 @@
 import { FC, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "@camunda/design-system/icons";
 import { Button, PageHeader } from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { userQueries } from "src/utility/api/users/queries";


### PR DESCRIPTION
## Description

This PR bumps the Camunda design system to the latest version in Admin. We don't have visual regression tests for Admin, but during some click-through I did not notice anything broken. In addition to the pure version bump, I added some the new features in separate commits one at a time:
- Replace `lucide-react` imports with the new `@camunda/design-system/icons` proxy. App's dependency on Lucide is removed.
- Integrated the new `Link` component where `<a>` or `Button variant="link"` was used.
- Utilize new `helperText` and `invalidText` properties on inputs.
- Replace buttons with icon only with new `IconButton`.

**Note:** I plan to replace the `DropdownSearch` mentioned in the linked issue in a stacked PR.

## Checklist

- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #62281 

