### PR TITLE
fix: bump log4j to 2.25.5 to resolve CVE-2026-49844

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -64,7 +64,7 @@
     <kotlin-stdlib.version>2.1.0</kotlin-stdlib.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
     <netty.version>4.1.137.Final</netty.version>
-    <log4j2.version>2.25.4</log4j2.version>
+    <log4j2.version>2.25.5</log4j2.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.37</logback.version>
     <slf4j.version>2.0.16</slf4j.version>


### PR DESCRIPTION
## Description

CVE-2026-49844 was scheduled as fixed in Optimize 8.7.28, via camunda-optimize#16654. That fix landed on the `maintenance/3.15` branch of the (now-archived) camunda-optimize repo and shipped in Optimize 3.15.17-3.15.19. It never reached this monorepo, because `optimize/` here is a separate history — there was nothing for the usual backport automation to act on.

The 8.7.27-optimize release (2026-09-02) still ships log4j 2.25.4. This monorepo's `stable/optimize-8.7` already has the structural fix from #16654 (log4j-bom imported ahead of spring-boot-dependencies, so the override applies to the whole log4j family) — it was just never bumped past 2.25.4.

This PR bumps `log4j2.version` to 2.25.5 to match, closing the gap for the next 8.7.x-optimize release.

## Checklist
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by CI DRI
  - [ ] ci.yml modifications comply with "Unified CI" requirements

## Related issues

- [x] This PR does not need a linked issue
