### PR TITLE
feat: add PgBouncer/Postgres connection metrics to load-test dashboard

### DIFF
--- a/load-tests/setup/charts/load-test-setup/README.md
+++ b/load-tests/setup/charts/load-test-setup/README.md
@@ -195,3 +195,7 @@ Setting `postgresql.pooler.enabled` directly (e.g. via
 Camunda connected straight to the Cluster's `-rw` Service — the Pooler deploys but nothing
 routes through it.
 
+### Connection monitoring
+
+`PodMonitor`s are wired automatically for the Cluster's and (when enabled) the Pooler's own connection metrics — no separate toggle.
+

--- a/load-tests/setup/charts/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/charts/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.postgresql.enabled -}}
+---
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Values.postgresql.clusterName }}
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: {{ .Values.postgresql.clusterName }}
+  podMetricsEndpoints:
+    - port: metrics
+{{- end -}}

--- a/load-tests/setup/charts/load-test-setup/templates/postgresql-pooler-podmonitor.yaml
+++ b/load-tests/setup/charts/load-test-setup/templates/postgresql-pooler-podmonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.pooler.enabled -}}
+---
+# Scrape the CNPG Pooler's (PgBouncer) own pool metrics, exposed as
+# cnpg_pgbouncer_pools_* (cl_active/cl_waiting on the client side,
+# sv_active/sv_idle/sv_used on the server side), labeled by database/user.
+#
+# Reference: https://cloudnative-pg.io/docs/current/connection_pooling
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Values.postgresql.clusterName }}-pooler
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/poolerName: {{ .Values.postgresql.clusterName }}-pooler
+  podMetricsEndpoints:
+    - port: metrics
+{{- end -}}

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql-pooler-podmonitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql-pooler-podmonitor.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/postgresql-pooler-podmonitor.yaml
+# Scrape the CNPG Pooler's (PgBouncer) own pool metrics, exposed as
+# cnpg_pgbouncer_pools_* (cl_active/cl_waiting on the client side,
+# sv_active/sv_idle/sv_used on the server side), labeled by database/user.
+#
+# Reference: https://cloudnative-pg.io/docs/current/connection_pooling
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql-pooler
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/poolerName: postgresql-pooler
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql-pooler-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql-pooler-podmonitor.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/postgresql-pooler-podmonitor.yaml
+# Scrape the CNPG Pooler's (PgBouncer) own pool metrics, exposed as
+# cnpg_pgbouncer_pools_* (cl_active/cl_waiting on the client side,
+# sv_active/sv_idle/sv_used on the server side), labeled by database/user.
+#
+# Reference: https://cloudnative-pg.io/docs/current/connection_pooling
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql-pooler
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/poolerName: postgresql-pooler
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql-pooler-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql-pooler-podmonitor.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/postgresql-pooler-podmonitor.yaml
+# Scrape the CNPG Pooler's (PgBouncer) own pool metrics, exposed as
+# cnpg_pgbouncer_pools_* (cl_active/cl_waiting on the client side,
+# sv_active/sv_idle/sv_used on the server side), labeled by database/user.
+#
+# Reference: https://cloudnative-pg.io/docs/current/connection_pooling
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql-pooler
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/poolerName: postgresql-pooler
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql-podmonitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql-podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# Source: load-test-setup/templates/postgresql-podmonitor.yaml
+# Scrape the CNPG-managed PostgreSQL cluster's own metrics (e.g. cnpg_backends_total,
+# labeled by state: active/idle/idle in transaction/...)
+#
+# A PodMonitor is a Prometheus Operator CRD (a scrape-config object the existing
+# Prometheus picks up) — it deploys no Pods/Deployments/Services of its own.
+# `Cluster.spec.monitoring.enablePodMonitor` is deprecated in favor of a standalone
+# PodMonitor: https://cloudnative-pg.io/docs/current/monitoring
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql
+  labels:
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgresql
+  podMetricsEndpoints:
+    - port: metrics

--- a/monitor/grafana/dashboards/data_layer.json
+++ b/monitor/grafana/dashboards/data_layer.json
@@ -3349,6 +3349,634 @@
           ],
           "title": "RDBMS Execution Queue Memory Size",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "HikariCP client-pool connections opened by each Camunda pod towards Postgres (or PgBouncer, if enabled), per physical tenant.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 33
+          },
+          "id": 700,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(hikaricp_connections_active{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\"}) by (pod, physicalTenant)",
+              "legendFormat": "{{pod}} {{physicalTenant}} active",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(hikaricp_connections_idle{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\"}) by (pod, physicalTenant)",
+              "legendFormat": "{{pod}} {{physicalTenant}} idle",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "HikariCP Connections (Active/Idle, by node)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "HikariCP pool utilization per Camunda pod (active connections ÷ configured maximum pool size).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.8
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 33
+          },
+          "id": 701,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(hikaricp_connections_active{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\"}) by (pod, physicalTenant)\n/\nsum(hikaricp_connections_max{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\"}) by (pod, physicalTenant)",
+              "legendFormat": "{{pod}} {{physicalTenant}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "HikariCP Pool Utilization",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "PgBouncer client-side pool (Camunda pods → PgBouncer), by Postgres database/user. cl_active = linked to a server; cl_waiting = queued for one (backpressure signal). Only populated when the CNPG Pooler is enabled. No per-pod breakdown is available here: PgBouncer's transaction pooling severs the 1:1 client-to-server mapping, so node attribution lives on the HikariCP panel above instead.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 41
+          },
+          "id": 702,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(cnpg_pgbouncer_pools_cl_active{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (database, user)",
+              "legendFormat": "{{database}} ({{user}}) active",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(cnpg_pgbouncer_pools_cl_waiting{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (database, user)",
+              "legendFormat": "{{database}} ({{user}}) waiting",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "PgBouncer Client Pool (Active/Waiting)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "PgBouncer server-side pool (PgBouncer → Postgres), by database/user — the real number of backend connections the pool is holding open. sv_used connections were used but are not yet reset/returned to the pool.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 41
+          },
+          "id": 703,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(cnpg_pgbouncer_pools_sv_active{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (database, user)",
+              "legendFormat": "{{database}} ({{user}}) active",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(cnpg_pgbouncer_pools_sv_idle{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (database, user)",
+              "legendFormat": "{{database}} ({{user}}) idle",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(cnpg_pgbouncer_pools_sv_used{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (database, user)",
+              "legendFormat": "{{database}} ({{user}}) used",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "PgBouncer Server Pool (Active/Idle/Used)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Real PostgreSQL backend connections, by state, from the CNPG Cluster's own metrics — the authoritative count regardless of whether PgBouncer is in front of it.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 49
+          },
+          "id": 704,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(cnpg_backends_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (state)",
+              "legendFormat": "{{state}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Postgres Backend Connections (by state)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Total Postgres backend connections ÷ max_connections. Useful whether or not PgBouncer is in front of the cluster.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.8
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 49
+          },
+          "id": 705,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(cnpg_backends_total{cluster=~\"$cluster\", namespace=~\"$namespace\"})\n/\nsum(cnpg_pg_settings_setting{cluster=~\"$cluster\", namespace=~\"$namespace\", name=\"max_connections\"})",
+              "legendFormat": "utilization",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Postgres Connections Utilization",
+          "type": "timeseries"
         }
       ],
       "title": "RDBMS Exporter",


### PR DESCRIPTION
## Summary

Adds Grafana panels and PodMonitor scrape configs for Postgres/PgBouncer connection pool health in the load-test benchmark dashboard, building on PgBouncer support added in #61460.

- Two `PodMonitor`s (gated on `postgresql.enabled` / `postgresql.pooler.enabled`) scrape the CNPG Cluster's own connection metrics and the PgBouncer Pooler's pool metrics — no new workloads, just scrape config.
- Six new panels in the "RDBMS Exporter" row of `monitor/grafana/dashboards/data_layer.json`: HikariCP active/idle + utilization (per Camunda node/physical tenant), PgBouncer client-side and server-side pool stats, and real Postgres backend connection count + utilization.

Per-node attribution is only possible on the HikariCP side — PgBouncer transaction pooling severs the 1:1 client-to-server connection mapping.

Verified live against a real load test (postgresql + `--use-pgbouncer`) on the benchmark cluster.

<img width="1325" height="802" alt="image" src="https://github.com/user-attachments/assets/b6d84006-f427-43c1-93b6-a92045dd636a" />


## Related issues

closes #62515
