### PR TITLE
fix: restore timer icon on the draining tag

### DIFF
--- a/operate/client/src/modules/components/DrainingTag/index.tsx
+++ b/operate/client/src/modules/components/DrainingTag/index.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 const DrainingTag: React.FC<Props> = ({description, align = 'top'}) => (
   <Tooltip label={description} align={align} autoAlign>
-    <Tag size="sm" type="red" renderIcon={Timer} data-testid="draining-tag">
+    <Tag size="md" type="red" renderIcon={Timer} data-testid="draining-tag">
       Draining
     </Tag>
   </Tooltip>


### PR DESCRIPTION
## Description

Carbon's Tag component silently drops renderIcon whenever size is "sm" - the icon only renders at "md" or "lg". The 8.8 backport of the draining-UI feature (#62270) reimplemented DrainingTag from an early main commit (4710f4c2eda) that predates the later "improve UI for draining tags" commit (636851e5222, part of the original PR #59645 and already present on stable/8.9), which bumped the tag to size "md" specifically so the timer icon would show.

Bump size back to "md" to match main/8.9 and make the icon visible again.

## Related issues

related to https://github.com/camunda/camunda/issues/61504

