### PR TITLE
ci: skip SaaS E2E dispatch cleanly when the downstream workflow is disabled

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -808,9 +808,27 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
-          STATE="$(gh api repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_saas_pr_trigger_monorepo.yml --jq .state)"
-          echo "Downstream workflow state: $STATE"
-          if [[ "$STATE" != "active" ]]; then
+          # Fail CLOSED on the gate (see the two dispatch/wait steps below,
+          # which require enabled == 'true' explicitly) but fail OPEN on
+          # inability to determine state: a transient API blip here must not
+          # silently skip real SaaS coverage on an otherwise-normal PR, so a
+          # retry-exhausted check falls back to the pre-this-PR behavior
+          # (dispatch as usual) rather than skipping.
+          STATE=""
+          for attempt in 1 2 3; do
+            if STATE="$(gh api repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_saas_pr_trigger_monorepo.yml --jq .state 2>&1)"; then
+              break
+            fi
+            echo "::warning::Attempt ${attempt}/3 to read downstream workflow state failed: $STATE" >&2
+            STATE=""
+            [[ $attempt -lt 3 ]] && sleep $((attempt * 5))
+          done
+
+          if [[ -z "$STATE" ]]; then
+            echo "::warning::Could not determine downstream workflow state after 3 attempts -- defaulting to enabled so a transient API issue doesn't silently skip real SaaS coverage."
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$STATE" != "active" ]]; then
+            echo "Downstream workflow state: $STATE"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             {
               echo "### SaaS E2E tests skipped"
@@ -818,11 +836,12 @@ jobs:
               echo "The downstream workflow (\`playwright_saas_pr_trigger_monorepo.yml\` in camunda/c8-cross-component-e2e-tests) is currently **${STATE}**, not active -- skipping dispatch instead of waiting up to 35 minutes for a run that will never start."
             } >> "$GITHUB_STEP_SUMMARY"
           else
+            echo "Downstream workflow state: $STATE"
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Trigger repository_dispatch for SaaS Monorepo
-        if: steps.check-downstream.outputs.enabled != 'false'
+        if: steps.check-downstream.outputs.enabled == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
@@ -854,7 +873,7 @@ jobs:
 
       - name: Wait for downstream workflow to finish
         id: wait-downstream
-        if: steps.check-downstream.outputs.enabled != 'false'
+        if: steps.check-downstream.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -803,7 +803,26 @@ jobs:
           owner: camunda
           repositories: camunda,c8-cross-component-e2e-tests
 
+      - name: Check downstream SaaS workflow is enabled
+        id: check-downstream
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          STATE="$(gh api repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_saas_pr_trigger_monorepo.yml --jq .state)"
+          echo "Downstream workflow state: $STATE"
+          if [[ "$STATE" != "active" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### SaaS E2E tests skipped"
+              echo ""
+              echo "The downstream workflow (\`playwright_saas_pr_trigger_monorepo.yml\` in camunda/c8-cross-component-e2e-tests) is currently **${STATE}**, not active -- skipping dispatch instead of waiting up to 35 minutes for a run that will never start."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Trigger repository_dispatch for SaaS Monorepo
+        if: steps.check-downstream.outputs.enabled != 'false'
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
@@ -835,6 +854,7 @@ jobs:
 
       - name: Wait for downstream workflow to finish
         id: wait-downstream
+        if: steps.check-downstream.outputs.enabled != 'false'
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}


### PR DESCRIPTION
## Summary
- The downstream workflow (`camunda/c8-cross-component-e2e-tests`'s `playwright_saas_pr_trigger_monorepo.yml`) is being temporarily disabled while an org-creation reliability issue is worked out there.
- Without this change, disabling it there causes `Trigger SaaS E2E tests` to dispatch into a void: `repository_dispatch` never creates a run for a disabled workflow, so the `wait-downstream` step's poll never finds one and burns its full 35-minute timeout before exiting 1 -- on every single PR/push/merge-queue run.
- This job isn't a required check (only `check-results` is), so it never blocked merges -- but it would still show a guaranteed red mark and waste a runner for 35 minutes on every run for as long as the downstream stays disabled.

## Fix
Add a cheap state check (`GET .../actions/workflows/{file}` -> `.state`) right after the dispatch token is minted, and gate both the dispatch step and the `wait-downstream` step on it.

All later steps in the job already guard themselves on `wait-downstream`'s outputs/outcome (`downstream_run_url != ''`, `outcome == 'failure'`), so skipping those two steps propagates cleanly through the rest of the job with no further changes needed -- confirmed by reading each downstream step's own condition.

Re-enabling the downstream workflow requires no follow-up here: the next run just sees `state=active` and proceeds exactly as before.

## Test plan
- [x] YAML parses cleanly.
- [ ] Confirm on a real PR run once the downstream workflow is actually disabled: job should complete quickly with a "SaaS E2E tests skipped" step summary instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)