### PR TITLE
test: update locator due to changed placeholder

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -144,12 +144,8 @@ export class IdentityGroupsPage {
     this.emptyStateLocator = page.getByText('No groups created yet');
     this.assignUserButton = page.getByRole('button', {name: 'Assign user'});
     this.assignUserModal = page.getByRole('dialog', {name: 'Assign user'});
-    // On the new design system the assign-user field is a cmdk combobox. The
-    // groups modal uses `UserMultiSelect`'s default placeholder, so the
-    // accessible name is "Search by username" -- not the "Search by Username
-    // or Name" the roles modal overrides it to.
     this.searchBox = this.assignUserModal.getByRole('combobox', {
-      name: 'Search by username',
+      name: 'Search by name, email, or username',
     });
     // The results render in a Radix popover that portals as a *sibling* of the
     // dialog (DS #496), so the listbox is not a descendant of the modal --

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
@@ -45,11 +45,9 @@ export class IdentityRolesDetailsPage {
     this.closeAssignUserModal = this.assignUserModal.getByRole('button', {
       name: 'Close',
     });
-    // On the new design system the assign-user modal's search field is a cmdk
-    // combobox ("Search by Username or Name") rather than Carbon's searchbox.
     this.assignUserModalSearchField = this.assignUserModal.getByRole(
       'combobox',
-      {name: 'Search by Username or Name'},
+      {name: 'Search by name, email, or username'},
     );
     // The results render in a Radix popover that portals as a *sibling* of the
     // dialog (DS #496), so the listbox is not a descendant of the modal —

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
@@ -124,7 +124,7 @@ export class IdentityTenantsPage {
       name: 'Assign user',
     });
     this.assignUserSearchbox = this.assignUserModal.getByRole('combobox', {
-      name: 'Search by username',
+      name: 'Search by name, email, or username',
     });
     this.assignUserSearchboxResult = page.getByRole('listbox');
     this.assignUserOption = (username) =>


### PR DESCRIPTION
## Description

Found in on demand [run](https://github.com/camunda/camunda/actions/runs/34347431238/job/102452711965). Updated locators, tests are passing.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. All green [here](https://github.com/camunda/camunda/actions/runs/34350126295) 🎉 

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

