### PR TITLE
fix: stop template issue examples leaking into backports

### DIFF
--- a/.github/actions/release-notes/test/backport-template.test.ts
+++ b/.github/actions/release-notes/test/backport-template.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { test } from 'node:test';
+import { extractSection, isOptOutTicked, parseRefs } from '../src/parser';
+
+const pullRequestTemplate = readFileSync(
+  resolve(process.cwd(), '../../pull_request_template.md'),
+  'utf8',
+);
+
+// Keep this parser aligned with korthout/backport-action v4.6.0. The action
+// scans the raw source PR body, including HTML comments, before replacing
+// ${issue_refs} in the generated backport description.
+const issueRefPattern = /(?:^| )((?:[^\n #/]+\/[^\n #/]+))?#([1-9][0-9]*)(?: |$)/gm;
+
+function getMentionedIssueRefs(body: string): string[] {
+  return body.match(issueRefPattern)?.map((reference) => reference.trim()) ?? [];
+}
+
+function renderBackportDescription(
+  sourceBody: string,
+  sourcePullRequest: number,
+  targetBranch: string,
+): string {
+  const issueRefs = getMentionedIssueRefs(sourceBody).join(' ');
+  return [
+    `⤵️ Backport of #${sourcePullRequest} → \`${targetBranch}\``,
+    '',
+    `relates to ${issueRefs}`,
+  ].join('\n');
+}
+
+test('the PR template contains no issue-like placeholders for backport-action', () => {
+  // given
+  const generated = renderBackportDescription(pullRequestTemplate, 62512, 'stable/8.9');
+
+  // then
+  assert.match(generated, /Backport of #62512 → `stable\/8\.9`/);
+  assert.deepEqual(getMentionedIssueRefs(pullRequestTemplate), []);
+  assert.doesNotMatch(generated, /#1234/);
+});
+
+test('a source PR with one real issue keeps that issue once', () => {
+  // given
+  const sourceBody = `${pullRequestTemplate}\ncloses #28374`;
+
+  // when
+  const generated = renderBackportDescription(sourceBody, 62512, 'stable/8.9');
+
+  // then
+  assert.match(generated, /Backport of #62512 → `stable\/8\.9`/);
+  assert.equal(generated.match(/#28374/g)?.length, 1);
+  assert.match(generated, /relates to #28374/);
+});
+
+test('multiple real issues keep their source order and occur once each', () => {
+  // given
+  const sourceBody = `${pullRequestTemplate}\nrelates to #28374\nfixes #54840`;
+
+  // when
+  const generated = renderBackportDescription(sourceBody, 62512, 'stable/8.9');
+
+  // then
+  assert.match(generated, /relates to #28374 #54840/);
+  assert.equal(generated.match(/#28374/g)?.length, 1);
+  assert.equal(generated.match(/#54840/g)?.length, 1);
+});
+
+test('the release-notes parser still ignores template boilerplate', () => {
+  // given
+  const section = extractSection(pullRequestTemplate);
+
+  // then
+  assert.ok(section);
+  assert.deepEqual(parseRefs(section), []);
+  assert.equal(isOptOutTicked(pullRequestTemplate), false);
+});

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,13 +12,13 @@
 
 <!--
 Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
-- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
-- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
+- This PR fully resolves the issue:  closes <issue-number>  (also: fixes <issue-number>, resolves <issue-number> — auto-closes it on merge)
+- One of several PRs for the issue (an epic, or work split across releases):  relates to <issue-number>  or a bare  <issue-number>
 This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
 No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
 -->
 
-closes #
+closes <issue-number>
 
 - [ ] This PR does not need a linked issue
 


### PR DESCRIPTION
## Summary

The backport workflow uses `korthout/backport-action@v4.6.0` with `${issue_refs}`. That action scans the raw source PR body, including HTML comments, so the PR template's instructional `#1234` examples were copied as repeated unrelated issue references.

The template now uses non-parseable `<issue-number>` placeholders instead. The `Backport of #<source-PR>` marker and target branch format remain unchanged for stale-backport tracking.

## Before / after

Source PR #62512 left the old template boilerplate in its body. The generated backport #62528 contained:

```text
relates to #1234 #1234 #1234 #1234
```

With the updated template, an issue-free source PR produces no `#1234` placeholder. Real references are preserved once each, for example:

```text
⤵️ Backport of #62512 → `stable/8.9`

relates to #28374 #54840
```

Issue #1234 is an old unrelated issue and was picked up from template boilerplate, not intentionally linked.

## Validation

- Added regression coverage for no-issue, single-issue, and multiple-issue source descriptions.
- Verified source order and exactly-once rendering for real references.
- Verified the backport marker and target branch remain present.
- Verified release-notes parser behavior remains unchanged.
- Release-notes tests, typecheck, bundle drift check, full `just install`, and relevant workflow `actionlint` passed.

## Related issues

- [x] This PR does not need a linked issue
