### PR TITLE
ci: skip SaaS E2E dispatch cleanly when the downstream workflow is disabled (stable/8.9)

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -816,7 +816,45 @@ jobs:
           owner: camunda
           repositories: camunda,c8-cross-component-e2e-tests
 
+      - name: Check downstream SaaS workflow is enabled
+        id: check-downstream
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          # Fail CLOSED on the gate (see the two dispatch/wait steps below,
+          # which require enabled == 'true' explicitly) but fail OPEN on
+          # inability to determine state: a transient API blip here must not
+          # silently skip real SaaS coverage on an otherwise-normal PR, so a
+          # retry-exhausted check falls back to the pre-this-PR behavior
+          # (dispatch as usual) rather than skipping.
+          STATE=""
+          for attempt in 1 2 3; do
+            if STATE="$(gh api repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_saas_pr_trigger_monorepo.yml --jq .state 2>&1)"; then
+              break
+            fi
+            echo "::warning::Attempt ${attempt}/3 to read downstream workflow state failed: $STATE" >&2
+            STATE=""
+            [[ $attempt -lt 3 ]] && sleep $((attempt * 5))
+          done
+
+          if [[ -z "$STATE" ]]; then
+            echo "::warning::Could not determine downstream workflow state after 3 attempts -- defaulting to enabled so a transient API issue doesn't silently skip real SaaS coverage."
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$STATE" != "active" ]]; then
+            echo "Downstream workflow state: $STATE"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### SaaS E2E tests skipped"
+              echo ""
+              echo "The downstream workflow (\`playwright_saas_pr_trigger_monorepo.yml\` in camunda/c8-cross-component-e2e-tests) is currently **${STATE}**, not active -- skipping dispatch instead of waiting for a run that will never start."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Downstream workflow state: $STATE"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Trigger repository_dispatch for SaaS Monorepo
+        if: steps.check-downstream.outputs.enabled == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
@@ -848,6 +886,7 @@ jobs:
 
       - name: Wait for downstream workflow to finish
         id: wait-downstream
+        if: steps.check-downstream.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}


### PR DESCRIPTION
Backport of camunda/camunda#62546 to `stable/8.9`.

The downstream workflow (camunda/c8-cross-component-e2e-tests's `playwright_saas_pr_trigger_monorepo.yml`) is being temporarily disabled while an org-creation reliability issue is worked out there. Without this, disabling it there makes `Trigger SaaS E2E tests` dispatch into a void and burn its full timeout before failing, on every PR/push against this branch.

Adds a state check gating the dispatch/wait steps, fail-closed on the gate (`enabled == 'true'` required) but fail-open on an unreadable state after 3 retries (defaults to `enabled=true`, matching #62546 post-Copilot-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)