### PR TITLE
ci: retry Optimize IT git fetch of main after HTTP/2 cancel

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -126,8 +126,16 @@ jobs:
         # zizmor: ignore[artipacked]
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Transient GitHub HTTP/2 cancels fail this fetch with exit 128; retry
+      # in-step so the 30m job is not spent on a one-shot RPC flake.
       - name: Fetch main branch
-        run: git fetch origin main:refs/remote/origin/main
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 15
+          timeout_minutes: 5
+          shell: bash
+          command: git fetch origin main:refs/remote/origin/main
 
       - name: Setup Maven
         uses: ./.github/actions/setup-build
@@ -225,8 +233,16 @@ jobs:
         # zizmor: ignore[artipacked]
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Transient GitHub HTTP/2 cancels fail this fetch with exit 128; retry
+      # in-step so the 30m job is not spent on a one-shot RPC flake.
       - name: Fetch main branch
-        run: git fetch origin main:refs/remote/origin/main
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 15
+          timeout_minutes: 5
+          shell: bash
+          command: git fetch origin main:refs/remote/origin/main
 
       - name: Setup Maven
         uses: ./.github/actions/setup-build


### PR DESCRIPTION
## Description

Optimize Elasticsearch and OpenSearch ITs fetch `main` with a single unretried `git fetch`. A transient GitHub HTTP/2 cancel fails the whole job (exit 128) before Maven or the ITs run.

Wrap both `Fetch main branch` steps with `nick-fields/retry` (already pinned in this workflow): 3 attempts, 15s wait, 5-minute per-attempt timeout.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #62532