### PR TITLE
refactor: reimplement license tags with design-system badges

### DIFF
--- a/identity/client/src/components/layout/AppHeaderV2/LicenseBadges.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/LicenseBadges.tsx
@@ -61,10 +61,10 @@ function getVariants(
   }
 
   const expiresAt =
-    license.expiresAt === null ? undefined : Date.parse(license.expiresAt);
+    license.expiresAt === null ? NaN : Date.parse(license.expiresAt);
   const now = Date.now();
 
-  if (expiresAt !== undefined && expiresAt < now) {
+  if (!Number.isNaN(expiresAt) && expiresAt < now) {
     variants.push({
       key: "non-commercial-expired",
       label: t("licenseNonCommercialExpiredLabel"),
@@ -72,7 +72,7 @@ function getVariants(
       description: t("licenseNonCommercialExpiredDescription"),
     });
   } else if (
-    expiresAt !== undefined &&
+    !Number.isNaN(expiresAt) &&
     expiresAt - EXPIRY_WARNING_THRESHOLD_MS < now
   ) {
     const daysLeft = Math.max(0, Math.floor((expiresAt - now) / DAY_MS));

--- a/identity/client/src/components/layout/AppHeaderV2/LicenseBadges.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/LicenseBadges.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  Badge,
+  Link,
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverTrigger,
+} from "@camunda/design-system";
+import type { License } from "@camunda/camunda-api-zod-schemas/8.10";
+import type { TFunction } from "i18next";
+import type { ReactNode } from "react";
+
+import useTranslate from "src/utility/localization";
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+const EXPIRY_WARNING_THRESHOLD_MS = DAY_MS * 30;
+
+const NON_PRODUCTION_TERMS_LINK =
+  "https://legal.camunda.com/#self-managed-non-production-terms";
+const SALES_CONTACT_LINK = "https://camunda.com/contact/";
+
+const UNKNOWN_LICENSE: License = {
+  validLicense: false,
+  licenseType: "unknown",
+  isCommercial: false,
+  expiresAt: null,
+};
+
+type Variant = {
+  key: string;
+  label: string;
+  tone: "neutral" | "warning" | "danger";
+  description?: ReactNode;
+};
+
+function getVariants(
+  license: License,
+  t: TFunction,
+  nonProductionDescription: ReactNode,
+): Variant[] {
+  const variants: Variant[] = [
+    {
+      key: "license-status",
+      label: license.validLicense
+        ? t("licenseProductionLabel")
+        : t("licenseNonProductionLabel"),
+      tone: "neutral",
+      description: license.validLicense ? undefined : nonProductionDescription,
+    },
+  ];
+
+  if (!license.isCommercial) {
+    const expiresAt =
+      license.expiresAt === null ? undefined : Date.parse(license.expiresAt);
+    const now = Date.now();
+
+    if (expiresAt !== undefined && expiresAt < now) {
+      variants.push({
+        key: "non-commercial-expired",
+        label: t("licenseNonCommercialExpiredLabel"),
+        tone: "danger",
+        description: t("licenseNonCommercialExpiredDescription"),
+      });
+    } else if (
+      expiresAt !== undefined &&
+      expiresAt - EXPIRY_WARNING_THRESHOLD_MS < now
+    ) {
+      const daysLeft = Math.max(0, Math.floor((expiresAt - now) / DAY_MS));
+      variants.push({
+        key: "non-commercial-expiring",
+        label: t("licenseNonCommercialExpiringLabel", { count: daysLeft }),
+        tone: "warning",
+        description: t("licenseNonCommercialExpiringDescription"),
+      });
+    } else {
+      variants.push({
+        key: "non-commercial",
+        label: t("licenseNonCommercialLabel"),
+        tone: "neutral",
+      });
+    }
+  }
+
+  return variants;
+}
+
+type Props = {
+  license: License | null | undefined;
+};
+
+export const LicenseBadges = ({ license }: Props) => {
+  const { t, Translate } = useTranslate("navigation");
+  const resolvedLicense = license ?? UNKNOWN_LICENSE;
+  const nonProductionDescription = (
+    <Translate
+      i18nKey="licenseNonProductionDescription"
+      components={{
+        termsLink: (
+          <Link
+            href={NON_PRODUCTION_TERMS_LINK}
+            target="_blank"
+            rel="noreferrer noopener"
+            inline
+          />
+        ),
+        salesLink: (
+          <Link
+            href={SALES_CONTACT_LINK}
+            target="_blank"
+            rel="noreferrer noopener"
+            inline
+          />
+        ),
+      }}
+    />
+  );
+  const variants = getVariants(resolvedLicense, t, nonProductionDescription);
+
+  if (resolvedLicense.licenseType === "saas") {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {variants.map(({ key, label, tone, description }) =>
+        description === undefined ? (
+          <Badge key={key} variant={tone}>
+            {label}
+          </Badge>
+        ) : (
+          <Popover key={key}>
+            <PopoverTrigger asChild>
+              <Badge asChild variant={tone}>
+                <button type="button">{label}</button>
+              </Badge>
+            </PopoverTrigger>
+            <PopoverContent align="center">
+              <PopoverDescription>{description}</PopoverDescription>
+            </PopoverContent>
+          </Popover>
+        ),
+      )}
+    </div>
+  );
+};

--- a/identity/client/src/components/layout/AppHeaderV2/LicenseBadges.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/LicenseBadges.tsx
@@ -56,37 +56,38 @@ function getVariants(
       description: license.validLicense ? undefined : nonProductionDescription,
     },
   ];
+  if (license.isCommercial) {
+    return variants;
+  }
 
-  if (!license.isCommercial) {
-    const expiresAt =
-      license.expiresAt === null ? undefined : Date.parse(license.expiresAt);
-    const now = Date.now();
+  const expiresAt =
+    license.expiresAt === null ? undefined : Date.parse(license.expiresAt);
+  const now = Date.now();
 
-    if (expiresAt !== undefined && expiresAt < now) {
-      variants.push({
-        key: "non-commercial-expired",
-        label: t("licenseNonCommercialExpiredLabel"),
-        tone: "danger",
-        description: t("licenseNonCommercialExpiredDescription"),
-      });
-    } else if (
-      expiresAt !== undefined &&
-      expiresAt - EXPIRY_WARNING_THRESHOLD_MS < now
-    ) {
-      const daysLeft = Math.max(0, Math.floor((expiresAt - now) / DAY_MS));
-      variants.push({
-        key: "non-commercial-expiring",
-        label: t("licenseNonCommercialExpiringLabel", { count: daysLeft }),
-        tone: "warning",
-        description: t("licenseNonCommercialExpiringDescription"),
-      });
-    } else {
-      variants.push({
-        key: "non-commercial",
-        label: t("licenseNonCommercialLabel"),
-        tone: "neutral",
-      });
-    }
+  if (expiresAt !== undefined && expiresAt < now) {
+    variants.push({
+      key: "non-commercial-expired",
+      label: t("licenseNonCommercialExpiredLabel"),
+      tone: "danger",
+      description: t("licenseNonCommercialExpiredDescription"),
+    });
+  } else if (
+    expiresAt !== undefined &&
+    expiresAt - EXPIRY_WARNING_THRESHOLD_MS < now
+  ) {
+    const daysLeft = Math.max(0, Math.floor((expiresAt - now) / DAY_MS));
+    variants.push({
+      key: "non-commercial-expiring",
+      label: t("licenseNonCommercialExpiringLabel", { count: daysLeft }),
+      tone: "warning",
+      description: t("licenseNonCommercialExpiringDescription"),
+    });
+  } else {
+    variants.push({
+      key: "non-commercial",
+      label: t("licenseNonCommercialLabel"),
+      tone: "neutral",
+    });
   }
 
   return variants;

--- a/identity/client/src/components/layout/AppHeaderV2/index.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {
-  C3LicenseTag,
   preview_C3ToolsArea as C3ToolsArea,
   preview_useCamundaTools as useCamundaTools,
   type UseCamundaToolsOptions,
@@ -20,7 +19,6 @@ import {
   type GlobalActionButton,
   type UserMenuItem,
 } from "@camunda/design-system";
-import type { License as LicenseDto } from "@camunda/camunda-api-zod-schemas/8.10";
 import { useCallback, useMemo, type MouseEvent } from "react";
 import { useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
@@ -34,6 +32,7 @@ import { authenticationQueries } from "src/utility/api/authentication/queries.ts
 
 import { ForwardRefLink } from "./ForwardRefLink";
 import { InfoMenu } from "./InfoMenu";
+import { LicenseBadges } from "./LicenseBadges";
 import { LogoutAwareUserMenu } from "./LogoutAwareUserMenu";
 import { ThemeSelector } from "./ThemeSelector";
 import { useBreadcrumbs } from "./useBreadcrumbs";
@@ -172,8 +171,6 @@ const AppHeaderV2 = ({ hideNavLinks = false }: { hideNavLinks?: boolean }) => {
     [tNav],
   );
 
-  const licenseTag = getLicenseTag(license);
-
   return (
     <ToolsProvider>
       <AppHeader
@@ -190,17 +187,7 @@ const AppHeaderV2 = ({ hideNavLinks = false }: { hideNavLinks?: boolean }) => {
           </ForwardRefLink>
         }
         breadcrumb={breadcrumb}
-        trailing={
-          licenseTag.show ? (
-            <div className="flex items-center">
-              <C3LicenseTag
-                isProductionLicense={licenseTag.isProductionLicense}
-                isCommercial={licenseTag.isCommercial}
-                expiresAt={licenseTag.expiresAt}
-              />
-            </div>
-          ) : undefined
-        }
+        trailing={<LicenseBadges license={license} />}
         globalActions={globalActions}
         actions={
           camundaUser === undefined ? undefined : (
@@ -231,23 +218,5 @@ const AppHeaderV2 = ({ hideNavLinks = false }: { hideNavLinks?: boolean }) => {
     </ToolsProvider>
   );
 };
-
-function getLicenseTag(license: LicenseDto | null | undefined) {
-  if (license === undefined || license === null) {
-    return {
-      show: true,
-      isProductionLicense: false,
-      isCommercial: false,
-      expiresAt: undefined,
-    };
-  }
-
-  return {
-    show: license.licenseType === undefined || license.licenseType != "saas",
-    isProductionLicense: license.validLicense,
-    isCommercial: license.isCommercial,
-    expiresAt: license.expiresAt ?? undefined,
-  };
-}
 
 export default AppHeaderV2;

--- a/identity/client/src/components/layout/AppHeaderV2/index.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/index.tsx
@@ -16,6 +16,7 @@ import {
   AppSidebar,
   CamundaLogo,
   Text,
+  useIsMobile,
   type GlobalActionButton,
   type UserMenuItem,
 } from "@camunda/design-system";
@@ -85,6 +86,7 @@ const AppHeaderV2 = ({ hideNavLinks = false }: { hideNavLinks?: boolean }) => {
   const { t } = useTranslate("authentication");
   const { t: tNav } = useTranslate("navigation");
   const { pathname, search } = useLocation();
+  const isMobile = useIsMobile();
 
   const logoutWithNotification = useCallback(() => {
     enqueueNotification({
@@ -187,7 +189,7 @@ const AppHeaderV2 = ({ hideNavLinks = false }: { hideNavLinks?: boolean }) => {
           </ForwardRefLink>
         }
         breadcrumb={breadcrumb}
-        trailing={<LicenseBadges license={license} />}
+        trailing={isMobile ? undefined : <LicenseBadges license={license} />}
         globalActions={globalActions}
         actions={
           camundaUser === undefined ? undefined : (

--- a/identity/client/src/utility/localization/en/navigation.json
+++ b/identity/client/src/utility/localization/en/navigation.json
@@ -24,5 +24,14 @@
   "sidebarCollapseAria": "Collapse sidebar",
   "sidebarExpandAria": "Expand sidebar",
   "sidebarGroupCollapseAria": "Collapse {{label}}",
-  "sidebarGroupExpandAria": "Expand {{label}}"
+  "sidebarGroupExpandAria": "Expand {{label}}",
+  "licenseProductionLabel": "Production license",
+  "licenseNonProductionLabel": "Non-production license",
+  "licenseNonProductionDescription": "Non-production license. For production usage details, visit our <termsLink>terms & conditions page</termsLink> or <salesLink>contact our sales team</salesLink>.",
+  "licenseNonCommercialLabel": "Non-commercial license",
+  "licenseNonCommercialExpiredLabel": "Non-commercial license - expired",
+  "licenseNonCommercialExpiredDescription": "To continue using all features, please renew your license.",
+  "licenseNonCommercialExpiringLabel_one": "Non-commercial license - {{count}} day left",
+  "licenseNonCommercialExpiringLabel_other": "Non-commercial license - {{count}} days left",
+  "licenseNonCommercialExpiringDescription": "Please renew and provide new license keys to continue production use of Camunda."
 }


### PR DESCRIPTION
## Description

This PR ports the design-system based [license component from the OC webapp](https://github.com/camunda/camunda/blob/main/webapp/client/apps/orchestration-cluster-webapp/src/shared/header/shadcn.components/LicenseBadges.tsx) to legacy Admin.
Once change I made: `title` has been changed to `description` that is rendered in a `<Popover>` component. This aligns it closer the the `C3LicenseTag` component.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60654

