### PR TITLE
test: replace jqwik with Hegel for property-based tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ faces-config.NavData
 *.lock.db
 .cache-main
 .cache-tests
-.jqwik-database
+.hegel/
 .run
 
 *.DS_Store

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -129,7 +129,7 @@
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>
     <version.jetbrains-annotations>26.1.0</version.jetbrains-annotations>
-    <version.jqwik>1.10.1</version.jqwik>
+    <version.hegel>0.5.1</version.hegel>
     <version.jmock>2.13.1</version.jmock>
     <version.jmh>1.37</version.jmh>
     <version.json-smart>2.6.0</version.json-smart>
@@ -1698,21 +1698,9 @@
       </dependency>
 
       <dependency>
-        <groupId>net.jqwik</groupId>
-        <artifactId>jqwik</artifactId>
-        <version>${version.jqwik}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>net.jqwik</groupId>
-        <artifactId>jqwik-api</artifactId>
-        <version>${version.jqwik}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>net.jqwik</groupId>
-        <artifactId>jqwik-time</artifactId>
-        <version>${version.jqwik}</version>
+        <groupId>dev.hegel</groupId>
+        <artifactId>hegel-jna</artifactId>
+        <version>${version.hegel}</version>
       </dependency>
 
       <dependency>

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -236,14 +236,8 @@
     </dependency>
 
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik-api</artifactId>
+      <groupId>dev.hegel</groupId>
+      <artifactId>hegel-jna</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -357,7 +351,6 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
-            <dependency>net.jqwik:jqwik</dependency>
             <dependency>io.netty:netty-tcnative-boringssl-static</dependency>
             <dependency>io.netty:netty-transport-native-epoll</dependency>
           </usedDependencies>

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomSequence.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomSequence.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Builds the long operation sequences of the randomized raft tests from a seeded {@link Random}.
+ *
+ * <p>The sequences are derived from a single seed drawn from Hegel instead of being drawn element
+ * by element: at ten thousand steps per sequence they overrun the engine's per-test-case data
+ * budget, and these tests run with shrinking disabled anyway, so a shrinkable sequence would buy
+ * nothing.
+ */
+final class RandomSequence {
+
+  private RandomSequence() {}
+
+  static <T> List<T> of(final Random random, final List<T> choices, final int size) {
+    final var sequence = new ArrayList<T>(size);
+    for (int i = 0; i < size; i++) {
+      sequence.add(choices.get(random.nextInt(choices.size())));
+    }
+    return sequence;
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedForceConfigureTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedForceConfigureTest.java
@@ -15,9 +15,15 @@
  */
 package io.atomix.raft;
 
+import static dev.hegel.Generators.longs;
 import static io.atomix.raft.cluster.RaftMember.Type.ACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HealthCheck;
+import dev.hegel.HegelTest;
+import dev.hegel.OptBoolean;
+import dev.hegel.Phase;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.impl.ReconfigurationHelper;
@@ -31,15 +37,7 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.EdgeCasesMode;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
-import net.jqwik.api.ShrinkingMode;
-import net.jqwik.api.lifecycle.AfterTry;
-import net.jqwik.api.lifecycle.BeforeProperty;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +54,7 @@ public final class RandomizedForceConfigureTest {
   private List<MemberId> raftMembers;
   private Path raftDataDirectory;
 
-  @BeforeProperty
+  @BeforeEach
   public void initOperations() {
     // Need members ids to generate pair operations
     final var servers =
@@ -69,73 +67,83 @@ public final class RandomizedForceConfigureTest {
     raftMembers = servers;
   }
 
-  @AfterTry
-  public void shutDownRaftNodes() throws IOException {
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  public void correctnessTest(final TestCase tc) throws Exception {
+    // given - the seed drawn from Hegel determines the operation sequence, the members each
+    // operation is applied to, and the raft nodes' own randomness, so a reported seed replays the
+    // whole case.
+    final long seed = tc.draw(longs(), "seed");
+    LOG.info("Running test case with seed {}", seed);
+    final var random = new Random(seed);
+    final var raftOperations = RandomSequence.of(random, defaultOperations, OPERATION_SIZE);
+    final var raftMembers = RandomSequence.of(random, this.raftMembers, OPERATION_SIZE);
+    setUpRaftNodes(random);
+    try {
+      // Wait until all members are ready. It doesn't make sense to force configure before all
+      // members
+      // have bootstrapped.
+      while (!(raftContexts.allMembersAreReady())) {
+        raftContexts.runUntilDone();
+        raftContexts.processAllMessage();
+        raftContexts.tickHeartbeatTimeout();
+      }
+
+      // when - execute operations including force configure (0,2)
+      final var memberIter = raftMembers.iterator();
+      for (final RaftOperation operation : raftOperations) {
+        final MemberId member = memberIter.next();
+        LOG.info("{} on {}", operation, member);
+        operation.run(raftContexts, member);
+      }
+
+      // Run force configure once again in case the previous ones timed out
+      forceConfigureOperation.run(raftContexts, MemberId.from("0"));
+      // run until force configure is completed
+      for (int i = 0; i < 10; i++) {
+        raftContexts.runUntilDone();
+        raftContexts.processAllMessage();
+        raftContexts.tickHeartbeatTimeout();
+      }
+
+      final var newMembers =
+          Map.of(
+              MemberId.from("0"),
+              raftContexts.getRaftContext(0),
+              MemberId.from("2"),
+              raftContexts.getRaftContext(2));
+      runUntilMembersAreInSync(newMembers);
+
+      // then
+
+      assertThatConfigurationContainsOnly0and2(0);
+      assertThatConfigurationContainsOnly0and2(2);
+
+      // eventually a leader should be elected
+      assertThat(raftContexts.hasLeaderAtTheLatestTerm())
+          .describedAs("Leader election should be completed if there are no messages lost.")
+          .isTrue();
+
+      raftContexts.assertAllEntriesCommittedAndReplicatedToAll(newMembers);
+      raftContexts.assertAllLogsEqual();
+      raftContexts.assertNoGapsInLog();
+      raftContexts.assertNoJournalAppendErrors();
+      raftContexts.assertNoDataLoss();
+    } finally {
+      shutDownRaftNodes();
+    }
+  }
+
+  private void shutDownRaftNodes() throws IOException {
     raftContexts.shutdown();
     FileUtil.deleteFolder(raftDataDirectory);
     raftDataDirectory = null;
-    // reset the future, so it can be run again in the next try
+    // reset the future, so it can be run again in the next test case
     forceConfigureOperation.reset();
-    LOG.info("=== Try completed ===");
-  }
-
-  @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
-  public void correctnessTest(
-      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-    // given
-    setUpRaftNodes(new Random(seed));
-
-    // Wait until all members are ready. It doesn't make sense to force configure before all members
-    // have bootstrapped.
-    while (!(raftContexts.allMembersAreReady())) {
-      raftContexts.runUntilDone();
-      raftContexts.processAllMessage();
-      raftContexts.tickHeartbeatTimeout();
-    }
-
-    // when - execute operations including force configure (0,2)
-    final var memberIter = raftMembers.iterator();
-    for (final RaftOperation operation : raftOperations) {
-      final MemberId member = memberIter.next();
-      LOG.info("{} on {}", operation, member);
-      operation.run(raftContexts, member);
-    }
-
-    // Run force configure once again in case the previous ones timed out
-    forceConfigureOperation.run(raftContexts, MemberId.from("0"));
-    // run until force configure is completed
-    for (int i = 0; i < 10; i++) {
-      raftContexts.runUntilDone();
-      raftContexts.processAllMessage();
-      raftContexts.tickHeartbeatTimeout();
-    }
-
-    final var newMembers =
-        Map.of(
-            MemberId.from("0"),
-            raftContexts.getRaftContext(0),
-            MemberId.from("2"),
-            raftContexts.getRaftContext(2));
-    runUntilMembersAreInSync(newMembers);
-
-    // then
-
-    assertThatConfigurationContainsOnly0and2(0);
-    assertThatConfigurationContainsOnly0and2(2);
-
-    // eventually a leader should be elected
-    assertThat(raftContexts.hasLeaderAtTheLatestTerm())
-        .describedAs("Leader election should be completed if there are no messages lost.")
-        .isTrue();
-
-    raftContexts.assertAllEntriesCommittedAndReplicatedToAll(newMembers);
-    raftContexts.assertAllLogsEqual();
-    raftContexts.assertNoGapsInLog();
-    raftContexts.assertNoJournalAppendErrors();
-    raftContexts.assertNoDataLoss();
+    LOG.info("=== Test case completed ===");
   }
 
   private void runUntilMembersAreInSync(final Map<MemberId, RaftContext> newMembers) {
@@ -158,23 +166,6 @@ public final class RandomizedForceConfigureTest {
     assertThat(members)
         .describedAs("Configuration must have only members 0 and 2")
         .containsExactlyInAnyOrder("0", "2");
-  }
-
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperations() {
-    final var operation = Arbitraries.of(defaultOperations);
-    return operation.list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<List<MemberId>> raftMembers() {
-    final var members = Arbitraries.of(raftMembers);
-    return members.list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<Long> seeds() {
-    return Arbitraries.longs();
   }
 
   private void setUpRaftNodes(final Random random) throws Exception {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
@@ -7,8 +7,14 @@
  */
 package io.atomix.raft;
 
+import static dev.hegel.Generators.longs;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HealthCheck;
+import dev.hegel.HegelTest;
+import dev.hegel.OptBoolean;
+import dev.hegel.Phase;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.RaftContext;
@@ -21,20 +27,10 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.EdgeCasesMode;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.PropertyDefaults;
-import net.jqwik.api.Provide;
-import net.jqwik.api.ShrinkingMode;
-import net.jqwik.api.lifecycle.AfterTry;
-import net.jqwik.api.lifecycle.BeforeProperty;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
 public class RandomizedRaftJoinTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RandomizedRaftJoinTest.class);
@@ -46,7 +42,7 @@ public class RandomizedRaftJoinTest {
   private MemberId member1;
   private List<RaftOperation> operationsWithRestarts;
 
-  @BeforeProperty
+  @BeforeEach
   public void initMembers() {
     // Initialize the two member IDs for the 2-node cluster
     member0 = MemberId.from("0");
@@ -54,8 +50,170 @@ public class RandomizedRaftJoinTest {
     operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
   }
 
-  @AfterTry
-  public void shutDownRaftNodes() throws IOException {
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void joinCompletes(final TestCase tc) throws Exception {
+    // The seed drawn from Hegel determines the operation sequence, the members each operation is
+    // applied to, and the raft nodes' own randomness, so a reported seed replays the whole case.
+    final long seed = tc.draw(longs(), "seed");
+    LOG.info("Running test case with seed {}", seed);
+    final var random = new Random(seed);
+    final var raftOperations = RandomSequence.of(random, operationsWithRestarts, OPERATION_SIZE);
+    final var raftMembers = RandomSequence.of(random, List.of(member0, member1), OPERATION_SIZE);
+    setUpRaftNodes(random);
+    try {
+      var joinFuture = raftContexts.join(member1, Set.of(member0, member1));
+
+      // given - when there are failures such as message loss
+      final var memberIter = raftMembers.iterator();
+      for (final RaftOperation operation : raftOperations) {
+        final MemberId member = memberIter.next();
+        LOG.info("{} on {}", operation, member);
+        operation.run(raftContexts, member);
+        // sample the safety invariant on every step: it records the vote of each member at the term
+        // it is currently in, so a vote that is overwritten between two steps is only observable
+        // while it is still recorded
+        raftContexts.assertAtMostOneVotePerMemberAndTerm();
+        if (joinFuture.isCompletedExceptionally()) {
+          // retry join
+          LOG.info("Join failed. Retrying...");
+          joinFuture = raftContexts.join(member1, Set.of(member0, member1));
+        }
+      }
+
+      raftContexts.runUntilDone();
+      raftContexts.processAllMessage();
+      raftContexts.tickHeartbeatTimeout();
+
+      // when - no more message loss or restarts
+
+      LOG.info("Stopping failures, waiting for join to complete");
+
+      // hoping that 2000 iterations are enough to complete the join process
+      int maxStepsToReplicateEntries = 10100;
+      while (!((joinFuture.isDone() && !joinFuture.isCompletedExceptionally())
+              && raftContexts.allMembersAreReady()
+              && raftContexts.hasLeaderAtTheLatestTerm())
+          && maxStepsToReplicateEntries-- > 0) {
+
+        if (joinFuture.isCompletedExceptionally()) {
+          // retry join
+          LOG.info("Join failed. Retrying...");
+          joinFuture = raftContexts.join(member1, Set.of(member0, member1));
+        }
+
+        raftContexts.runUntilDone();
+        raftContexts.processAllMessage();
+        raftContexts.tickHeartbeatTimeout();
+      }
+
+      // then
+      assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
+      assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
+      raftContexts.assertAllMembersAreReady();
+      raftContexts.assertAtMostOneVotePerMemberAndTerm();
+    } finally {
+      shutDownRaftNodes();
+    }
+  }
+
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void joinThenPromoteCompletes(final TestCase tc) throws Exception {
+    // The seed drawn from Hegel determines the operation sequence, the members each operation is
+    // applied to, and the raft nodes' own randomness, so a reported seed replays the whole case.
+    final long seed = tc.draw(longs(), "seed");
+    LOG.info("Running test case with seed {}", seed);
+    final var random = new Random(seed);
+    final var raftOperations = RandomSequence.of(random, operationsWithRestarts, OPERATION_SIZE);
+    final var raftMembers = RandomSequence.of(random, List.of(member0, member1), OPERATION_SIZE);
+    setUpRaftNodes(random);
+    try {
+      var joinFuture =
+          raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+      CompletableFuture<Void> promoteFuture = null;
+
+      // given - when there are failures such as message loss, including restarts of the joined
+      // member: the join future only completes once the admitting configuration entry is durably
+      // in this node's own log (see ReconfigurationHelper#awaitLocalDurability), so a restart right
+      // after completion always finds that entry via reloadConfigurationFromLog and never falls
+      // back to treating this node as a fresh, unconfigured one.
+      final var memberIter = raftMembers.iterator();
+      for (final RaftOperation operation : raftOperations) {
+        final MemberId member = memberIter.next();
+        LOG.info("{} on {}", operation, member);
+        operation.run(raftContexts, member);
+        // sample the safety invariant on every step: it records the vote of each member at the
+        // term it is currently in, so a vote that is overwritten between two steps is only
+        // observable while it is still recorded
+        raftContexts.assertAtMostOneVotePerMemberAndTerm();
+        if (joinFuture.isCompletedExceptionally()) {
+          // retry join
+          LOG.info("Join failed. Retrying...");
+          joinFuture =
+              raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+        } else if (joinFuture.isDone() && shouldRetryPromote(promoteFuture)) {
+          LOG.info("Promoting member 1...");
+          promoteFuture = raftContexts.promote(member1);
+        }
+      }
+
+      raftContexts.runUntilDone();
+      raftContexts.processAllMessage();
+      raftContexts.tickHeartbeatTimeout();
+
+      // when - no more message loss or restarts
+
+      LOG.info("Stopping failures, waiting for join and promotion to complete");
+
+      int maxStepsToReplicateEntries = 10100;
+      while (!(joinFuture.isDone()
+              && !joinFuture.isCompletedExceptionally()
+              && promoteFuture != null
+              && promoteFuture.isDone()
+              && !promoteFuture.isCompletedExceptionally()
+              && member1IsActiveInLeadersConfiguration()
+              && raftContexts.allMembersAreReady()
+              && raftContexts.hasLeaderAtTheLatestTerm())
+          && maxStepsToReplicateEntries-- > 0) {
+
+        if (joinFuture.isCompletedExceptionally()) {
+          // retry join
+          LOG.info("Join failed. Retrying...");
+          joinFuture =
+              raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
+        } else if (joinFuture.isDone() && shouldRetryPromote(promoteFuture)) {
+          LOG.info("Promoting member 1...");
+          promoteFuture = raftContexts.promote(member1);
+        }
+
+        raftContexts.runUntilDone();
+        raftContexts.processAllMessage();
+        raftContexts.tickHeartbeatTimeout();
+      }
+
+      // then
+      assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
+      assertThat(promoteFuture)
+          .describedAs("Promotion of member 1 should be completed")
+          .isCompleted();
+      assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
+      assertThat(member1IsActiveInLeadersConfiguration())
+          .describedAs("Member 1 is ACTIVE in the leader's configuration")
+          .isTrue();
+      raftContexts.assertAllMembersAreReady();
+    } finally {
+      shutDownRaftNodes();
+    }
+  }
+
+  private void shutDownRaftNodes() throws IOException {
     if (raftContexts != null) {
       raftContexts.shutdown();
     }
@@ -63,149 +221,6 @@ public class RandomizedRaftJoinTest {
       FileUtil.deleteFolder(raftDataDirectory);
       raftDataDirectory = null;
     }
-  }
-
-  @Property
-  void joinCompletes(
-      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-    setUpRaftNodes(new Random(seed));
-
-    var joinFuture = raftContexts.join(member1, Set.of(member0, member1));
-
-    // given - when there are failures such as message loss
-    final var memberIter = raftMembers.iterator();
-    for (final RaftOperation operation : raftOperations) {
-      final MemberId member = memberIter.next();
-      LOG.info("{} on {}", operation, member);
-      operation.run(raftContexts, member);
-      // sample the safety invariant on every step: it records the vote of each member at the term
-      // it is currently in, so a vote that is overwritten between two steps is only observable
-      // while it is still recorded
-      raftContexts.assertAtMostOneVotePerMemberAndTerm();
-      if (joinFuture.isCompletedExceptionally()) {
-        // retry join
-        LOG.info("Join failed. Retrying...");
-        joinFuture = raftContexts.join(member1, Set.of(member0, member1));
-      }
-    }
-
-    raftContexts.runUntilDone();
-    raftContexts.processAllMessage();
-    raftContexts.tickHeartbeatTimeout();
-
-    // when - no more message loss or restarts
-
-    LOG.info("Stopping failures, waiting for join to complete");
-
-    // hoping that 2000 iterations are enough to complete the join process
-    int maxStepsToReplicateEntries = 10100;
-    while (!((joinFuture.isDone() && !joinFuture.isCompletedExceptionally())
-            && raftContexts.allMembersAreReady()
-            && raftContexts.hasLeaderAtTheLatestTerm())
-        && maxStepsToReplicateEntries-- > 0) {
-
-      if (joinFuture.isCompletedExceptionally()) {
-        // retry join
-        LOG.info("Join failed. Retrying...");
-        joinFuture = raftContexts.join(member1, Set.of(member0, member1));
-      }
-
-      raftContexts.runUntilDone();
-      raftContexts.processAllMessage();
-      raftContexts.tickHeartbeatTimeout();
-    }
-
-    // then
-    assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
-    assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
-    raftContexts.assertAllMembersAreReady();
-    raftContexts.assertAtMostOneVotePerMemberAndTerm();
-  }
-
-  @Property
-  void joinThenPromoteCompletes(
-      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-    setUpRaftNodes(new Random(seed));
-
-    var joinFuture =
-        raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
-    CompletableFuture<Void> promoteFuture = null;
-
-    // given - when there are failures such as message loss, including restarts of the joined
-    // member: the join future only completes once the admitting configuration entry is durably
-    // in this node's own log (see ReconfigurationHelper#awaitLocalDurability), so a restart right
-    // after completion always finds that entry via reloadConfigurationFromLog and never falls
-    // back to treating this node as a fresh, unconfigured one.
-    final var memberIter = raftMembers.iterator();
-    for (final RaftOperation operation : raftOperations) {
-      final MemberId member = memberIter.next();
-      LOG.info("{} on {}", operation, member);
-      operation.run(raftContexts, member);
-      // sample the safety invariant on every step: it records the vote of each member at the
-      // term it is currently in, so a vote that is overwritten between two steps is only
-      // observable while it is still recorded
-      raftContexts.assertAtMostOneVotePerMemberAndTerm();
-      if (joinFuture.isCompletedExceptionally()) {
-        // retry join
-        LOG.info("Join failed. Retrying...");
-        joinFuture =
-            raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
-      } else if (joinFuture.isDone() && shouldRetryPromote(promoteFuture)) {
-        LOG.info("Promoting member 1...");
-        promoteFuture = raftContexts.promote(member1);
-      }
-    }
-
-    raftContexts.runUntilDone();
-    raftContexts.processAllMessage();
-    raftContexts.tickHeartbeatTimeout();
-
-    // when - no more message loss or restarts
-
-    LOG.info("Stopping failures, waiting for join and promotion to complete");
-
-    int maxStepsToReplicateEntries = 10100;
-    while (!(joinFuture.isDone()
-            && !joinFuture.isCompletedExceptionally()
-            && promoteFuture != null
-            && promoteFuture.isDone()
-            && !promoteFuture.isCompletedExceptionally()
-            && member1IsActiveInLeadersConfiguration()
-            && raftContexts.allMembersAreReady()
-            && raftContexts.hasLeaderAtTheLatestTerm())
-        && maxStepsToReplicateEntries-- > 0) {
-
-      if (joinFuture.isCompletedExceptionally()) {
-        // retry join
-        LOG.info("Join failed. Retrying...");
-        joinFuture =
-            raftContexts.join(member1, RaftMember.Type.PROMOTABLE, Set.of(member0, member1));
-      } else if (joinFuture.isDone() && shouldRetryPromote(promoteFuture)) {
-        LOG.info("Promoting member 1...");
-        promoteFuture = raftContexts.promote(member1);
-      }
-
-      raftContexts.runUntilDone();
-      raftContexts.processAllMessage();
-      raftContexts.tickHeartbeatTimeout();
-    }
-
-    // then
-    assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
-    assertThat(promoteFuture)
-        .describedAs("Promotion of member 1 should be completed")
-        .isCompleted();
-    assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
-    assertThat(member1IsActiveInLeadersConfiguration())
-        .describedAs("Member 1 is ACTIVE in the leader's configuration")
-        .isTrue();
-    raftContexts.assertAllMembersAreReady();
   }
 
   /**
@@ -246,9 +261,9 @@ public class RandomizedRaftJoinTest {
     // then steps down after minStepDownFailureCount consecutive failures to reach the joining
     // member, as it does in production when the joiner is unreachable for two election timeouts.
     //
-    // Per try, not per property: shutdown() runs after every try and closes the harness' meter
-    // registry, so a reused instance would register the next try's contexts into a closed registry
-    // and carry its predecessor's data-loss bookkeeping over into an unrelated cluster.
+    // Per test case, not per property: shutdown() runs after every case and closes the harness'
+    // meter registry, so a reused instance would register the next case's contexts into a closed
+    // registry and carry its predecessor's data-loss bookkeeping over into an unrelated cluster.
     raftContexts =
         new ControllableRaftContexts(
             2, config -> config.setMaxQuorumResponseTimeout(Duration.ofMillis(1)));
@@ -257,22 +272,5 @@ public class RandomizedRaftJoinTest {
     raftContexts.setup(raftDataDirectory, random, Set.of(0));
 
     LOG.info("Set up 2-node raft cluster, bootstrapped with member 0 only");
-  }
-
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperations() {
-    final var operation = Arbitraries.of(operationsWithRestarts);
-    return operation.list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<List<MemberId>> raftMembers() {
-    final var members = Arbitraries.of(member0, member1);
-    return members.list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<Long> seeds() {
-    return Arbitraries.longs();
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftScaleDownTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftScaleDownTest.java
@@ -7,8 +7,14 @@
  */
 package io.atomix.raft;
 
+import static dev.hegel.Generators.longs;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HealthCheck;
+import dev.hegel.HegelTest;
+import dev.hegel.OptBoolean;
+import dev.hegel.Phase;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.RaftContext;
@@ -21,16 +27,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.EdgeCasesMode;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.PropertyDefaults;
-import net.jqwik.api.Provide;
-import net.jqwik.api.ShrinkingMode;
-import net.jqwik.api.lifecycle.AfterTry;
-import net.jqwik.api.lifecycle.BeforeProperty;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +36,6 @@ import org.slf4j.LoggerFactory;
  * so that its removal commits without its own participation. Mirrors the structure of {@link
  * RandomizedRaftJoinTest}, but with three bootstrapped ACTIVE members.
  */
-@PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
 public class RandomizedRaftScaleDownTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RandomizedRaftScaleDownTest.class);
@@ -52,7 +48,7 @@ public class RandomizedRaftScaleDownTest {
   private MemberId member2;
   private List<RaftOperation> operationsWithRestarts;
 
-  @BeforeProperty
+  @BeforeEach
   public void initMembers() {
     member0 = MemberId.from("0");
     member1 = MemberId.from("1");
@@ -60,8 +56,114 @@ public class RandomizedRaftScaleDownTest {
     operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
   }
 
-  @AfterTry
-  public void shutDownRaftNodes() throws IOException {
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void scaleDownCompletes(final TestCase tc) throws Exception {
+    // The seed drawn from Hegel determines the operation sequence, the members each operation is
+    // applied to, and the raft nodes' own randomness, so a reported seed replays the whole case.
+    final long seed = tc.draw(longs(), "seed");
+    LOG.info("Running test case with seed {}", seed);
+    final var random = new Random(seed);
+    final var raftOperations = RandomSequence.of(random, operationsWithRestarts, OPERATION_SIZE);
+    final var raftMembers =
+        RandomSequence.of(random, List.of(member0, member1, member2), OPERATION_SIZE);
+    setUpRaftNodes(random);
+    try {
+      // Both operations fail fast on CONFIGURATION_ERROR or when the member restarts while they are
+      // pending, so they are simply re-issued until they complete: first the demotion, then the
+      // leave.
+      var demoteFuture = raftContexts.demote(member2);
+      CompletableFuture<Void> leaveFuture = null;
+
+      // given - when there are failures such as message loss
+      final var memberIter = raftMembers.iterator();
+      for (final RaftOperation operation : raftOperations) {
+        final MemberId member = memberIter.next();
+        if ("Restart member".equals(operation.toString()) && member.equals(member2)) {
+          // Known pre-existing residuals, outside this task's scope: a member that restarts during
+          // the demote/leave window can miss the corresponding configuration entries and fall back
+          // to a stale or initial configuration whose index the leader ignores as "no information"
+          // (LeaderAppender#updateConfigurationIndex), so it is never re-configured and its local
+          // demote() runs against a wrong self-view; a removed member restarting during the
+          // append-to-commit window additionally transitions itself INACTIVE at bootstrap. Skip
+          // restarts of the leaving member instead of fighting these here.
+          continue;
+        }
+        LOG.info("{} on {}", operation, member);
+        operation.run(raftContexts, member);
+        // sample the safety invariant on every step: it records the vote of each member at the
+        // term it is currently in, so a vote that is overwritten between two steps is only
+        // observable while it is still recorded
+        raftContexts.assertAtMostOneVotePerMemberAndTerm();
+        if (leaveFuture == null) {
+          if (shouldRetryDemote(demoteFuture)) {
+            LOG.info("Demoting member 2...");
+            demoteFuture = raftContexts.demote(member2);
+          } else if (demoteFuture.isDone()) {
+            LOG.info("Demote completed. Leaving...");
+            leaveFuture = raftContexts.leave(member2);
+          }
+        } else if (leaveFuture.isCompletedExceptionally()) {
+          LOG.info("Leave failed. Retrying...");
+          leaveFuture = raftContexts.leave(member2);
+        }
+      }
+
+      raftContexts.runUntilDone();
+      raftContexts.processAllMessage();
+      raftContexts.tickHeartbeatTimeout();
+
+      // when - no more message loss or restarts
+
+      LOG.info("Stopping failures, waiting for demote and leave to complete");
+
+      final var remainingMembers = Set.of(member0, member1);
+      int maxStepsToReplicateEntries = 10100;
+      while (!(leaveFuture != null
+              && leaveFuture.isDone()
+              && !leaveFuture.isCompletedExceptionally()
+              && raftContexts.allMembersAreReady(remainingMembers)
+              && raftContexts.hasLeaderAtTheLatestTerm())
+          && maxStepsToReplicateEntries-- > 0) {
+
+        if (leaveFuture == null) {
+          if (shouldRetryDemote(demoteFuture)) {
+            LOG.info("Demoting member 2...");
+            demoteFuture = raftContexts.demote(member2);
+          } else if (demoteFuture.isDone()) {
+            LOG.info("Demote completed. Leaving...");
+            leaveFuture = raftContexts.leave(member2);
+          }
+        } else if (leaveFuture.isCompletedExceptionally()) {
+          LOG.info("Leave failed. Retrying...");
+          leaveFuture = raftContexts.leave(member2);
+        }
+
+        raftContexts.runUntilDone();
+        raftContexts.processAllMessage();
+        raftContexts.tickHeartbeatTimeout();
+      }
+
+      // then - the leave is only ever issued once the leader's configuration has member 2 as
+      // PASSIVE, so a completed leave also witnesses that the demotion phase took effect
+      assertThat(demoteFuture)
+          .describedAs("Demotion of member 2 should be completed")
+          .isCompleted();
+      assertThat(leaveFuture).describedAs("Leave of member 2 should be completed").isCompleted();
+      assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
+      assertThat(raftContexts.allMembersAreReady(remainingMembers))
+          .describedAs("The remaining members are ready")
+          .isTrue();
+      raftContexts.assertAllLogsEqual(remainingMembers);
+    } finally {
+      shutDownRaftNodes();
+    }
+  }
+
+  private void shutDownRaftNodes() throws IOException {
     if (raftContexts != null) {
       raftContexts.shutdown();
     }
@@ -69,100 +171,6 @@ public class RandomizedRaftScaleDownTest {
       FileUtil.deleteFolder(raftDataDirectory);
       raftDataDirectory = null;
     }
-  }
-
-  @Property
-  void scaleDownCompletes(
-      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-    setUpRaftNodes(new Random(seed));
-
-    // Both operations fail fast on CONFIGURATION_ERROR or when the member restarts while they are
-    // pending, so they are simply re-issued until they complete: first the demotion, then the
-    // leave.
-    var demoteFuture = raftContexts.demote(member2);
-    CompletableFuture<Void> leaveFuture = null;
-
-    // given - when there are failures such as message loss
-    final var memberIter = raftMembers.iterator();
-    for (final RaftOperation operation : raftOperations) {
-      final MemberId member = memberIter.next();
-      if ("Restart member".equals(operation.toString()) && member.equals(member2)) {
-        // Known pre-existing residuals, outside this task's scope: a member that restarts during
-        // the demote/leave window can miss the corresponding configuration entries and fall back
-        // to a stale or initial configuration whose index the leader ignores as "no information"
-        // (LeaderAppender#updateConfigurationIndex), so it is never re-configured and its local
-        // demote() runs against a wrong self-view; a removed member restarting during the
-        // append-to-commit window additionally transitions itself INACTIVE at bootstrap. Skip
-        // restarts of the leaving member instead of fighting these here.
-        continue;
-      }
-      LOG.info("{} on {}", operation, member);
-      operation.run(raftContexts, member);
-      // sample the safety invariant on every step: it records the vote of each member at the
-      // term it is currently in, so a vote that is overwritten between two steps is only
-      // observable while it is still recorded
-      raftContexts.assertAtMostOneVotePerMemberAndTerm();
-      if (leaveFuture == null) {
-        if (shouldRetryDemote(demoteFuture)) {
-          LOG.info("Demoting member 2...");
-          demoteFuture = raftContexts.demote(member2);
-        } else if (demoteFuture.isDone()) {
-          LOG.info("Demote completed. Leaving...");
-          leaveFuture = raftContexts.leave(member2);
-        }
-      } else if (leaveFuture.isCompletedExceptionally()) {
-        LOG.info("Leave failed. Retrying...");
-        leaveFuture = raftContexts.leave(member2);
-      }
-    }
-
-    raftContexts.runUntilDone();
-    raftContexts.processAllMessage();
-    raftContexts.tickHeartbeatTimeout();
-
-    // when - no more message loss or restarts
-
-    LOG.info("Stopping failures, waiting for demote and leave to complete");
-
-    final var remainingMembers = Set.of(member0, member1);
-    int maxStepsToReplicateEntries = 10100;
-    while (!(leaveFuture != null
-            && leaveFuture.isDone()
-            && !leaveFuture.isCompletedExceptionally()
-            && raftContexts.allMembersAreReady(remainingMembers)
-            && raftContexts.hasLeaderAtTheLatestTerm())
-        && maxStepsToReplicateEntries-- > 0) {
-
-      if (leaveFuture == null) {
-        if (shouldRetryDemote(demoteFuture)) {
-          LOG.info("Demoting member 2...");
-          demoteFuture = raftContexts.demote(member2);
-        } else if (demoteFuture.isDone()) {
-          LOG.info("Demote completed. Leaving...");
-          leaveFuture = raftContexts.leave(member2);
-        }
-      } else if (leaveFuture.isCompletedExceptionally()) {
-        LOG.info("Leave failed. Retrying...");
-        leaveFuture = raftContexts.leave(member2);
-      }
-
-      raftContexts.runUntilDone();
-      raftContexts.processAllMessage();
-      raftContexts.tickHeartbeatTimeout();
-    }
-
-    // then - the leave is only ever issued once the leader's configuration has member 2 as
-    // PASSIVE, so a completed leave also witnesses that the demotion phase took effect
-    assertThat(demoteFuture).describedAs("Demotion of member 2 should be completed").isCompleted();
-    assertThat(leaveFuture).describedAs("Leave of member 2 should be completed").isCompleted();
-    assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
-    assertThat(raftContexts.allMembersAreReady(remainingMembers))
-        .describedAs("The remaining members are ready")
-        .isTrue();
-    raftContexts.assertAllLogsEqual(remainingMembers);
   }
 
   /**
@@ -199,7 +207,7 @@ public class RandomizedRaftScaleDownTest {
 
     // Create ControllableRaftContexts with 3 nodes. Reduce the quorum response timeout to make
     // the wall-clock gated leader step-down reachable under the deterministic scheduler, see
-    // RandomizedRaftJoinTest. Created per try because shutdown() runs after every try, see
+    // RandomizedRaftJoinTest. Created per test case because shutdown() runs after every case, see
     // RandomizedRaftJoinTest#setUpRaftNodes.
     raftContexts =
         new ControllableRaftContexts(
@@ -209,22 +217,5 @@ public class RandomizedRaftScaleDownTest {
     raftContexts.setup(raftDataDirectory, random);
 
     LOG.info("Set up 3-node raft cluster");
-  }
-
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperations() {
-    final var operation = Arbitraries.of(operationsWithRestarts);
-    return operation.list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<List<MemberId>> raftMembers() {
-    final var members = Arbitraries.of(member0, member1, member2);
-    return members.list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<Long> seeds() {
-    return Arbitraries.longs();
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -15,8 +15,14 @@
  */
 package io.atomix.raft;
 
+import static dev.hegel.Generators.longs;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HealthCheck;
+import dev.hegel.HegelTest;
+import dev.hegel.OptBoolean;
+import dev.hegel.Phase;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -27,21 +33,11 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.EdgeCasesMode;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.PropertyDefaults;
-import net.jqwik.api.Provide;
-import net.jqwik.api.ShrinkingMode;
-import net.jqwik.api.lifecycle.AfterTry;
-import net.jqwik.api.lifecycle.BeforeProperty;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-@PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
 public class RandomizedRaftTest {
 
   private static final int OPERATION_SIZE = 10000;
@@ -56,7 +52,7 @@ public class RandomizedRaftTest {
   private List<MemberId> raftMembers;
   private Path raftDataDirectory;
 
-  @BeforeProperty
+  @BeforeEach
   public void initOperations() {
     // Need members ids to generate pair operations
     final var servers =
@@ -73,126 +69,134 @@ public class RandomizedRaftTest {
     raftMembers = servers;
   }
 
-  @AfterTry
-  public void shutDownRaftNodes() throws IOException {
-    raftContexts.shutdown();
-    FileUtil.deleteFolder(raftDataDirectory);
-    raftDataDirectory = null;
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void consistencyTestWithNoSnapshot(final TestCase tc) throws Exception {
+    runRandomized(tc, defaultOperations, this::consistencyTest);
   }
 
-  @Property
-  void consistencyTestWithNoSnapshot(
-      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-
-    consistencyTest(raftOperations, raftMembers, seed);
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void consistencyTestWithSnapshot(final TestCase tc) throws Exception {
+    runRandomized(tc, operationsWithSnapshot, this::consistencyTest);
   }
 
-  @Property
-  void consistencyTestWithSnapshot(
-      @ForAll("raftOperationsWithSnapshot") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-
-    consistencyTest(raftOperations, raftMembers, seed);
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void consistencyTestWithRestarts(final TestCase tc) throws Exception {
+    runRandomized(tc, operationsWithRestarts, this::consistencyTest);
   }
 
-  @Property
-  void consistencyTestWithRestarts(
-      @ForAll("raftOperationsWithRestarts") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-
-    consistencyTest(raftOperations, raftMembers, seed);
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void consistencyTestWithSnapshotsAndRestarts(final TestCase tc) throws Exception {
+    runRandomized(tc, operationsWithSnapshotsAndRestarts, this::consistencyTest);
   }
 
-  @Property
-  void consistencyTestWithSnapshotsAndRestarts(
-      @ForAll("raftOperationsWithSnapshotsAndRestarts") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-
-    consistencyTest(raftOperations, raftMembers, seed);
+  @HegelTest(
+      testCases = 1,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void consistencyTestAfterDataLoss(final TestCase tc) throws Exception {
+    runRandomized(tc, operationsWithSnapshotsAndRestartsWithDataLoss, this::consistencyTest);
   }
 
-  @Property(tries = 1)
-  void consistencyTestAfterDataLoss(
-      @ForAll("raftOperationsWithSnapshotsAndRestartsWithDataLoss")
-          final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-
-    consistencyTest(raftOperations, raftMembers, seed);
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void livenessTestWithRestarts(final TestCase tc) throws Exception {
+    runRandomized(tc, operationsWithRestarts, this::livenessTest);
   }
 
-  @Property
-  void livenessTestWithRestarts(
-      @ForAll("raftOperationsWithRestarts") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-    livenessTest(raftOperations, raftMembers, seed);
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void livenessTestWithRestartsAndSnapshots(final TestCase tc) throws Exception {
+    runRandomized(tc, operationsWithSnapshotsAndRestarts, this::livenessTest);
   }
 
-  @Property
-  void livenessTestWithRestartsAndSnapshots(
-      @ForAll("raftOperationsWithSnapshotsAndRestarts") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-    livenessTest(raftOperations, raftMembers, seed);
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void livenessTestWithNoSnapshot(final TestCase tc) throws Exception {
+    runRandomized(tc, defaultOperations, this::livenessTest);
   }
 
-  @Property
-  void livenessTestWithNoSnapshot(
-      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-
-    livenessTest(raftOperations, raftMembers, seed);
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void livenessTestWithSnapshot(final TestCase tc) throws Exception {
+    runRandomized(tc, operationsWithSnapshot, this::livenessTest);
   }
 
-  @Property
-  void livenessTestWithSnapshot(
-      @ForAll("raftOperationsWithSnapshot") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
+  @HegelTest(
+      testCases = 10,
+      phases = {Phase.EXPLICIT, Phase.REUSE, Phase.GENERATE},
+      derandomize = OptBoolean.FALSE,
+      suppressHealthCheck = HealthCheck.TOO_SLOW)
+  void livenessTestWithSnapshotAndSingleRestart(final TestCase tc) throws Exception {
+    runRandomized(
+        tc,
+        operationsWithSnapshot,
+        (raftOperations, raftMembers) -> {
+          // After all operations, restart all members once
+          final var modifiedOperations = new ArrayList<>(raftOperations);
+          for (final var member : this.raftMembers) {
+            modifiedOperations.add(
+                RaftOperation.of("Restart member", ControllableRaftContexts::restart));
+          }
 
-    livenessTest(raftOperations, raftMembers, seed);
+          final var modifiedMemberList = new ArrayList<>(raftMembers);
+          modifiedMemberList.addAll(this.raftMembers);
+
+          livenessTest(modifiedOperations, modifiedMemberList);
+        });
   }
 
-  @Property
-  void livenessTestWithSnapshotAndSingleRestart(
-      @ForAll("raftOperationsWithSnapshot") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
+  /**
+   * Runs one test case: the seed drawn from Hegel determines the operation sequence, the members
+   * each operation is applied to, and the raft nodes' own randomness, so a reported seed replays
+   * the whole case.
+   */
+  private void runRandomized(
+      final TestCase tc, final List<RaftOperation> operations, final RaftTest test)
       throws Exception {
-
-    // After all operations, restart all members once
-    final var modifiedOperations = new ArrayList<>(raftOperations);
-    for (final var member : this.raftMembers) {
-      modifiedOperations.add(RaftOperation.of("Restart member", ControllableRaftContexts::restart));
+    final long seed = tc.draw(longs(), "seed");
+    LOG.info("Running test case with seed {}", seed);
+    final var random = new Random(seed);
+    final var raftOperations = RandomSequence.of(random, operations, OPERATION_SIZE);
+    final var members = RandomSequence.of(random, raftMembers, OPERATION_SIZE);
+    setUpRaftNodes(random);
+    try {
+      test.run(raftOperations, members);
+    } finally {
+      shutDownRaftNodes();
     }
-
-    final var modifiedMemberList = new ArrayList<>(raftMembers);
-    modifiedMemberList.addAll(this.raftMembers);
-
-    livenessTest(modifiedOperations, modifiedMemberList, seed);
   }
 
   private void consistencyTest(
-      final List<RaftOperation> raftOperations, final List<MemberId> raftMembers, final long seed)
-      throws Exception {
-    setUpRaftNodes(new Random(seed));
-
+      final List<RaftOperation> raftOperations, final List<MemberId> raftMembers) throws Exception {
     int step = 0;
     final var memberIter = raftMembers.iterator();
     for (final RaftOperation operation : raftOperations) {
@@ -219,10 +223,7 @@ public class RandomizedRaftTest {
   }
 
   private void livenessTest(
-      final List<RaftOperation> raftOperations, final List<MemberId> raftMembers, final long seed)
-      throws Exception {
-    setUpRaftNodes(new Random(seed));
-
+      final List<RaftOperation> raftOperations, final List<MemberId> raftMembers) throws Exception {
     // given - when there are failures such as message loss
     final var memberIter = raftMembers.iterator();
     for (final RaftOperation operation : raftOperations) {
@@ -267,52 +268,21 @@ public class RandomizedRaftTest {
     raftContexts.assertNoDataLoss();
   }
 
-  /** Basic raft operations without snapshotting, compaction or restart */
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperations() {
-    final var operation = Arbitraries.of(defaultOperations);
-    return operation.list().ofSize(OPERATION_SIZE);
-  }
-
-  /** Basic raft operation with snapshotting and compaction */
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperationsWithSnapshot() {
-    final var operation = Arbitraries.of(operationsWithSnapshot);
-    return operation.list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperationsWithRestarts() {
-    return Arbitraries.of(operationsWithRestarts).list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperationsWithSnapshotsAndRestarts() {
-    return Arbitraries.of(operationsWithSnapshotsAndRestarts).list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperationsWithSnapshotsAndRestartsWithDataLoss() {
-    return Arbitraries.of(operationsWithSnapshotsAndRestartsWithDataLoss)
-        .list()
-        .ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<List<MemberId>> raftMembers() {
-    final var members = Arbitraries.of(raftMembers);
-    return members.list().ofSize(OPERATION_SIZE);
-  }
-
-  @Provide
-  Arbitrary<Long> seeds() {
-    return Arbitraries.longs();
-  }
-
   private void setUpRaftNodes(final Random random) throws Exception {
     // Could not make @TempDir annotation work
     raftDataDirectory = Files.createTempDirectory(null);
     raftContexts = new ControllableRaftContexts(3);
     raftContexts.setup(raftDataDirectory, random);
+  }
+
+  private void shutDownRaftNodes() throws IOException {
+    raftContexts.shutdown();
+    FileUtil.deleteFolder(raftDataDirectory);
+    raftDataDirectory = null;
+  }
+
+  @FunctionalInterface
+  private interface RaftTest {
+    void run(List<RaftOperation> raftOperations, List<MemberId> raftMembers) throws Exception;
   }
 }

--- a/zeebe/backup-stores/common/pom.xml
+++ b/zeebe/backup-stores/common/pom.xml
@@ -55,32 +55,11 @@
     </dependency>
 
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <!--  Ensure non-jqwik junit5 tests can be run -->
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
 
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <usedDependencies>
-            <dependency>net.jqwik:jqwik</dependency>
-          </usedDependencies>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -154,19 +154,12 @@
     </dependency>
 
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik</artifactId>
+      <groupId>dev.hegel</groupId>
+      <artifactId>hegel-jna</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <!--  Ensure non-jqwik junit5 tests can be run -->
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
@@ -184,9 +177,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <usedDependencies>
-            <dependency>net.jqwik:jqwik</dependency>
-          </usedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- Will be used soon and is already useful for bringing in dependencies on auto-generated google api libraries -->
             <ignoredUnusedDeclaredDependency>com.google.cloud:google-cloud-storage</ignoredUnusedDeclaredDependency>

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataPropertyTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataPropertyTest.java
@@ -7,9 +7,19 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import static dev.hegel.Generators.composite;
+import static dev.hegel.Generators.forType;
+import static dev.hegel.Generators.fromRegex;
+import static dev.hegel.Generators.integers;
+import static dev.hegel.Generators.longs;
+import static dev.hegel.Generators.optional;
+import static dev.hegel.Generators.sampledFrom;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.cloud.storage.Blob;
+import dev.hegel.Generator;
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
@@ -19,12 +29,6 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
 import java.util.Map;
 import java.util.OptionalLong;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.mockito.Mockito;
 
 final class ManifestMetadataPropertyTest {
@@ -32,9 +36,60 @@ final class ManifestMetadataPropertyTest {
   private static final String BASE_PATH = "base/";
   private static final String MANIFEST_BLOB_NAME = "manifest.json";
 
-  @Property(tries = 100)
-  void shouldRoundTripAnyManifest(@ForAll("manifests") final Manifest manifest) {
+  private static final Generator<BackupIdentifierImpl> IDENTIFIERS =
+      composite(
+          tc ->
+              new BackupIdentifierImpl(
+                  tc.draw(integers().min(0).max(100)),
+                  tc.draw(integers().min(1).max(64)),
+                  tc.draw(longs().min(1).max(1_000_000L))));
+
+  private static final Generator<Instant> CHECKPOINT_TIMESTAMPS =
+      longs()
+          .min(Instant.parse("2020-01-01T00:00:00Z").getEpochSecond())
+          .max(Instant.parse("2030-01-01T00:00:00Z").getEpochSecond())
+          .map(Instant::ofEpochSecond);
+
+  private static final Generator<BackupDescriptorImpl> DESCRIPTORS =
+      composite(
+          tc ->
+              new BackupDescriptorImpl(
+                  tc.draw(optional(fromRegex("[a-zA-Z]{1,10}"))),
+                  tc.draw(optional(longs().min(0).max(1_000_000L)))
+                      .map(OptionalLong::of)
+                      .orElse(OptionalLong.empty()),
+                  tc.draw(longs().min(0).max(1_000_000L)),
+                  tc.draw(integers().min(1).max(32)),
+                  tc.draw(fromRegex("[a-zA-Z0-9]{1,20}")),
+                  tc.draw(CHECKPOINT_TIMESTAMPS),
+                  tc.draw(forType(CheckpointType.class))));
+
+  private static final Generator<BackupImpl> BACKUPS =
+      composite(
+          tc ->
+              new BackupImpl(
+                  tc.draw(IDENTIFIERS),
+                  tc.draw(DESCRIPTORS),
+                  new NamedFileSetImpl(Map.of()),
+                  new NamedFileSetImpl(Map.of())));
+
+  private static final Generator<Manifest> MANIFESTS =
+      composite(
+          tc -> {
+            final var inProgress = Manifest.createInProgress(tc.draw(BACKUPS));
+            return switch (tc.draw(sampledFrom("IN_PROGRESS", "COMPLETED", "FAILED", "DELETED"))) {
+              case "IN_PROGRESS" -> inProgress;
+              case "COMPLETED" -> inProgress.complete();
+              case "FAILED" -> inProgress.fail("test failure reason");
+              case "DELETED" -> inProgress.complete().delete();
+              default -> throw new IllegalStateException();
+            };
+          });
+
+  @HegelTest(testCases = 100)
+  void shouldRoundTripAnyManifest(final TestCase tc) {
     // given
+    final var manifest = tc.draw(MANIFESTS, "manifest");
     final var expectedStatus = Manifest.toStatus(manifest);
     final var id = manifest.id();
     final var blobName =
@@ -80,68 +135,5 @@ final class ManifestMetadataPropertyTest {
     } else {
       assertThat(status.descriptor()).isEmpty();
     }
-  }
-
-  @Provide
-  Arbitrary<Manifest> manifests() {
-    return backups()
-        .flatMap(
-            backup -> {
-              final var inProgress = Manifest.createInProgress(backup);
-              return Arbitraries.of("IN_PROGRESS", "COMPLETED", "FAILED", "DELETED")
-                  .map(
-                      state ->
-                          switch (state) {
-                            case "IN_PROGRESS" -> inProgress;
-                            case "COMPLETED" -> inProgress.complete();
-                            case "FAILED" -> inProgress.fail("test failure reason");
-                            case "DELETED" -> inProgress.complete().delete();
-                            default -> throw new IllegalStateException();
-                          });
-            });
-  }
-
-  Arbitrary<BackupImpl> backups() {
-    return Combinators.combine(identifiers(), descriptors())
-        .as(
-            (id, descriptor) ->
-                new BackupImpl(
-                    id,
-                    descriptor,
-                    new NamedFileSetImpl(Map.of()),
-                    new NamedFileSetImpl(Map.of())));
-  }
-
-  Arbitrary<BackupIdentifierImpl> identifiers() {
-    return Combinators.combine(
-            Arbitraries.integers().between(0, 100),
-            Arbitraries.integers().between(1, 64),
-            Arbitraries.longs().between(1L, 1_000_000L))
-        .as(BackupIdentifierImpl::new);
-  }
-
-  Arbitrary<BackupDescriptorImpl> descriptors() {
-    return Combinators.combine(
-            Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10).optional(),
-            Arbitraries.longs().between(0L, 1_000_000L).optional(),
-            Arbitraries.longs().between(0L, 1_000_000L),
-            Arbitraries.integers().between(1, 32),
-            Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(20),
-            Arbitraries.longs()
-                .between(
-                    Instant.parse("2020-01-01T00:00:00Z").getEpochSecond(),
-                    Instant.parse("2030-01-01T00:00:00Z").getEpochSecond())
-                .map(Instant::ofEpochSecond),
-            Arbitraries.of(CheckpointType.values()))
-        .as(
-            (snapshotId, firstLogPos, checkpointPos, partitions, version, timestamp, type) ->
-                new BackupDescriptorImpl(
-                    snapshotId,
-                    firstLogPos.map(OptionalLong::of).orElse(OptionalLong.empty()),
-                    checkpointPos,
-                    partitions,
-                    version,
-                    timestamp,
-                    type));
   }
 }

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -451,16 +451,9 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- required to run both jqwik and junit as test engines -->
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik-api</artifactId>
+      <groupId>dev.hegel</groupId>
+      <artifactId>hegel-jna</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -507,9 +500,6 @@
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>io.camunda:zeebe-journal</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
-          <usedDependencies>
-            <dependency>net.jqwik:jqwik</dependency>
-          </usedDependencies>
         </configuration>
       </plugin>
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -7,6 +7,11 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
+import static dev.hegel.Generators.booleans;
+import static dev.hegel.Generators.composite;
+import static dev.hegel.Generators.forType;
+import static dev.hegel.Generators.integers;
+import static dev.hegel.Generators.lists;
 import static java.lang.String.format;
 import static java.util.List.of;
 import static java.util.concurrent.CompletableFuture.runAsync;
@@ -16,6 +21,9 @@ import static org.mockito.Mockito.framework;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import dev.hegel.Generator;
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransition.CancelledPartitionTransition;
@@ -36,15 +44,7 @@ import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.GenerationMode;
-import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
-import net.jqwik.api.lifecycle.AfterTry;
-import net.jqwik.api.lifecycle.BeforeTry;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,17 +52,26 @@ public class RandomizedPartitionTransitionTest {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(RandomizedPartitionTransitionTest.class);
 
-  private ActorScheduler actorScheduler;
-  private TestActor actor;
+  private static final Generator<TestOperation> TEST_OPERATION =
+      composite(
+          tc ->
+              createTestOperation(
+                  tc.draw(forType(TestOperationKind.class)), tc.draw(forType(Role.class))));
 
-  @BeforeTry
-  public void beforeTry() {
-    actorScheduler = ActorScheduler.newActorScheduler().build();
-    actorScheduler.start();
-
-    actor = new TestActor();
-    actorScheduler.submitActor(actor);
-  }
+  /**
+   * Up to four operations of which at least one requests a transition, followed by a final catch up
+   * so that every scheduled transition runs to its end.
+   */
+  private static final Generator<List<TestOperation>> TEST_OPERATIONS =
+      composite(
+          tc -> {
+            final var operations = new ArrayList<>(tc.draw(lists(TEST_OPERATION).maxSize(3)));
+            final var transition =
+                new RequestTransition(tc.draw(forType(Role.class)), tc.draw(booleans()));
+            operations.add(tc.draw(integers().min(0).max(operations.size())), transition);
+            operations.add(new CatchUpOperation());
+            return operations;
+          });
 
   /**
    * Verifies that during transitions at most one {@code StreamProcessor} is created. It sets up the
@@ -76,12 +85,10 @@ public class RandomizedPartitionTransitionTest {
    * The first step is there to manipulate execution order. In particular, the step will wait for a
    * countdown latch thus pausing transition execution. This in turn, allows scheduling successive
    * transition which cancel their predecessors
-   *
-   * @param operations the operations to run
    */
-  @Property(generation = GenerationMode.RANDOMIZED)
-  void atMostOneStreamProcessorIsRunningAtAnyTime(
-      @ForAll("testOperations") final List<TestOperation> operations) {
+  @HegelTest
+  void atMostOneStreamProcessorIsRunningAtAnyTime(final TestCase tc) {
+    final var operations = tc.draw(TEST_OPERATIONS, "operations");
     LOGGER.debug(
         format(
             "Testing property 'atMostOneStreamProcessorIsRunningAtAnyTime' on sequence %s",
@@ -107,10 +114,13 @@ public class RandomizedPartitionTransitionTest {
     context.setComponentHealthMonitor(mock(HealthMonitor.class));
 
     final var sut = new PartitionTransitionImpl(of(firstStep, streamProcessorStep));
-    sut.setConcurrencyControl(actor);
-    sut.updateTransitionContext(context);
+    runWithActor(
+        actor -> {
+          sut.setConcurrencyControl(actor);
+          sut.updateTransitionContext(context);
 
-    runOperations(operations, sut);
+          runOperations(operations, sut);
+        });
 
     assertThat(instanceTracker.getOpenedInstances())
         .describedAs("Active stream processors at end of transition sequence")
@@ -129,12 +139,10 @@ public class RandomizedPartitionTransitionTest {
    * The first step is there to manipulate execution order. In particular, the step will wait for a
    * countdown latch thus pausing transition execution. This in turn, allows scheduling successive
    * transition which cancel their predecessors
-   *
-   * @param operations the operations to run
    */
-  @Property(generation = GenerationMode.RANDOMIZED)
-  void atMostOneZeebeDbIsOpenAtAnyTime(
-      @ForAll("testOperations") final List<TestOperation> operations) {
+  @HegelTest
+  void atMostOneZeebeDbIsOpenAtAnyTime(final TestCase tc) {
+    final var operations = tc.draw(TEST_OPERATIONS, "operations");
     LOGGER.debug(
         format("Testing property 'atMostOneZeebeDbIsOpenAtAnyTime' on sequence %s", operations));
 
@@ -155,20 +163,32 @@ public class RandomizedPartitionTransitionTest {
     context.setStateController(new TestStateController(instanceTracker));
 
     final var sut = new PartitionTransitionImpl(of(firstStep, zeebeDbStep));
-    sut.setConcurrencyControl(actor);
-    sut.updateTransitionContext(context);
+    runWithActor(
+        actor -> {
+          sut.setConcurrencyControl(actor);
+          sut.updateTransitionContext(context);
 
-    runOperations(operations, sut);
+          runOperations(operations, sut);
+        });
 
     assertThat(instanceTracker.getOpenedInstances())
         .describedAs("Zeebe DB processes at end of transition sequence")
         .hasSizeLessThan(2);
   }
 
-  @AfterTry
-  public void afterTry() {
-    actorScheduler.stop();
-    framework().clearInlineMocks(); // prevent memory leaks from statically held mocks and stubbings
+  /** Every generated sequence runs on a fresh actor scheduler so that cases cannot interfere. */
+  private static void runWithActor(final Consumer<TestActor> test) {
+    final var actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+    final var actor = new TestActor();
+    actorScheduler.submitActor(actor);
+    try {
+      test.accept(actor);
+    } finally {
+      actorScheduler.stop();
+      // prevent memory leaks from statically held mocks and stubbings
+      framework().clearInlineMocks();
+    }
   }
 
   private void runOperations(
@@ -221,25 +241,7 @@ public class RandomizedPartitionTransitionTest {
     }
   }
 
-  @Provide
-  Arbitrary<List<TestOperation>> testOperations() {
-    final var kind = Arbitraries.of(TestOperationKind.class);
-    final var role = Arbitraries.of(RaftServer.Role.class);
-
-    final var operation = Combinators.combine(kind, role).as(this::createTestOperation);
-
-    return operation
-        .list()
-        .ofMaxSize(4)
-        .filter(list -> list.stream().anyMatch(RequestTransition.class::isInstance))
-        .map(
-            list -> {
-              list.add(new CatchUpOperation());
-              return list;
-            });
-  }
-
-  private TestOperation createTestOperation(
+  private static TestOperation createTestOperation(
       final TestOperationKind kind, final RaftServer.Role role) {
     switch (kind) {
       case TRANSITION_TO_ROLE_NO_PAUSE:

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -145,25 +145,12 @@
     </dependency>
 
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik</artifactId>
+      <groupId>dev.hegel</groupId>
+      <artifactId>hegel-jna</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik-time</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <!--  Ensure non-jqwik junit5 tests can be run -->
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
@@ -194,9 +181,6 @@
             <!-- Required by javac annotation processor for nullaway -->
             <ignoredNonTestScopedDependency>org.agrona:agrona</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
-          <usedDependencies>
-            <dependency>net.jqwik:jqwik</dependency>
-          </usedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -9,26 +9,26 @@ package io.camunda.zeebe.dynamic.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.Generator;
+import dev.hegel.HegelTest;
+import dev.hegel.OptBoolean;
+import dev.hegel.TestCase;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.util.ClusterTopologyDomain;
 import java.io.IOException;
 import java.nio.file.Files;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.domains.Domain;
-import net.jqwik.api.domains.DomainContext;
 
 final class PersistedClusterConfigurationRandomizedPropertyTest {
 
-  @Property(tries = 100)
-  @Domain(ClusterTopologyDomain.class)
-  @Domain(DomainContext.Global.class)
-  void shouldUpdatePersistedFile(
-      @ForAll final ClusterConfiguration initialTopology,
-      @ForAll final ClusterConfiguration updatedTopology)
-      throws IOException {
+  private static final Generator<ClusterConfiguration> CLUSTER_CONFIGURATIONS =
+      ClusterTopologyDomain.clusterTopologies();
+
+  @HegelTest(testCases = 100, derandomize = OptBoolean.FALSE)
+  void shouldUpdatePersistedFile(final TestCase tc) throws IOException {
     // given
+    final var initialTopology = tc.draw(CLUSTER_CONFIGURATIONS, "initialTopology");
+    final var updatedTopology = tc.draw(CLUSTER_CONFIGURATIONS, "updatedTopology");
     final var tmp = Files.createTempDirectory("topology");
     final var topologyFile = tmp.resolve("topology.meta");
     final var serializer = new ProtoBufSerializer();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.dynamic.config.api;
 import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
@@ -23,9 +25,6 @@ import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.domains.Domain;
 import org.junit.jupiter.api.Test;
 
 class AddMembersTransformerTest {
@@ -79,11 +78,10 @@ class AddMembersTransformerTest {
     assertThat(result.get()).isEmpty();
   }
 
-  @Property(tries = 100)
-  @Domain(MemberIdArbitraries.class)
-  void shouldOnlyGenerateOperationsForNewMembersProperty(
-      @ForAll final Set<MemberId> candidateMembers) {
+  @HegelTest(testCases = 100)
+  void shouldOnlyGenerateOperationsForNewMembersProperty(final TestCase tc) {
     // given
+    final var candidateMembers = tc.draw(MemberIdArbitraries.memberIds(), "candidateMembers");
     final var addRequest = new AddMembersTransformer(candidateMembers);
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static dev.hegel.Generators.integers;
 import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperations;
 import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
@@ -49,9 +52,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.constraints.IntRange;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -69,11 +69,11 @@ final class ClusterScaleRequestTransformerTest {
   private final MemberId id1 = MemberId.from("1");
   private final MemberId id2 = MemberId.from("2");
 
-  @Property(tries = 10)
-  void shouldScaleBrokersWhenPartitionsUnchanged(
-      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
-      @ForAll @IntRange(min = 2, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 2, max = 100) final int newClusterSize) {
+  @HegelTest(testCases = 10)
+  void shouldScaleBrokersWhenPartitionsUnchanged(final TestCase tc) {
+    final int partitionCount = tc.draw(integers().min(1).max(100), "partitionCount");
+    final int oldClusterSize = tc.draw(integers().min(2).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(2).max(100), "newClusterSize");
     shouldScaleBrokersAndPartitionsByCount(
         partitionCount,
         Optional.empty(),
@@ -84,11 +84,11 @@ final class ClusterScaleRequestTransformerTest {
         Optional.empty());
   }
 
-  @Property(tries = 10)
-  void shouldScaleBrokersWhenPartitionsUnchangedWhenZoned(
-      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
-      @ForAll @IntRange(min = 2, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 2, max = 100) final int newClusterSize) {
+  @HegelTest(testCases = 10)
+  void shouldScaleBrokersWhenPartitionsUnchangedWhenZoned(final TestCase tc) {
+    final int partitionCount = tc.draw(integers().min(1).max(100), "partitionCount");
+    final int oldClusterSize = tc.draw(integers().min(2).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(2).max(100), "newClusterSize");
     shouldScaleBrokersAndPartitionsByCount(
         partitionCount,
         Optional.empty(),
@@ -99,11 +99,11 @@ final class ClusterScaleRequestTransformerTest {
         Optional.of(ZONE_A));
   }
 
-  @Property(tries = 10)
-  void shouldScalePartitionsWhenClusterSizeUnchanged(
-      @ForAll @IntRange(min = 3, max = 100) final int clusterSize,
-      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+  @HegelTest(testCases = 10)
+  void shouldScalePartitionsWhenClusterSizeUnchanged(final TestCase tc) {
+    final int clusterSize = tc.draw(integers().min(3).max(100), "clusterSize");
+    final int oldPartitionCount = tc.draw(integers().min(1).max(10), "oldPartitionCount");
+    final int newPartitionCount = tc.draw(integers().min(10).max(20), "newPartitionCount");
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),
@@ -114,11 +114,11 @@ final class ClusterScaleRequestTransformerTest {
         Optional.empty());
   }
 
-  @Property(tries = 10)
-  void shouldScalePartitionsWhenClusterSizeUnchangedWhenZoned(
-      @ForAll @IntRange(min = 3, max = 100) final int clusterSize,
-      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+  @HegelTest(testCases = 10)
+  void shouldScalePartitionsWhenClusterSizeUnchangedWhenZoned(final TestCase tc) {
+    final int clusterSize = tc.draw(integers().min(3).max(100), "clusterSize");
+    final int oldPartitionCount = tc.draw(integers().min(1).max(10), "oldPartitionCount");
+    final int newPartitionCount = tc.draw(integers().min(10).max(20), "newPartitionCount");
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),
@@ -129,12 +129,12 @@ final class ClusterScaleRequestTransformerTest {
         Optional.of(ZONE_A));
   }
 
-  @Property(tries = 10)
-  void shouldChangeReplicationFactorWhenClusterSizeAndPartitionsUnchanged(
-      @ForAll @IntRange(min = 5, max = 10) final int clusterSize,
-      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
-      @ForAll @IntRange(min = 1, max = 5) final int oldReplicationFactor,
-      @ForAll @IntRange(min = 1, max = 5) final int newReplicationFactor) {
+  @HegelTest(testCases = 10)
+  void shouldChangeReplicationFactorWhenClusterSizeAndPartitionsUnchanged(final TestCase tc) {
+    final int clusterSize = tc.draw(integers().min(5).max(10), "clusterSize");
+    final int partitionCount = tc.draw(integers().min(1).max(100), "partitionCount");
+    final int oldReplicationFactor = tc.draw(integers().min(1).max(5), "oldReplicationFactor");
+    final int newReplicationFactor = tc.draw(integers().min(1).max(5), "newReplicationFactor");
     shouldScaleBrokersAndPartitionsByCount(
         partitionCount,
         Optional.empty(),
@@ -146,12 +146,12 @@ final class ClusterScaleRequestTransformerTest {
         Optional.empty());
   }
 
-  @Property(tries = 10)
-  void shouldScaleBrokersAndPartitions(
-      @ForAll @IntRange(min = 3, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 3, max = 100) final int newClusterSize,
-      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+  @HegelTest(testCases = 10)
+  void shouldScaleBrokersAndPartitions(final TestCase tc) {
+    final int oldClusterSize = tc.draw(integers().min(3).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(3).max(100), "newClusterSize");
+    final int oldPartitionCount = tc.draw(integers().min(1).max(10), "oldPartitionCount");
+    final int newPartitionCount = tc.draw(integers().min(10).max(20), "newPartitionCount");
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),
@@ -162,12 +162,12 @@ final class ClusterScaleRequestTransformerTest {
         Optional.of(ZONE_A));
   }
 
-  @Property(tries = 10)
-  void shouldScaleBrokersAndPartitionsWhenZoned(
-      @ForAll @IntRange(min = 3, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 3, max = 100) final int newClusterSize,
-      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+  @HegelTest(testCases = 10)
+  void shouldScaleBrokersAndPartitionsWhenZoned(final TestCase tc) {
+    final int oldClusterSize = tc.draw(integers().min(3).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(3).max(100), "newClusterSize");
+    final int oldPartitionCount = tc.draw(integers().min(1).max(10), "oldPartitionCount");
+    final int newPartitionCount = tc.draw(integers().min(10).max(20), "newPartitionCount");
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),
@@ -178,14 +178,14 @@ final class ClusterScaleRequestTransformerTest {
         Optional.of(ZONE_A));
   }
 
-  @Property(tries = 10)
-  void shouldScaleBrokersAndPartitionsAndChangeReplicationFactor(
-      @ForAll @IntRange(min = 5, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 5, max = 100) final int newClusterSize,
-      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount,
-      @ForAll @IntRange(min = 1, max = 5) final int oldReplicationFactor,
-      @ForAll @IntRange(min = 1, max = 5) final int newReplicationFactor) {
+  @HegelTest(testCases = 10)
+  void shouldScaleBrokersAndPartitionsAndChangeReplicationFactor(final TestCase tc) {
+    final int oldClusterSize = tc.draw(integers().min(5).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(5).max(100), "newClusterSize");
+    final int oldPartitionCount = tc.draw(integers().min(1).max(10), "oldPartitionCount");
+    final int newPartitionCount = tc.draw(integers().min(10).max(20), "newPartitionCount");
+    final int oldReplicationFactor = tc.draw(integers().min(1).max(5), "oldReplicationFactor");
+    final int newReplicationFactor = tc.draw(integers().min(1).max(5), "newReplicationFactor");
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformerTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.dynamic.config.api;
 import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -19,9 +21,6 @@ import io.camunda.zeebe.dynamic.config.util.MemberIdArbitraries;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Comparator;
 import java.util.Set;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.domains.Domain;
 import org.junit.jupiter.api.Test;
 
 class RemoveMembersTransformerTest {
@@ -78,10 +77,10 @@ class RemoveMembersTransformerTest {
     assertThat(result.get()).isEmpty();
   }
 
-  @Property(tries = 100)
-  @Domain(MemberIdArbitraries.class)
-  void shouldSortOperationsByMemberId(@ForAll final Set<MemberId> candidateMembers) {
+  @HegelTest(testCases = 100)
+  void shouldSortOperationsByMemberId(final TestCase tc) {
     // given
+    final var candidateMembers = tc.draw(MemberIdArbitraries.memberIds(), "candidateMembers");
     final var removeRequest = new RemoveMembersTransformer(candidateMembers);
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static dev.hegel.Generators.integers;
 import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperations;
 import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
@@ -55,11 +58,6 @@ import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import net.jqwik.api.EdgeCasesMode;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.ShrinkingMode;
-import net.jqwik.api.constraints.IntRange;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -83,61 +81,61 @@ class ScaleRequestTransformerTest {
         .toList();
   }
 
-  @Property(tries = 10)
-  void shouldScaleAndReassignWithReplicationFactor1(
-      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
-      @ForAll @IntRange(min = 1, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 1, max = 100) final int newClusterSize) {
+  @HegelTest(testCases = 10)
+  void shouldScaleAndReassignWithReplicationFactor1(final TestCase tc) {
+    final int partitionCount = tc.draw(integers().min(1).max(100), "partitionCount");
+    final int oldClusterSize = tc.draw(integers().min(1).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(1).max(100), "newClusterSize");
     shouldScaleAndReassign(partitionCount, 1, oldClusterSize, newClusterSize);
   }
 
-  @Property(tries = 10)
-  void shouldScaleAndReassignWithReplicationFactor2(
-      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
-      @ForAll @IntRange(min = 2, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 2, max = 100) final int newClusterSize) {
+  @HegelTest(testCases = 10)
+  void shouldScaleAndReassignWithReplicationFactor2(final TestCase tc) {
+    final int partitionCount = tc.draw(integers().min(1).max(100), "partitionCount");
+    final int oldClusterSize = tc.draw(integers().min(2).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(2).max(100), "newClusterSize");
     shouldScaleAndReassign(partitionCount, 2, oldClusterSize, newClusterSize);
   }
 
-  @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
-  void shouldScaleAndReassignWithReplicationFactor3(
-      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
-      @ForAll @IntRange(min = 3, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 3, max = 100) final int newClusterSize) {
+  @HegelTest(testCases = 10)
+  void shouldScaleAndReassignWithReplicationFactor3(final TestCase tc) {
+    final int partitionCount = tc.draw(integers().min(1).max(100), "partitionCount");
+    final int oldClusterSize = tc.draw(integers().min(3).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(3).max(100), "newClusterSize");
     shouldScaleAndReassign(partitionCount, 3, oldClusterSize, newClusterSize);
   }
 
-  @Property(tries = 10)
-  void shouldScaleAndReassignWithReplicationFactor4(
-      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
-      @ForAll @IntRange(min = 4, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 4, max = 100) final int newClusterSize) {
+  @HegelTest(testCases = 10)
+  void shouldScaleAndReassignWithReplicationFactor4(final TestCase tc) {
+    final int partitionCount = tc.draw(integers().min(1).max(100), "partitionCount");
+    final int oldClusterSize = tc.draw(integers().min(4).max(100), "oldClusterSize");
+    final int newClusterSize = tc.draw(integers().min(4).max(100), "newClusterSize");
     shouldScaleAndReassign(partitionCount, 4, oldClusterSize, newClusterSize);
   }
 
-  @Property
-  void shouldFailIfClusterSizeLessThanReplicationFactor3(
-      @ForAll @IntRange(min = 0, max = 2) final int newClusterSize) {
+  @HegelTest
+  void shouldFailIfClusterSizeLessThanReplicationFactor3(final TestCase tc) {
+    final int newClusterSize = tc.draw(integers().min(0).max(2), "newClusterSize");
     shouldFailIfClusterSizeLessThanReplicationFactor(3, 3, 3, newClusterSize);
   }
 
-  @Property
-  void shouldFailIfClusterSizeLessThanReplicationFactor4(
-      @ForAll @IntRange(min = 0, max = 3) final int newClusterSize) {
+  @HegelTest
+  void shouldFailIfClusterSizeLessThanReplicationFactor4(final TestCase tc) {
+    final int newClusterSize = tc.draw(integers().min(0).max(3), "newClusterSize");
     shouldFailIfClusterSizeLessThanReplicationFactor(12, 4, 6, newClusterSize);
   }
 
-  @Property
-  void shouldFailIfDesiredPartitionCountIsLessThanNewPartitions(
-      @ForAll @IntRange(min = 1, max = 100) final int currentPartitionCount,
-      @ForAll @IntRange(min = 1, max = 100) final int desiredPartitionCount) {
+  @HegelTest
+  void shouldFailIfDesiredPartitionCountIsLessThanNewPartitions(final TestCase tc) {
+    final int currentPartitionCount = tc.draw(integers().min(1).max(100), "currentPartitionCount");
+    final int desiredPartitionCount = tc.draw(integers().min(1).max(100), "desiredPartitionCount");
     scaleUpWithValidation(currentPartitionCount, desiredPartitionCount, null);
   }
 
-  @Property
-  void shouldGenerateScaleUpOperationForAllPartition1Members(
-      @ForAll @IntRange(min = 1, max = 100) final int currentPartitionCount,
-      @ForAll @IntRange(min = 1, max = 100) final int newPartitionCount) {
+  @HegelTest
+  void shouldGenerateScaleUpOperationForAllPartition1Members(final TestCase tc) {
+    final int currentPartitionCount = tc.draw(integers().min(1).max(100), "currentPartitionCount");
+    final int newPartitionCount = tc.draw(integers().min(1).max(100), "newPartitionCount");
     final var desiredPartitionCount = currentPartitionCount + newPartitionCount;
     scaleUpWithValidation(
         currentPartitionCount,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationJsonSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationJsonSerializerPropertyTest.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.dynamic.config.serializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.Generator;
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
@@ -17,10 +20,6 @@ import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.util.ClusterTopologyDomain;
 import java.util.Map;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.domains.Domain;
-import net.jqwik.api.domains.DomainContext;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,14 +34,17 @@ final class ClusterConfigurationJsonSerializerPropertyTest {
   private static final String EQUALITY_HINT =
       """
       Configuration read back from JSON must equal the one written.
-      If both look the same, compare the collection types: jqwik generates sorted sets and maps, and \
-      a reader that builds unsorted ones yields an unequal-but-identical-looking configuration.""";
+      If both look the same, compare the collection types: the generators build sorted sets and maps, \
+      and a reader that builds unsorted ones yields an unequal-but-identical-looking configuration.""";
 
-  @Property(tries = 100)
-  @Domain(ClusterTopologyDomain.class)
-  @Domain(DomainContext.Global.class)
-  void shouldWriteAndReadBackAnyConfiguration(
-      @ForAll final CurrentClusterConfiguration configuration) {
+  private static final Generator<CurrentClusterConfiguration> CONFIGURATIONS =
+      ClusterTopologyDomain.currentClusterConfigurations();
+
+  @HegelTest(testCases = 100)
+  void shouldWriteAndReadBackAnyConfiguration(final TestCase tc) {
+    // given
+    final var configuration = tc.draw(CONFIGURATIONS, "configuration");
+
     // when
     final var json = ClusterConfigurationJsonSerializer.toJson(configuration);
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
@@ -9,28 +9,31 @@ package io.camunda.zeebe.dynamic.config.serializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.Generator;
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.util.ClusterTopologyDomain;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.domains.Domain;
-import net.jqwik.api.domains.DomainContext;
 
 final class ProtoBufSerializerPropertyTest {
+
+  private static final Generator<ClusterConfiguration> CLUSTER_CONFIGURATIONS =
+      ClusterTopologyDomain.clusterTopologies();
+  private static final Generator<CurrentClusterConfiguration> CURRENT_CLUSTER_CONFIGURATIONS =
+      ClusterTopologyDomain.currentClusterConfigurations();
 
   private static final String COLLECTION_EQUALITY_HINT =
       """
       Decoded configuration must be equal to the initial one.
       If this fails even though both objects look the same, make sure to take defensive copies of collections in the config and its nested types.
-      jqwik tends to generate sorted sets and maps which are not equal to the unsorted collections created on deserialization.""";
+      The generators build sorted sets and maps which are not equal to the unsorted collections created on deserialization.""";
 
-  @Property(tries = 100)
-  @Domain(ClusterTopologyDomain.class)
-  @Domain(DomainContext.Global.class)
-  void shouldEncodeAndDecode(@ForAll final ClusterConfiguration clusterConfiguration) {
+  @HegelTest(testCases = 100)
+  void shouldEncodeAndDecode(final TestCase tc) {
     // given
+    final var clusterConfiguration = tc.draw(CLUSTER_CONFIGURATIONS, "clusterConfiguration");
     final ClusterConfigurationGossipState gossipState = new ClusterConfigurationGossipState();
     gossipState.setClusterConfiguration(clusterConfiguration);
     final var protoBufSerializer = new ProtoBufSerializer();
@@ -44,12 +47,10 @@ final class ProtoBufSerializerPropertyTest {
         .isEqualTo(clusterConfiguration);
   }
 
-  @Property(tries = 100)
-  @Domain(ClusterTopologyDomain.class)
-  @Domain(DomainContext.Global.class)
-  void shouldEncodeAndDecodeCurrentClusterConfiguration(
-      @ForAll final CurrentClusterConfiguration configuration) {
+  @HegelTest(testCases = 100)
+  void shouldEncodeAndDecodeCurrentClusterConfiguration(final TestCase tc) {
     // given
+    final var configuration = tc.draw(CURRENT_CLUSTER_CONFIGURATIONS, "configuration");
     final var protoBufSerializer = new ProtoBufSerializer();
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static dev.hegel.Generators.integers;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
@@ -19,9 +22,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.constraints.IntRange;
 
 /**
  * Property-based tests for {@link AdditivePartitionReassigner}, in the style of {@code
@@ -41,12 +41,13 @@ final class AdditivePartitionReassignerPropertyTest {
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
   private final AdditivePartitionReassigner reassigner = new AdditivePartitionReassigner();
 
-  @Property(tries = 50)
-  void shouldSatisfyDistributionInvariantsWhenAddingPartitions(
-      @ForAll @IntRange(min = 1, max = 4) final int replicationFactor,
-      @ForAll @IntRange(min = 0, max = 10) final int extraMembers,
-      @ForAll @IntRange(min = 1, max = 30) final int oldPartitionCount,
-      @ForAll @IntRange(min = 0, max = 20) final int additionalPartitionCount) {
+  @HegelTest(testCases = 50)
+  void shouldSatisfyDistributionInvariantsWhenAddingPartitions(final TestCase tc) {
+    final int replicationFactor = tc.draw(integers().min(1).max(4), "replicationFactor");
+    final int extraMembers = tc.draw(integers().min(0).max(10), "extraMembers");
+    final int oldPartitionCount = tc.draw(integers().min(1).max(30), "oldPartitionCount");
+    final int additionalPartitionCount =
+        tc.draw(integers().min(0).max(20), "additionalPartitionCount");
     final int clusterSize = replicationFactor + extraMembers;
     final Set<MemberId> targetMembers = members(clusterSize);
     final int newPartitionCount = oldPartitionCount + additionalPartitionCount;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -7,6 +7,21 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static dev.hegel.Generators.composite;
+import static dev.hegel.Generators.fromRegex;
+import static dev.hegel.Generators.integers;
+import static dev.hegel.Generators.lists;
+import static dev.hegel.Generators.longs;
+import static dev.hegel.Generators.maps;
+import static dev.hegel.Generators.oneOf;
+import static dev.hegel.Generators.optional;
+import static dev.hegel.Generators.records;
+import static dev.hegel.Generators.sampledFrom;
+import static dev.hegel.Generators.sets;
+import static dev.hegel.Generators.text;
+
+import dev.hegel.Generator;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
@@ -38,13 +53,12 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.dynamic.config.state.TenantAvailability;
-import io.camunda.zeebe.util.ReflectUtil;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -54,75 +68,57 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.Provide;
-import net.jqwik.api.domains.DomainContextBase;
-import net.jqwik.api.providers.ArbitraryProvider;
-import net.jqwik.api.providers.TypeUsage;
-import net.jqwik.api.support.CollectorsSupport;
-import net.jqwik.time.api.DateTimes;
 
 /**
- * Contains all arbitraries needed to generate a {@link ClusterConfiguration}. The topology is not
+ * Contains all generators needed to generate a {@link ClusterConfiguration}. The topology is not
  * semantically correct (e.g. contains operations for members that don't exist) but all fields
  * should have valid values.
  */
-public final class ClusterTopologyDomain extends DomainContextBase {
+public final class ClusterTopologyDomain {
 
-  @Provide
-  Arbitrary<ClusterConfiguration> clusterTopologies() {
-    // Combine arbitraries (instead of just using `Arbitraries.forType(ClusterTopology.class)`
-    // here so that we have control over the version. Version must be greater than 0 for
+  private static final DerivedGenerators PLAIN = new DerivedGenerators(Map.of());
+
+  /**
+   * Derivation for types whose components include the model's value types. Deriving those from the
+   * type alone would either fail (they are not records) or produce values their constructors
+   * reject.
+   */
+  private static final DerivedGenerators DERIVED =
+      new DerivedGenerators(
+          Map.of(
+              MemberId.class, memberIds(),
+              Instant.class, nanoPrecisionInstants(),
+              PartitionDistributorConfig.class, partitionDistributorConfig(),
+              DynamicPartitionConfig.class, dynamicPartitionConfigs(),
+              RoutingState.class, routingStates()));
+
+  private ClusterTopologyDomain() {}
+
+  public static Generator<ClusterConfiguration> clusterTopologies() {
+    // Combine generators (instead of just deriving from `ClusterConfiguration.class`) so that we
+    // have control over the version. Version must be greater than 0 for
     // `ClusterTopology#isUninitialized` to return false.
-    final var arbitraryVersion = Arbitraries.integers().greaterOrEqual(0);
-    final var arbitraryMembers =
-        Arbitraries.maps(memberIds(), Arbitraries.forType(MemberState.class).enableRecursion())
-            .ofMaxSize(10);
-    final var arbitraryCompletedChange =
-        Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
-    final var arbitraryChangePlan =
-        Arbitraries.forType(ClusterChangePlan.class)
-            .enableRecursion()
-            .<ChangePlan>map(plan -> plan)
-            .optional();
-    final var arbitraryRoutingState = routingStates().optional();
-    final var arbitraryClusterId = Arbitraries.strings().ofMinLength(1).ofMaxLength(50).optional();
-    final var arbitraryIncarnationNumber = Arbitraries.longs().greaterOrEqual(0);
-    return Combinators.combine(
-            arbitraryVersion,
-            arbitraryMembers,
-            arbitraryCompletedChange,
-            arbitraryChangePlan,
-            arbitraryRoutingState,
-            arbitraryClusterId,
-            arbitraryIncarnationNumber)
-        .flatAs(
-            (version,
-                members,
-                lastChange,
-                pendingChanges,
-                routingState,
-                clusterId,
-                incarnationNumber) ->
-                partitionDistributorConfigs()
-                    .map(
-                        distributorConfig ->
-                            new ClusterConfiguration(
-                                version,
-                                members,
-                                lastChange,
-                                pendingChanges,
-                                routingState,
-                                clusterId,
-                                incarnationNumber,
-                                distributorConfig)));
+    final var members = maps(memberIds(), DERIVED.forType(MemberState.class)).maxSize(10);
+    final var completedChange = optional(DERIVED.forType(CompletedChange.class));
+    final var changePlan =
+        optional(DERIVED.forType(ClusterChangePlan.class).<ChangePlan>map(plan -> plan));
+    final var routingState = optional(routingStates());
+    final var clusterId = optional(text().minSize(1).maxSize(50));
+    return composite(
+        tc ->
+            new ClusterConfiguration(
+                tc.draw(integers().min(0)),
+                tc.draw(members),
+                tc.draw(completedChange),
+                tc.draw(changePlan),
+                tc.draw(routingState),
+                tc.draw(clusterId),
+                tc.draw(longs().min(0)),
+                tc.draw(partitionDistributorConfigs())));
   }
 
-  @Provide
-  Arbitrary<PartitionDistributorConfig> partitionDistributorConfig() {
-    return Arbitraries.of(
+  public static Generator<PartitionDistributorConfig> partitionDistributorConfig() {
+    return sampledFrom(
         new PartitionDistributorConfig.RoundRobinConfig(),
         new PartitionDistributorConfig.FixedConfig(),
         new PartitionDistributorConfig.ZoneAwareConfig(
@@ -140,9 +136,8 @@ public final class ClusterTopologyDomain extends DomainContextBase {
             List.of(new PartitionDistributorConfig.ZoneSpec("zone-a", 2, 1000))));
   }
 
-  @Provide
-  Arbitrary<Optional<PartitionDistributorConfig>> partitionDistributorConfigs() {
-    return Arbitraries.of(
+  public static Generator<Optional<PartitionDistributorConfig>> partitionDistributorConfigs() {
+    return sampledFrom(
         Optional.empty(),
         Optional.of(new PartitionDistributorConfig.RoundRobinConfig()),
         Optional.of(new PartitionDistributorConfig.FixedConfig()),
@@ -153,204 +148,174 @@ public final class ClusterTopologyDomain extends DomainContextBase {
                     new PartitionDistributorConfig.ZoneSpec("zone-b", 1, 500)))));
   }
 
-  @Provide
-  Arbitrary<RoutingState> routingStates() {
-    final var version = Arbitraries.longs().greaterOrEqual(0);
-    return Combinators.combine(version, requestHandling(), messageCorrelation())
-        .as(RoutingState::new);
+  public static Generator<RoutingState> routingStates() {
+    final var requestHandling = requestHandling();
+    final var messageCorrelation = messageCorrelation();
+    return composite(
+        tc ->
+            new RoutingState(
+                tc.draw(longs().min(0)), tc.draw(requestHandling), tc.draw(messageCorrelation)));
   }
 
-  @Provide
-  Arbitrary<RequestHandling> requestHandling() {
-    return Arbitraries.oneOf(
-        allPartitions().map(RequestHandling.class::cast),
-        activePartitions().map(RequestHandling.class::cast));
+  public static Generator<RequestHandling> requestHandling() {
+    return oneOf(allPartitions(), activePartitions());
   }
 
-  @Provide
-  Arbitrary<AllPartitions> allPartitions() {
-    return Arbitraries.integers().between(1, 5).map(AllPartitions::new);
+  public static Generator<AllPartitions> allPartitions() {
+    return integers().min(1).max(5).map(AllPartitions::new);
   }
 
-  @Provide
-  Arbitrary<ActivePartitions> activePartitions() {
-    final var basePartitionCount = Arbitraries.integers().between(1, 3);
-    final var activePartitions = Arbitraries.integers().between(4, 8).list().map(TreeSet::new);
-    final var inactivePartitions = Arbitraries.integers().between(9, 12).list().map(TreeSet::new);
-
-    return Combinators.combine(basePartitionCount, activePartitions, inactivePartitions)
-        .as(ActivePartitions::new);
+  public static Generator<ActivePartitions> activePartitions() {
+    final var activePartitions = lists(integers().min(4).max(8));
+    final var inactivePartitions = lists(integers().min(9).max(12));
+    return composite(
+        tc ->
+            new ActivePartitions(
+                tc.draw(integers().min(1).max(3)),
+                new TreeSet<>(tc.draw(activePartitions)),
+                new TreeSet<>(tc.draw(inactivePartitions))));
   }
 
-  @Provide
-  Arbitrary<MessageCorrelation> messageCorrelation() {
-    return Arbitraries.of(
-            ReflectUtil.implementationsOfSealedInterface(MessageCorrelation.class).toList())
-        .flatMap(Arbitraries::forType);
+  public static Generator<MessageCorrelation> messageCorrelation() {
+    final var hashMods = records(HashMod.class).with("partitionCount", integers().min(1));
+    return new DerivedGenerators(Map.of(HashMod.class, hashMods)).forType(MessageCorrelation.class);
   }
 
-  @Provide
-  Arbitrary<ClusterConfigurationChangeOperation> topologyChangeOperations() {
-    // jqwik does not support sealed classes yet, so we have to use reflection to get all possible
-    // types. See https://github.com/jqwik-team/jqwik/issues/523
-    return Arbitraries.of(
-            ReflectUtil.implementationsOfSealedInterface(ClusterConfigurationChangeOperation.class)
-                .toList())
-        .flatMap(Arbitraries::forType);
+  public static Generator<ClusterConfigurationChangeOperation> topologyChangeOperations() {
+    return DERIVED.forType(ClusterConfigurationChangeOperation.class);
   }
 
-  @Provide
-  Arbitrary<MemberId> memberIds() {
-    return Arbitraries.integers().greaterOrEqual(0).map(id -> MemberId.from(id.toString()));
+  public static Generator<MemberId> memberIds() {
+    return integers().min(0).map(id -> MemberId.from(id.toString()));
   }
 
-  @Provide
-  Arbitrary<DynamicPartitionConfig> dynamicPartitionConfigs() {
-    return Arbitraries.forType(ExportingConfig.class)
-        .enableRecursion()
-        .map(DynamicPartitionConfig::new)
-        .filter(DynamicPartitionConfig::isInitialized);
+  public static Generator<DynamicPartitionConfig> dynamicPartitionConfigs() {
+    return PLAIN.forType(ExportingConfig.class).map(DynamicPartitionConfig::new);
   }
 
   // ---- New multi-partition-group model (8.10) ----
 
-  @Provide
-  Arbitrary<CurrentClusterConfiguration> currentClusterConfigurations() {
+  public static Generator<CurrentClusterConfiguration> currentClusterConfigurations() {
+    final var global = globalConfigurations();
     final var partitionGroups =
-        Arbitraries.maps(partitionGroupIds(), partitionGroupConfigurations()).ofMaxSize(4);
-    return Combinators.combine(globalConfigurations(), partitionGroups, phasedChangeStates())
-        .as(
-            (global, groups, phasedChangeState) ->
-                // version is always INITIAL_VERSION and reserved; it is not used in merge.
-                new CurrentClusterConfiguration(
-                    CurrentClusterConfiguration.INITIAL_VERSION,
-                    global,
-                    groups,
-                    phasedChangeState));
+        maps(partitionGroupIds(), partitionGroupConfigurations()).maxSize(4);
+    final var phasedChangeState = phasedChangeStates();
+    return composite(
+        tc ->
+            // version is always INITIAL_VERSION and reserved; it is not used in merge.
+            new CurrentClusterConfiguration(
+                CurrentClusterConfiguration.INITIAL_VERSION,
+                tc.draw(global),
+                tc.draw(partitionGroups),
+                tc.draw(phasedChangeState)));
   }
 
-  @Provide
-  Arbitrary<GlobalConfiguration> globalConfigurations() {
-    final var version = Arbitraries.longs().greaterOrEqual(0);
+  public static Generator<GlobalConfiguration> globalConfigurations() {
     // clusterId must be non-empty: the serializer treats the empty string as "absent".
-    final var clusterId = Arbitraries.strings().ofMinLength(1).ofMaxLength(50).optional();
-    final var members = Arbitraries.maps(memberIds(), brokerStates()).ofMaxSize(6);
+    final var clusterId = optional(text().minSize(1).maxSize(50));
+    final var members = maps(memberIds(), brokerStates()).maxSize(6);
     // Cluster-wide changes run as graphs too, so this is the only plan shape generated here.
-    final Arbitrary<Optional<DependencyChangePlan>> pendingChanges =
-        globalDependencyChangePlans().optional();
-    final var lastChange = Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
-    return Combinators.combine(
-            version, clusterId, members, partitionDistributorConfigs(), pendingChanges, lastChange)
-        .as(
-            (v, cid, m, distributor, pending, last) ->
-                new GlobalConfiguration(v, cid, m, distributor, pending, last));
+    final var pendingChanges = optional(globalDependencyChangePlans());
+    final var lastChange = optional(DERIVED.forType(CompletedChange.class));
+    return composite(
+        tc ->
+            new GlobalConfiguration(
+                tc.draw(longs().min(0)),
+                tc.draw(clusterId),
+                tc.draw(members),
+                tc.draw(partitionDistributorConfigs()),
+                tc.draw(pendingChanges),
+                tc.draw(lastChange)));
   }
 
-  @Provide
-  Arbitrary<PartitionGroupConfiguration> partitionGroupConfigurations() {
-    final var version = Arbitraries.longs().greaterOrEqual(0);
-    final var incarnationNumber = Arbitraries.longs().greaterOrEqual(0);
-    final var members = Arbitraries.maps(memberIds(), brokerPartitionStates()).ofMaxSize(6);
-    final var routingState = routingStates().optional();
+  public static Generator<PartitionGroupConfiguration> partitionGroupConfigurations() {
+    final var members = maps(memberIds(), brokerPartitionStates()).maxSize(6);
+    final var routingState = optional(routingStates());
     // A group's change is always a dependency graph, so this is the only plan shape generated here.
-    final Arbitrary<Optional<DependencyChangePlan>> pendingChanges =
-        dependencyChangePlans().optional();
-    final var lastChange = Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
+    final var pendingChanges = optional(dependencyChangePlans());
+    final var lastChange = optional(DERIVED.forType(CompletedChange.class));
     final var availability = tenantAvailabilities();
-    return Combinators.combine(
-            version,
-            incarnationNumber,
-            members,
-            routingState,
-            pendingChanges,
-            lastChange,
-            availability)
-        .as(
-            (v, inc, m, routing, pending, last, tenantAvailability) ->
-                new PartitionGroupConfiguration(
-                    v, inc, m, routing, pending, last, tenantAvailability));
+    return composite(
+        tc ->
+            new PartitionGroupConfiguration(
+                tc.draw(longs().min(0)),
+                tc.draw(longs().min(0)),
+                tc.draw(members),
+                tc.draw(routingState),
+                tc.draw(pendingChanges),
+                tc.draw(lastChange),
+                tc.draw(availability)));
   }
 
-  @Provide
-  Arbitrary<TenantAvailability> tenantAvailabilities() {
-    final var version = Arbitraries.longs().greaterOrEqual(0);
-    final var state = Arbitraries.of(TenantAvailability.State.values());
-    return Combinators.combine(version, state).as(TenantAvailability::new);
+  public static Generator<TenantAvailability> tenantAvailabilities() {
+    final var state = sampledFrom(TenantAvailability.State.values());
+    return composite(tc -> new TenantAvailability(tc.draw(longs().min(0)), tc.draw(state)));
   }
 
-  @Provide
-  Arbitrary<BrokerState> brokerStates() {
-    final var version = Arbitraries.longs().greaterOrEqual(0);
-    final var state = Arbitraries.of(BrokerState.State.values());
-    return Combinators.combine(version, nanoPrecisionInstants(), state)
-        .as((v, lastUpdated, s) -> new BrokerState(v, lastUpdated, s));
+  public static Generator<BrokerState> brokerStates() {
+    final var state = sampledFrom(BrokerState.State.values());
+    return composite(
+        tc ->
+            new BrokerState(
+                tc.draw(longs().min(0)), tc.draw(nanoPrecisionInstants()), tc.draw(state)));
   }
 
-  @Provide
-  Arbitrary<BrokerPartitionState> brokerPartitionStates() {
-    final var version = Arbitraries.longs().greaterOrEqual(0);
+  public static Generator<BrokerPartitionState> brokerPartitionStates() {
     final var partitions =
-        Arbitraries.maps(
-                Arbitraries.integers().between(1, 20),
-                Arbitraries.forType(PartitionState.class).enableRecursion())
-            .ofMaxSize(4);
-    final var mode = Arbitraries.of(Mode.values());
-    return Combinators.combine(version, nanoPrecisionInstants(), partitions, mode)
-        .as((v, lastUpdated, p, m) -> new BrokerPartitionState(v, lastUpdated, p, m));
+        maps(integers().min(1).max(20), DERIVED.forType(PartitionState.class)).maxSize(4);
+    final var mode = sampledFrom(Mode.values());
+    return composite(
+        tc ->
+            new BrokerPartitionState(
+                tc.draw(longs().min(0)),
+                tc.draw(nanoPrecisionInstants()),
+                tc.draw(partitions),
+                tc.draw(mode)));
   }
 
-  @Provide
-  Arbitrary<PhasedChangeState> phasedChangeStates() {
+  public static Generator<PhasedChangeState> phasedChangeStates() {
     // History ids are reassigned sequentially from 0, and an optional pending plan (if any) gets
     // the next id after that — this keeps every id below nextId, satisfying PhasedChangeState's
     // invariant, while still exercising arbitrary statuses/timestamps/phases via the existing
     // completedPhasedChanges()/phases() generators.
-    final var rawHistory = completedPhasedChanges().list().ofMaxSize(3);
-    final var maybePhaseList = phases().list().ofMinSize(1).ofMaxSize(4).optional();
-    return Combinators.combine(rawHistory, maybePhaseList, nanoPrecisionInstants())
-        .flatAs(
-            (raw, maybePhases, pendingStartedAt) -> {
-              final List<CompletedPhasedChange> history = new ArrayList<>();
-              for (int i = 0; i < raw.size(); i++) {
-                final var c = raw.get(i);
-                history.add(
-                    new CompletedPhasedChange(i, c.status(), c.startedAt(), c.completedAt()));
-              }
-              final long pendingId = Math.max(history.size(), PhasedChangePlan.INITIAL_PLAN_ID);
-              if (maybePhases.isEmpty()) {
-                return Arbitraries.just(new PhasedChangeState(pendingId, Map.of(), history));
-              }
-              final var phaseList = maybePhases.get();
-              return Arbitraries.integers()
-                  .between(0, phaseList.size() - 1)
-                  .map(
-                      index -> {
-                        final var plan =
-                            new PhasedChangePlan(pendingId, index, phaseList, pendingStartedAt);
-                        return new PhasedChangeState(
-                            pendingId + 1, Map.of(pendingId, plan), history);
-                      });
-            });
+    final var rawHistory = lists(completedPhasedChanges()).maxSize(3);
+    final var maybePhaseList = optional(lists(phases()).minSize(1).maxSize(4));
+    return composite(
+        tc -> {
+          final List<CompletedPhasedChange> history = new ArrayList<>();
+          final var raw = tc.draw(rawHistory);
+          for (int i = 0; i < raw.size(); i++) {
+            final var c = raw.get(i);
+            history.add(new CompletedPhasedChange(i, c.status(), c.startedAt(), c.completedAt()));
+          }
+          final long pendingId = Math.max(history.size(), PhasedChangePlan.INITIAL_PLAN_ID);
+          final var maybePhases = tc.draw(maybePhaseList);
+          if (maybePhases.isEmpty()) {
+            return new PhasedChangeState(pendingId, Map.of(), history);
+          }
+          final var phaseList = maybePhases.get();
+          final var index = tc.draw(integers().min(0).max(phaseList.size() - 1));
+          final var plan =
+              new PhasedChangePlan(pendingId, index, phaseList, tc.draw(nanoPrecisionInstants()));
+          return new PhasedChangeState(pendingId + 1, Map.of(pendingId, plan), history);
+        });
   }
 
-  @Provide
-  Arbitrary<Phase> phases() {
-    final Arbitrary<Phase> globalPhases =
-        globalChangeOperations().list().ofMaxSize(3).<Phase>map(GlobalPhase::new);
+  public static Generator<Phase> phases() {
+    final Generator<Phase> globalPhases =
+        lists(globalChangeOperations()).maxSize(3).<Phase>map(GlobalPhase::new);
     // Each group's own operation list must be non-empty: PartitionGroupPhase.sequential builds an
     // OperationGraph per group, and OperationGraph.of rejects an empty one -- the same invariant
     // operationGraphs() below already respects.
-    final Arbitrary<Phase> sequentialGroupPhases =
-        Arbitraries.maps(
-                partitionGroupIds(),
-                partitionGroupChangeOperations().list().ofMinSize(1).ofMaxSize(3))
-            .ofMaxSize(3)
+    final Generator<Phase> sequentialGroupPhases =
+        maps(partitionGroupIds(), lists(partitionGroupChangeOperations()).minSize(1).maxSize(3))
+            .maxSize(3)
             .<Phase>map(PartitionGroupPhase::sequential);
-    final Arbitrary<Phase> graphGroupPhases =
-        Arbitraries.maps(partitionGroupIds(), operationGraphs())
-            .ofMaxSize(3)
+    final Generator<Phase> graphGroupPhases =
+        maps(partitionGroupIds(), operationGraphs())
+            .maxSize(3)
             .<Phase>map(PartitionGroupPhase::new);
-    return Arbitraries.oneOf(globalPhases, sequentialGroupPhases, graphGroupPhases);
+    return oneOf(globalPhases, sequentialGroupPhases, graphGroupPhases);
   }
 
   /**
@@ -360,13 +325,9 @@ public final class ClusterTopologyDomain extends DomainContextBase {
    * construction, with no rejection sampling needed to keep {@link OperationGraph#of} from
    * throwing.
    */
-  @Provide
-  Arbitrary<OperationGraph> operationGraphs() {
-    return partitionGroupChangeOperations()
-        .list()
-        .ofMinSize(1)
-        .ofMaxSize(4)
-        .flatMap(ClusterTopologyDomain::operationGraphOf);
+  public static Generator<OperationGraph> operationGraphs() {
+    final var operations = lists(partitionGroupChangeOperations()).minSize(1).maxSize(4);
+    return composite(tc -> operationGraphOf(tc, tc.draw(operations)));
   }
 
   /**
@@ -375,40 +336,25 @@ public final class ClusterTopologyDomain extends DomainContextBase {
    * different arms of {@code PlannedOperation}'s oneof, and a round-trip property fed only
    * partition-group operations would never exercise the other one.
    */
-  @Provide
-  Arbitrary<OperationGraph> globalOperationGraphs() {
-    return globalChangeOperations()
-        .list()
-        .ofMinSize(1)
-        .ofMaxSize(4)
-        .flatMap(ClusterTopologyDomain::operationGraphOf);
+  public static Generator<OperationGraph> globalOperationGraphs() {
+    final var operations = lists(globalChangeOperations()).minSize(1).maxSize(4);
+    return composite(tc -> operationGraphOf(tc, tc.draw(operations)));
   }
 
-  private static Arbitrary<OperationGraph> operationGraphOf(
-      final List<? extends ClusterConfigurationChangeOperation> operations) {
-    final List<Arbitrary<Set<Integer>>> dependsOnPerIndex = new ArrayList<>();
+  private static OperationGraph operationGraphOf(
+      final TestCase tc, final List<? extends ClusterConfigurationChangeOperation> operations) {
+    final SortedMap<OperationId, OperationGraph.PlannedOperation> planned = new TreeMap<>();
     for (int i = 0; i < operations.size(); i++) {
-      dependsOnPerIndex.add(
-          i == 0
-              ? Arbitraries.just(Set.of())
-              : Arbitraries.integers().between(0, i - 1).set().ofMaxSize(i));
+      final Set<Integer> dependsOnIndexes =
+          i == 0 ? Set.of() : tc.draw(sets(integers().min(0).max(i - 1)).maxSize(i));
+      final SortedSet<OperationId> dependsOn = new TreeSet<>();
+      for (final var index : dependsOnIndexes) {
+        dependsOn.add(OperationId.of(index));
+      }
+      planned.put(
+          OperationId.of(i), new OperationGraph.PlannedOperation(operations.get(i), dependsOn));
     }
-    return Combinators.combine(dependsOnPerIndex)
-        .as(
-            dependsOnByIndex -> {
-              final SortedMap<OperationId, OperationGraph.PlannedOperation> planned =
-                  new TreeMap<>();
-              for (int i = 0; i < operations.size(); i++) {
-                final SortedSet<OperationId> dependsOn = new TreeSet<>();
-                for (final var index : dependsOnByIndex.get(i)) {
-                  dependsOn.add(OperationId.of(index));
-                }
-                planned.put(
-                    OperationId.of(i),
-                    new OperationGraph.PlannedOperation(operations.get(i), dependsOn));
-              }
-              return OperationGraph.of(planned);
-            });
+    return OperationGraph.of(planned);
   }
 
   /**
@@ -417,138 +363,77 @@ public final class ClusterTopologyDomain extends DomainContextBase {
    * graph, which is the shape every real plan has and the one round-trip/merge/decode tests need to
    * see exercised.
    */
-  @Provide
-  Arbitrary<DependencyChangePlan> dependencyChangePlans() {
+  public static Generator<DependencyChangePlan> dependencyChangePlans() {
     return dependencyChangePlansOver(operationGraphs());
   }
 
-  @Provide
-  Arbitrary<DependencyChangePlan> globalDependencyChangePlans() {
+  public static Generator<DependencyChangePlan> globalDependencyChangePlans() {
     return dependencyChangePlansOver(globalOperationGraphs());
   }
 
-  private Arbitrary<DependencyChangePlan> dependencyChangePlansOver(
-      final Arbitrary<OperationGraph> graphs) {
-    final var id = Arbitraries.longs().between(0, 500);
-    final var status = Arbitraries.of(ClusterChangePlan.Status.values());
-    return Combinators.combine(id, status, nanoPrecisionInstants(), graphs)
-        .as(PartialDependencyChangePlan::new)
-        .flatMap(ClusterTopologyDomain::withCompletedOperations);
+  private static Generator<DependencyChangePlan> dependencyChangePlansOver(
+      final Generator<OperationGraph> graphs) {
+    final var status = sampledFrom(ClusterChangePlan.Status.values());
+    return composite(
+        tc -> {
+          final long id = tc.draw(longs().min(0).max(500));
+          final var planStatus = tc.draw(status);
+          final var startedAt = tc.draw(nanoPrecisionInstants());
+          final var graph = tc.draw(graphs);
+          final var ids = new ArrayList<>(graph.operations().keySet());
+          final var pickedIds = tc.draw(sets(sampledFrom(ids)).maxSize(ids.size()));
+          // An operation counts as complete only once everything it depends on is: no
+          // execution can produce any other combination, and DependencyChangePlan rejects
+          // one outright. Ids ascend with dependency order (see operationGraphs()), so a
+          // single ascending pass suffices -- a picked operation whose dependencies were not
+          // themselves picked is simply not reached yet, and is dropped.
+          //
+          // Each completion gets its own instant, derived from the operation id so it stays
+          // reproducible. Reusing startedAt for all of them would make every generated plan
+          // share the shape an encoder bug produces -- writing startedAt in place of each
+          // operation's real completion instant -- and the round-trip property could then
+          // never tell the bug from the fixture.
+          final SortedMap<OperationId, Instant> completed = new TreeMap<>();
+          for (final var operationId : ids) {
+            final var plannedOperation = graph.operations().get(operationId);
+            if (pickedIds.contains(operationId)
+                && completed.keySet().containsAll(plannedOperation.dependsOn())) {
+              completed.put(operationId, startedAt.plusMillis(1L + operationId.value()));
+            }
+          }
+          return new DependencyChangePlan(id, planStatus, startedAt, graph, completed);
+        });
   }
 
-  private static Arbitrary<DependencyChangePlan> withCompletedOperations(
-      final PartialDependencyChangePlan partial) {
-    final var ids = new ArrayList<>(partial.graph().operations().keySet());
-    return Arbitraries.of(ids)
-        .set()
-        .ofMaxSize(ids.size())
-        .map(
-            pickedIds -> {
-              // An operation counts as complete only once everything it depends on is: no
-              // execution can produce any other combination, and DependencyChangePlan rejects
-              // one outright. Ids ascend with dependency order (see operationGraphs()), so a
-              // single ascending pass suffices -- a picked operation whose dependencies were not
-              // themselves picked is simply not reached yet, and is dropped.
-              //
-              // Each completion gets its own instant, derived from the operation id so it stays
-              // reproducible. Reusing startedAt for all of them would make every generated plan
-              // share the shape an encoder bug produces -- writing startedAt in place of each
-              // operation's real completion instant -- and the round-trip property could then
-              // never tell the bug from the fixture.
-              final SortedMap<OperationId, Instant> completed = new TreeMap<>();
-              for (final var operationId : ids) {
-                final var planned = partial.graph().operations().get(operationId);
-                if (pickedIds.contains(operationId)
-                    && completed.keySet().containsAll(planned.dependsOn())) {
-                  completed.put(
-                      operationId, partial.startedAt().plusMillis(1L + operationId.value()));
-                }
-              }
-              return new DependencyChangePlan(
-                  partial.id(), partial.status(), partial.startedAt(), partial.graph(), completed);
-            });
+  public static Generator<CompletedPhasedChange> completedPhasedChanges() {
+    final var status = sampledFrom(PhasedChangePlanStatus.values());
+    return composite(
+        tc ->
+            new CompletedPhasedChange(
+                tc.draw(longs().min(0).max(500)),
+                tc.draw(status),
+                tc.draw(nanoPrecisionInstants()),
+                tc.draw(nanoPrecisionInstants())));
   }
 
-  @Provide
-  Arbitrary<CompletedPhasedChange> completedPhasedChanges() {
-    final var id = Arbitraries.longs().between(0, 500);
-    final var status = Arbitraries.of(PhasedChangePlanStatus.values());
-    return Combinators.combine(id, status, nanoPrecisionInstants(), nanoPrecisionInstants())
-        .as(
-            (planId, s, startedAt, completedAt) ->
-                new CompletedPhasedChange(planId, s, startedAt, completedAt));
+  public static Generator<GlobalChangeOperation> globalChangeOperations() {
+    return DERIVED.forType(GlobalChangeOperation.class);
   }
 
-  @Provide
-  Arbitrary<GlobalChangeOperation> globalChangeOperations() {
-    return Arbitraries.of(
-            ReflectUtil.implementationsOfSealedInterface(GlobalChangeOperation.class).toList())
-        .flatMap(Arbitraries::forType);
+  public static Generator<PartitionGroupOperation> partitionGroupChangeOperations() {
+    return DERIVED.forType(PartitionGroupOperation.class);
   }
 
-  @Provide
-  Arbitrary<PartitionGroupOperation> partitionGroupChangeOperations() {
-    return Arbitraries.of(
-            ReflectUtil.implementationsOfSealedInterface(PartitionGroupOperation.class).toList())
-        .flatMap(Arbitraries::forType);
+  public static Generator<String> partitionGroupIds() {
+    return fromRegex("[a-zA-Z]{1,10}");
   }
 
-  @Provide
-  Arbitrary<String> partitionGroupIds() {
-    return Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10);
+  /** Nanosecond-precision instants. */
+  public static Generator<Instant> nanoPrecisionInstants() {
+    return composite(
+        tc ->
+            Instant.ofEpochSecond(
+                tc.draw(longs().min(0).max(4_000_000_000L)),
+                tc.draw(integers().min(0).max(999_999_999))));
   }
-
-  /** Nanosecond-precision instants. The default precision in jqwik is seconds. */
-  @Provide
-  Arbitrary<Instant> nanoPrecisionInstants() {
-    return DateTimes.instants()
-        .between(Instant.ofEpochSecond(0), Instant.ofEpochSecond(4_000_000_000L))
-        .ofPrecision(ChronoUnit.NANOS);
-  }
-
-  @SuppressWarnings("unused")
-  static class SortedMapArbitraryProvider implements ArbitraryProvider {
-    @Override
-    public boolean canProvideFor(final TypeUsage targetType) {
-      return targetType.isAssignableFrom(SortedMap.class);
-    }
-
-    @Override
-    public Set<Arbitrary<?>> provideFor(
-        final TypeUsage targetType, final SubtypeProvider subtypeProvider) {
-      final TypeUsage keyType = targetType.getTypeArgument(0);
-      final TypeUsage valueType = targetType.getTypeArgument(1);
-
-      return subtypeProvider
-          .resolveAndCombine(keyType, valueType)
-          .map(
-              arbitraries -> {
-                final Arbitrary<?> keyArbitrary = arbitraries.get(0);
-                final Arbitrary<?> valueArbitrary = arbitraries.get(1);
-                return Arbitraries.maps(keyArbitrary, valueArbitrary).map(TreeMap::new);
-              })
-          .collect(CollectorsSupport.toLinkedHashSet());
-    }
-  }
-
-  @SuppressWarnings("unused")
-  static class SortedSetArbitraryProvider implements ArbitraryProvider {
-    @Override
-    public boolean canProvideFor(final TypeUsage targetType) {
-      return targetType.isAssignableFrom(SortedSet.class);
-    }
-
-    @Override
-    public Set<Arbitrary<?>> provideFor(
-        final TypeUsage targetType, final SubtypeProvider subtypeProvider) {
-      final TypeUsage elementType = targetType.getTypeArgument(0);
-      final Set<Arbitrary<?>> elementArbitraries = subtypeProvider.apply(elementType);
-      return elementArbitraries.stream()
-          .map(arbitrary -> arbitrary.set().map(TreeSet::new))
-          .collect(CollectorsSupport.toLinkedHashSet());
-    }
-  }
-
-  private record PartialDependencyChangePlan(
-      long id, ClusterChangePlan.Status status, Instant startedAt, OperationGraph graph) {}
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/DerivedGenerators.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/DerivedGenerators.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static dev.hegel.Generators.lists;
+import static dev.hegel.Generators.maps;
+import static dev.hegel.Generators.optional;
+import static dev.hegel.Generators.sets;
+
+import dev.hegel.Generator;
+import dev.hegel.Generators;
+import dev.hegel.generators.RecordGenerator;
+import io.camunda.zeebe.util.ReflectUtil;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Derives generators for the configuration state model by reflection, on top of what {@link
+ * Generators#forType} supports: sealed interfaces generate any of their (transitively) permitted
+ * implementations, sorted collections are generated as such, and record components whose type has a
+ * registered generator use that one. Deriving from the types keeps a newly added implementation of
+ * a sealed interface covered without touching the generators.
+ */
+final class DerivedGenerators {
+
+  private final Map<Class<?>, Generator<?>> registered;
+
+  DerivedGenerators(final Map<Class<?>, Generator<?>> registered) {
+    this.registered = Map.copyOf(registered);
+  }
+
+  @SuppressWarnings("unchecked")
+  <T> Generator<T> forType(final Class<T> type) {
+    return (Generator<T>) derive(type);
+  }
+
+  private Generator<?> derive(final Type type) {
+    if (type instanceof final ParameterizedType parameterized) {
+      return deriveParameterized(parameterized);
+    }
+    if (type instanceof final Class<?> cls) {
+      return deriveClass(cls);
+    }
+    throw new IllegalArgumentException("Cannot derive a generator for type " + type);
+  }
+
+  private Generator<?> deriveClass(final Class<?> cls) {
+    final var generator = registered.get(cls);
+    if (generator != null) {
+      return generator;
+    }
+    if (cls.isSealed()) {
+      final var implementations =
+          ReflectUtil.implementationsOfSealedInterface(cls).map(this::deriveClass).toList();
+      return Generators.oneOf(implementations.toArray(new Generator<?>[0]));
+    }
+    if (cls.isRecord()) {
+      RecordGenerator<?> records = Generators.records(cls);
+      for (final var component : cls.getRecordComponents()) {
+        records = records.with(component.getName(), derive(component.getGenericType()));
+      }
+      return records;
+    }
+    return Generators.forType(cls);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Generator<?> deriveParameterized(final ParameterizedType type) {
+    final var raw = (Class<?>) type.getRawType();
+    final var arguments = type.getActualTypeArguments();
+    final var first = (Generator<Object>) derive(arguments[0]);
+    if (raw == SortedMap.class) {
+      return maps(first, (Generator<Object>) derive(arguments[1])).map(TreeMap::new);
+    }
+    if (raw == SortedSet.class) {
+      return sets(first).map(TreeSet::new);
+    }
+    if (raw == List.class) {
+      return lists(first);
+    }
+    if (raw == Set.class) {
+      return sets(first);
+    }
+    if (raw == Map.class) {
+      return maps(first, (Generator<Object>) derive(arguments[1]));
+    }
+    if (raw == Optional.class) {
+      return optional(first);
+    }
+    throw new IllegalArgumentException("Cannot derive a generator for generic type " + type);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/MemberIdArbitraries.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/MemberIdArbitraries.java
@@ -7,28 +7,33 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static dev.hegel.Generators.composite;
+import static dev.hegel.Generators.integers;
+import static dev.hegel.Generators.oneOf;
+import static dev.hegel.Generators.sampledFrom;
+import static dev.hegel.Generators.sets;
+
+import dev.hegel.Generator;
 import io.atomix.cluster.MemberId;
 import java.util.Set;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.Provide;
-import net.jqwik.api.domains.DomainContextBase;
 
-/** Arbitraries generating {@link MemberId}s that are valid according to its constructors. */
-public final class MemberIdArbitraries extends DomainContextBase {
+/** Generators for {@link MemberId}s that are valid according to its constructors. */
+public final class MemberIdArbitraries {
 
-  @Provide
-  Arbitrary<MemberId> memberId() {
-    final var nonZoned = Arbitraries.integers().between(0, 50).map(MemberId::from);
-    final var zone = Arbitraries.of("zone-a", "zone-b", "zone-c", "region1");
-    final var nodeIdx = Arbitraries.integers().between(0, 50);
-    final var zoned = Combinators.combine(zone, nodeIdx).as(MemberId::from);
-    return Arbitraries.oneOf(nonZoned, zoned);
+  private MemberIdArbitraries() {}
+
+  public static Generator<MemberId> memberId() {
+    final Generator<MemberId> nonZoned = integers().min(0).max(50).map(MemberId::from);
+    final Generator<MemberId> zoned =
+        composite(
+            tc ->
+                MemberId.from(
+                    tc.draw(sampledFrom("zone-a", "zone-b", "zone-c", "region1")),
+                    tc.draw(integers().min(0).max(50))));
+    return oneOf(nonZoned, zoned);
   }
 
-  @Provide
-  Arbitrary<Set<MemberId>> memberIds() {
-    return memberId().set().ofMaxSize(20);
+  public static Generator<Set<MemberId>> memberIds() {
+    return sets(memberId()).maxSize(20);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RandomizedRoundRobinDistribution2RegionTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RandomizedRoundRobinDistribution2RegionTest.java
@@ -7,24 +7,24 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static dev.hegel.Generators.integers;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.constraints.IntRange;
 
 public class RandomizedRoundRobinDistribution2RegionTest {
 
-  @Property(tries = 10)
-  void shouldDistributedPartitionsEquallyIn2Regions(
-      @ForAll @IntRange(min = 2, max = 100) final int clusterSizeFactor,
-      @ForAll @IntRange(min = 1, max = 200) final int partitionCount) {
+  @HegelTest(testCases = 10)
+  void shouldDistributedPartitionsEquallyIn2Regions(final TestCase tc) {
+    final int clusterSizeFactor = tc.draw(integers().min(2).max(100), "clusterSizeFactor");
+    final int partitionCount = tc.draw(integers().min(1).max(200), "partitionCount");
     // cluster size should be always multiple of 2 for a 2-region deployment
     final var clusterSize = 2 * clusterSizeFactor;
     allPartitionHaveTwoReplicasInEachRegion(clusterSize, partitionCount);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassignerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassignerPropertyTest.java
@@ -7,8 +7,12 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static dev.hegel.Generators.booleans;
+import static dev.hegel.Generators.integers;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
@@ -22,9 +26,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.constraints.IntRange;
 
 /**
  * Property-based tests for {@link ZoneAwareAdditivePartitionReassigner}, in the style of {@link
@@ -50,18 +51,19 @@ final class ZoneAwareAdditivePartitionReassignerPropertyTest {
 
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
-  @Property(tries = 100)
-  void shouldSatisfyDistributionInvariantsWhenAddingPartitions(
-      @ForAll @IntRange(min = 2, max = 3) final int zoneCount,
-      @ForAll @IntRange(min = 1, max = 4) final int zoneAReplicas,
-      @ForAll @IntRange(min = 1, max = 4) final int zoneBReplicas,
-      @ForAll @IntRange(min = 1, max = 4) final int zoneCReplicas,
-      @ForAll @IntRange(min = 0, max = 4) final int zoneAExtraBrokers,
-      @ForAll @IntRange(min = 0, max = 4) final int zoneBExtraBrokers,
-      @ForAll @IntRange(min = 0, max = 4) final int zoneCExtraBrokers,
-      @ForAll final boolean topZonesTied,
-      @ForAll @IntRange(min = 1, max = 15) final int oldPartitionCount,
-      @ForAll @IntRange(min = 0, max = 15) final int additionalPartitionCount) {
+  @HegelTest(testCases = 100)
+  void shouldSatisfyDistributionInvariantsWhenAddingPartitions(final TestCase tc) {
+    final int zoneCount = tc.draw(integers().min(2).max(3), "zoneCount");
+    final int zoneAReplicas = tc.draw(integers().min(1).max(4), "zoneAReplicas");
+    final int zoneBReplicas = tc.draw(integers().min(1).max(4), "zoneBReplicas");
+    final int zoneCReplicas = tc.draw(integers().min(1).max(4), "zoneCReplicas");
+    final int zoneAExtraBrokers = tc.draw(integers().min(0).max(4), "zoneAExtraBrokers");
+    final int zoneBExtraBrokers = tc.draw(integers().min(0).max(4), "zoneBExtraBrokers");
+    final int zoneCExtraBrokers = tc.draw(integers().min(0).max(4), "zoneCExtraBrokers");
+    final boolean topZonesTied = tc.draw(booleans(), "topZonesTied");
+    final int oldPartitionCount = tc.draw(integers().min(1).max(15), "oldPartitionCount");
+    final int additionalPartitionCount =
+        tc.draw(integers().min(0).max(15), "additionalPartitionCount");
     final List<ZoneSpec> zoneSpecs =
         buildZoneSpecs(zoneCount, zoneAReplicas, zoneBReplicas, zoneCReplicas, topZonesTied);
     final int replicationFactor = zoneSpecs.stream().mapToInt(ZoneSpec::numberOfReplicas).sum();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributorTest.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static dev.hegel.Generators.integers;
 import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
@@ -24,9 +27,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.constraints.IntRange;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -284,11 +284,11 @@ final class ZoneAwarePartitionDistributorTest {
     assertThat(result).isEqualTo(expected);
   }
 
-  @Property(tries = 25)
-  void shouldEqualPlainRoundRobinForAnyFullyBareCluster(
-      @ForAll @IntRange(min = 2, max = 30) final int replicationFactor,
-      @ForAll @IntRange(min = 0, max = 30) final int extraBrokers,
-      @ForAll @IntRange(min = 1, max = 30) final int partitionCount) {
+  @HegelTest(testCases = 25)
+  void shouldEqualPlainRoundRobinForAnyFullyBareCluster(final TestCase tc) {
+    final int replicationFactor = tc.draw(integers().min(2).max(30), "replicationFactor");
+    final int extraBrokers = tc.draw(integers().min(0).max(30), "extraBrokers");
+    final int partitionCount = tc.draw(integers().min(1).max(30), "partitionCount");
     // given — two zones whose replicas sum to the replication factor, distinct priorities so the
     // zone-aware path would normally engage, and a fully bare cluster with at least RF brokers.
     final var zoneAReplicas = (replicationFactor + 1) / 2;

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -145,8 +145,8 @@
     </dependency>
 
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik-api</artifactId>
+      <groupId>dev.hegel</groupId>
+      <artifactId>hegel-jna</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadataTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadataTest.java
@@ -7,8 +7,12 @@
  */
 package io.camunda.zeebe.logstreams.impl.log;
 
+import static dev.hegel.Generators.sampledFrom;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.Generator;
+import dev.hegel.HegelTest;
+import dev.hegel.TestCase;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -17,20 +21,28 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.Arrays;
 import java.util.List;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 
 final class LogAppendEntryMetadataTest {
 
-  @Property
-  void shouldCopyMetadata(
-      @ForAll("recordTypes") final RecordType recordType,
-      @ForAll("valueTypes") final ValueType valueType,
-      @ForAll("intents") final Intent intent) {
+  private static final Generator<RecordType> RECORD_TYPES =
+      sampledFrom(
+          Arrays.stream(RecordType.values()).filter(v -> v != RecordType.SBE_UNKNOWN).toList());
+  private static final Generator<ValueType> VALUE_TYPES =
+      sampledFrom(
+          Arrays.stream(ValueType.values()).filter(v -> v != ValueType.SBE_UNKNOWN).toList());
+  private static final Generator<Intent> INTENTS =
+      sampledFrom(
+          Intent.INTENT_CLASSES.stream()
+              .<Intent>flatMap(clazz -> Arrays.stream(clazz.getEnumConstants()))
+              .distinct()
+              .toList());
+
+  @HegelTest
+  void shouldCopyMetadata(final TestCase tc) {
     // given
+    final var recordType = tc.draw(RECORD_TYPES, "recordType");
+    final var valueType = tc.draw(VALUE_TYPES, "valueType");
+    final var intent = tc.draw(INTENTS, "intent");
     final var compatibleIntent = Intent.fromProtocolValue(valueType, intent.value());
     final var entries = List.of(createEntry(recordType, valueType, compatibleIntent));
 
@@ -49,26 +61,5 @@ final class LogAppendEntryMetadataTest {
     final var metadata =
         new RecordMetadata().recordType(recordType).valueType(valueType).intent(intent);
     return LogAppendEntry.of(metadata, new UnifiedRecordValue(0));
-  }
-
-  @Provide
-  Arbitrary<RecordType> recordTypes() {
-    return Arbitraries.of(
-        Arrays.stream(RecordType.values()).filter(v -> v != RecordType.SBE_UNKNOWN).toList());
-  }
-
-  @Provide
-  Arbitrary<ValueType> valueTypes() {
-    return Arbitraries.of(
-        Arrays.stream(ValueType.values()).filter(v -> v != ValueType.SBE_UNKNOWN).toList());
-  }
-
-  @Provide
-  Arbitrary<Intent> intents() {
-    return Arbitraries.of(
-        Intent.INTENT_CLASSES.stream()
-            .flatMap(clazz -> Arrays.stream(clazz.getEnumConstants()))
-            .distinct()
-            .toList());
   }
 }

--- a/zeebe/rebalance/pom.xml
+++ b/zeebe/rebalance/pom.xml
@@ -91,7 +91,6 @@
     </dependency>
 
     <dependency>
-      <!--  Ensure non-jqwik junit5 tests can be run -->
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/zeebe/zb-db/pom.xml
+++ b/zeebe/zb-db/pom.xml
@@ -73,8 +73,8 @@
     </dependency>
 
     <dependency>
-      <groupId>net.jqwik</groupId>
-      <artifactId>jqwik-api</artifactId>
+      <groupId>dev.hegel</groupId>
+      <artifactId>hegel-jna</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
@@ -7,8 +7,15 @@
  */
 package io.camunda.zeebe.db.impl;
 
+import static dev.hegel.Generators.longs;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.hegel.HegelTest;
+import dev.hegel.Invariant;
+import dev.hegel.OptBoolean;
+import dev.hegel.Rule;
+import dev.hegel.Stateful;
+import dev.hegel.TestCase;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
@@ -16,25 +23,17 @@ import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
-import net.jqwik.api.arbitraries.ListArbitrary;
-import net.jqwik.api.lifecycle.AfterProperty;
-import net.jqwik.api.lifecycle.AfterTry;
-import net.jqwik.api.lifecycle.BeforeProperty;
 import org.assertj.core.util.Files;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class ColumnFamilyRandomizedPropertyTest {
 
-  private Map<Long, Long> map;
   private ColumnFamily<DbLong, DbLong> columnFamily;
   private ZeebeDb<DefaultColumnFamily> zeebeDb;
 
-  @BeforeProperty
-  private void setup() {
+  @BeforeEach
+  void setup() {
     final var pathName = Files.newTemporaryFolder();
     final ZeebeDbFactory<DefaultColumnFamily> dbFactory = DefaultZeebeDbFactory.getDefaultFactory();
     zeebeDb = dbFactory.createDb(pathName);
@@ -42,159 +41,85 @@ public class ColumnFamilyRandomizedPropertyTest {
     columnFamily =
         zeebeDb.createColumnFamily(
             DefaultColumnFamily.DEFAULT, zeebeDb.createContext(), new DbLong(), new DbLong());
-    map = new HashMap<>();
   }
 
-  @Property
-  void columnFamilyHasSameEntriesAsMapAfterModifying(
-      @ForAll("operations") final Iterable<TestableOperation> operations) {
-    operations.forEach(op -> op.apply(map));
-    operations.forEach(op -> op.apply(columnFamily));
-    assertEqualEntries(columnFamily, map);
-  }
-
-  @AfterTry
-  private void cleanup() {
-    columnFamily.forEach((k, v) -> columnFamily.deleteExisting(k));
-    map.clear();
-  }
-
-  @AfterProperty
-  private void teardown() throws Exception {
+  @AfterEach
+  void teardown() throws Exception {
     zeebeDb.close();
   }
 
-  @Provide
-  ListArbitrary<TestableOperation> operations() {
-    final var op =
-        Arbitraries.of(
-            InsertOp.class,
-            UpdateOp.class,
-            UpsertOp.class,
-            DeleteExisting.class,
-            DeleteIfExists.class);
-    final var k = Arbitraries.longs().greaterOrEqual(0);
-    final var v = Arbitraries.longs();
-    return Combinators.combine(op, k, v)
-        .as(
-            (arbitraryOp, arbitraryK, arbitraryV) -> {
-              try {
-                return (TestableOperation)
-                    arbitraryOp
-                        .getDeclaredConstructor(long.class, long.class)
-                        .newInstance(arbitraryK, arbitraryV);
-              } catch (final Exception e) {
-                throw new RuntimeException(e);
-              }
-            })
-        .list();
-  }
-
-  private void assertEqualEntries(
-      final ColumnFamily<DbLong, DbLong> columnFamily, final Map<Long, Long> map) {
-    map.forEach(
-        (key, value) -> {
-          final var dbKey = new DbLong();
-          dbKey.wrapLong(key);
-          assertThat(columnFamily.get(dbKey))
-              .as("Key " + dbKey.getValue() + " should exist ")
-              .isNotNull()
-              .as("Key " + dbKey.getValue() + " should have value " + value)
-              .extracting(DbLong::getValue)
-              .isEqualTo(value);
-        });
-    columnFamily.forEach(
-        (key, value) -> assertThat(map).containsEntry(key.getValue(), value.getValue()));
-  }
-
-  record InsertOp(long key, long value) implements TestableOperation {
-
-    @Override
-    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
-      return columnFamily::insert;
-    }
-
-    @Override
-    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
-      return map::putIfAbsent;
+  @HegelTest(derandomize = OptBoolean.FALSE)
+  void columnFamilyHasSameEntriesAsMapAfterModifying(final TestCase tc) {
+    try {
+      Stateful.run(new ColumnFamilyModel(), tc);
+    } finally {
+      columnFamily.forEach((k, v) -> columnFamily.deleteExisting(k));
     }
   }
 
-  record UpdateOp(long key, long value) implements TestableOperation {
+  /** Drives the column family and a plain map with the same operations, expecting them to agree. */
+  private final class ColumnFamilyModel {
+    private final Map<Long, Long> map = new HashMap<>();
 
-    @Override
-    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
-      return columnFamily::update;
+    @Rule
+    void insert(final TestCase tc) {
+      apply(tc, columnFamily::insert, map::putIfAbsent);
     }
 
-    @Override
-    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
-      return (k, newValue) -> map.computeIfPresent(k, (k1, oldValue) -> newValue);
-    }
-  }
-
-  record UpsertOp(long key, long value) implements TestableOperation {
-
-    @Override
-    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
-      return columnFamily::upsert;
+    @Rule
+    void update(final TestCase tc) {
+      apply(tc, columnFamily::update, (k, v) -> map.computeIfPresent(k, (k1, oldValue) -> v));
     }
 
-    @Override
-    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
-      return map::put;
-    }
-  }
-
-  record DeleteIfExists(long key, long value) implements TestableOperation {
-
-    @Override
-    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
-      return (k, v) -> columnFamily.deleteIfExists(k);
+    @Rule
+    void upsert(final TestCase tc) {
+      apply(tc, columnFamily::upsert, map::put);
     }
 
-    @Override
-    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
-      return (k, v) -> map.remove(k);
-    }
-  }
-
-  record DeleteExisting(long key, long value) implements TestableOperation {
-
-    @Override
-    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
-      return (k, v) -> columnFamily.deleteExisting(k);
+    @Rule
+    void deleteExisting(final TestCase tc) {
+      apply(tc, (k, v) -> columnFamily.deleteExisting(k), (k, v) -> map.remove(k));
     }
 
-    @Override
-    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
-      return (k, v) -> map.remove(k);
+    @Rule
+    void deleteIfExists(final TestCase tc) {
+      apply(tc, (k, v) -> columnFamily.deleteIfExists(k), (k, v) -> map.remove(k));
     }
-  }
 
-  interface TestableOperation {
-    long key();
+    @Invariant
+    void hasSameEntriesAsMap(final TestCase tc) {
+      map.forEach(
+          (key, value) -> {
+            final var dbKey = new DbLong();
+            dbKey.wrapLong(key);
+            assertThat(columnFamily.get(dbKey))
+                .as("Key " + dbKey.getValue() + " should exist ")
+                .isNotNull()
+                .as("Key " + dbKey.getValue() + " should have value " + value)
+                .extracting(DbLong::getValue)
+                .isEqualTo(value);
+          });
+      columnFamily.forEach(
+          (key, value) -> assertThat(map).containsEntry(key.getValue(), value.getValue()));
+    }
 
-    long value();
+    private void apply(
+        final TestCase tc,
+        final BiConsumer<DbLong, DbLong> columnFamilyOperation,
+        final BiConsumer<Long, Long> mapOperation) {
+      final long key = tc.draw(longs().min(0), "key");
+      final long value = tc.draw(longs(), "value");
+      mapOperation.accept(key, value);
 
-    BiConsumer<DbLong, DbLong> modify(ColumnFamily<DbLong, DbLong> columnFamily);
-
-    BiConsumer<Long, Long> modify(Map<Long, Long> map);
-
-    default void apply(final ColumnFamily<DbLong, DbLong> columnFamily) {
       final var dbKey = new DbLong();
       final var dbValue = new DbLong();
-      dbKey.wrapLong(key());
-      dbValue.wrapLong(value());
+      dbKey.wrapLong(key);
+      dbValue.wrapLong(value);
       try {
-        modify(columnFamily).accept(dbKey, dbValue);
+        columnFamilyOperation.accept(dbKey, dbValue);
       } catch (final RuntimeException e) {
-        assertThat(e).hasRootCauseInstanceOf(ZeebeDbInconsistentException.class);
+        assertThat(e).isInstanceOf(ZeebeDbInconsistentException.class);
       }
-    }
-
-    default void apply(final Map<Long, Long> map) {
-      modify(map).accept(key(), value());
     }
   }
 }


### PR DESCRIPTION
## Description

Replaces jqwik with [Hegel](https://hegel.dev) (`dev.hegel:hegel-jna`) for all
property-based tests.

**Disclosure:** I work at Antithesis, which develops Hegel, and I maintain
`hegel-java`. I have no commercial interest in Camunda adopting it; the
motivation is the jqwik prompt-injection issue below and the two property tests
that turned out never to run. Hegel is Apache-2.0 licensed, and jqwik can be
kept or restored if the team prefers a different route (for example pinning
jqwik below 1.10.0 as the issue proposes).

Hegel is a plain JUnit Jupiter extension, so the property tests are discovered
like any other test: no separate JUnit Platform engine, no per-module engine
dependency, no dependency-analyzer exceptions.

This also removes the jqwik 1.10.x build-stream prompt injection described in
the linked issue, since `parent/pom.xml` is already on 1.10.1 and no jqwik
artifact remains after this change.

Along the way it fixes a gap: `zb-db` and `logstreams` declared `jqwik-api`
without the jqwik engine, so `ColumnFamilyRandomizedPropertyTest` and
`LogAppendEntryMetadataTest` were never discovered and have never run. Both run
now. The former had a wrong assertion (expected wrapped inconsistency errors,
`runInTransaction` rethrows them unchanged) that is corrected here.

Reviewer notes on the less obvious choices:

- **Randomized raft tests draw one seed and derive their 10,000-step sequences
  from it** (`RandomSequence`). Drawing element by element overruns Hegel's
  per-case data budget. With the size health checks suppressed the run passes
  without executing a single case, so that route is not an option. Shrinking
  was already off for these tests under jqwik. They set `derandomize = FALSE`
  because Hegel derandomizes in CI and the `include-random-tests` profile
  exists to explore new sequences, and they suppress the too-slow health check
  because a single case takes seconds. Each case now logs its seed.
- **`DerivedGenerators`** (dynamic-config test util) derives generators for
  sealed interfaces, sorted collections and registered value types such as
  `MemberId` and `Instant`, which jqwik's `forType` resolved through domain
  `@Provide` methods and custom providers. New implementations of a sealed
  operation interface stay covered automatically.
- **`ColumnFamilyRandomizedPropertyTest`** is a Hegel stateful model test
  (`@Rule`/`@Invariant`).
- Explicit `tries` values are carried over as `testCases`; jqwik's 1000-try
  default maps to Hegel's default of 100.
- `.hegel/` (Hegel's local failure database, disabled in CI) replaces
  `.jqwik-database` in `.gitignore`.

Verification: all 19 ported test classes pass locally, including the
`include-random-tests` profile (131 raft cases, every case executed and
logged), plus spotless, license and dependency-analyzer checks and a full-repo
`./mvnw install -Dquickly`.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)). Not needed: test-only change on `main`.

## Related issues

relates to #54280