### PR TITLE
fix: prevent nodes misreading a half-created RDBMS schema as pre-versioning 8.9.0

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/schema-version-seed.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/schema-version-seed.xml
@@ -25,9 +25,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
   <!--
-    Same table as create_rdbms_schema_version_table in changesets/8.10.0.xml, created here first;
-    whichever run gets there first wins and the other marks its changeset ran. The master changelog
-    stays the definition of record — it always runs after this one, so it applies any later columns.
+    The same table as create_rdbms_schema_version_table in changesets/8.10.0.xml. Whichever run
+    reaches it first creates the table and the other marks its changeset ran, so the two definitions
+    have to stay identical. Neither can be edited once released anyway — Liquibase checksums make an
+    executed changeset immutable — so changing this table later means a new addColumn changeset in
+    changesets/, which applies however the table was created.
   -->
   <changeSet id="create_rdbms_schema_version_table_before_migration" author="camunda">
     <preConditions onFail="MARK_RAN">
@@ -47,18 +49,28 @@
 
   <!--
     Records 8.9.0 for a schema that predates version tracking — the one case the check cannot
-    otherwise know about, since an 8.9.x database carries no version row. DEPLOYED_RESOURCE is the
-    first table changesets/8.10.0.xml creates, so EXPORTER_POSITION without it means pre-8.10 code
-    built this schema. That signal is only trustworthy because the changelog lock is held here: a
-    fresh database has neither table yet and a migrated one has both, so both mark this ran.
+    otherwise know about, since an 8.9.x database carries no version row.
+
+    IDX_AUDIT_LOG_ACTOR_ID is the artifact of the last changeset in changesets/8.9.0.xml and shipped
+    before 8.9.0 GA, so its presence means every pre-8.10 changeset ran. DEPLOYED_RESOURCE is the
+    first table changesets/8.10.0.xml creates, so its absence means none of 8.10's did. Together
+    they identify a schema that pre-8.10 code finished, which a first migration interrupted part-way
+    is not — that one is left unseeded so the master run can resume it instead of being refused as
+    an upgrade that skips a minor. Presence is only a trustworthy signal at all because this runs
+    inside the changelog lock, where no peer can be part-way through creating what it reads.
+
+    The row count keeps the insert idempotent. Liquibase commits a changeset's changes before it
+    records the changeset, so a crash in between would otherwise retry into a primary-key violation
+    on ID = 1.
   -->
   <changeSet id="seed_pre_versioning_schema_version" author="camunda">
     <preConditions onFail="MARK_RAN">
       <and>
-        <tableExists tableName="${prefix}EXPORTER_POSITION"/>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_ACTOR_ID" tableName="${prefix}AUDIT_LOG"/>
         <not>
           <tableExists tableName="${prefix}DEPLOYED_RESOURCE"/>
         </not>
+        <sqlCheck expectedResult="0">SELECT COUNT(*) FROM ${prefix}RDBMS_SCHEMA_VERSION</sqlCheck>
       </and>
     </preConditions>
     <insert tableName="${prefix}RDBMS_SCHEMA_VERSION">

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/schema-version-seed.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/schema-version-seed.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--suppress LiquibaseXmlUnresolvedProperty -->
+<!--
+  ~ Records the schema version before the schema is migrated, so the compatibility check reads a
+  ~ version this schema recorded instead of inferring one from which tables currently exist.
+  ~
+  ~ Inferring was wrong for almost all of a first migration: EXPORTER_POSITION comes from changeset
+  ~ 1 and RDBMS_SCHEMA_VERSION 129 later, and that window is indistinguishable from a pre-versioning
+  ~ 8.9.x schema. Peers starting into it inferred 8.9.0, refused the upgrade as skipping a minor, and
+  ~ never exported that tenant again (#62554).
+  ~
+  ~ LiquibaseSchemaManager runs this on its own before the master run, so the check sees the seeded
+  ~ row and the legacy-or-fresh decision happens under the changelog lock. It is kept out of
+  ~ changelog-master.xml and changesets/, which LiquibaseScriptGenerator turns into shipped SQL.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <!--
+    Same table as create_rdbms_schema_version_table in changesets/8.10.0.xml, created here first;
+    whichever run gets there first wins and the other marks its changeset ran. The master changelog
+    stays the definition of record — it always runs after this one, so it applies any later columns.
+  -->
+  <changeSet id="create_rdbms_schema_version_table_before_migration" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}RDBMS_SCHEMA_VERSION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}RDBMS_SCHEMA_VERSION">
+      <column name="ID" type="SMALLINT" defaultValueNumeric="1">
+        <constraints nullable="false" primaryKey="true" checkConstraint="ID = 1"/>
+      </column>
+      <column name="VERSION" type="VARCHAR(32)">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+
+  <!--
+    Records 8.9.0 for a schema that predates version tracking — the one case the check cannot
+    otherwise know about, since an 8.9.x database carries no version row. DEPLOYED_RESOURCE is the
+    first table changesets/8.10.0.xml creates, so EXPORTER_POSITION without it means pre-8.10 code
+    built this schema. That signal is only trustworthy because the changelog lock is held here: a
+    fresh database has neither table yet and a migrated one has both, so both mark this ran.
+  -->
+  <changeSet id="seed_pre_versioning_schema_version" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <and>
+        <tableExists tableName="${prefix}EXPORTER_POSITION"/>
+        <not>
+          <tableExists tableName="${prefix}DEPLOYED_RESOURCE"/>
+        </not>
+      </and>
+    </preConditions>
+    <insert tableName="${prefix}RDBMS_SCHEMA_VERSION">
+      <column name="ID" valueNumeric="1"/>
+      <column name="VERSION" value="8.9.0"/>
+    </insert>
+  </changeSet>
+
+</databaseChangeLog>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/schema-version-seed.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/schema-version-seed.xml
@@ -48,25 +48,54 @@
   </changeSet>
 
   <!--
-    Records 8.9.0 for a schema that predates version tracking — the one case the check cannot
-    otherwise know about, since an 8.9.x database carries no version row.
+    The two changesets below record the version of a schema that predates version tracking — the one
+    case the check cannot otherwise know about, since an 8.9.x database carries no version row.
 
-    IDX_AUDIT_LOG_ACTOR_ID is the artifact of the last changeset in changesets/8.9.0.xml and shipped
-    before 8.9.0 GA, so its presence means every pre-8.10 changeset ran. DEPLOYED_RESOURCE is the
-    first table changesets/8.10.0.xml creates, so its absence means none of 8.10's did. Together
-    they identify a schema that pre-8.10 code finished, which a first migration interrupted part-way
-    is not — that one is left unseeded so the master run can resume it instead of being refused as
-    an upgrade that skips a minor. Presence is only a trustworthy signal at all because this runs
-    inside the changelog lock, where no peer can be part-way through creating what it reads.
+    Both demand a schema that pre-8.10 code left at a released state, which a migration interrupted
+    part-way is not. The master changelog applies 8.9.0.xml, then 8.9.9.xml, then 8.10.0.xml, so:
 
-    The row count keeps the insert idempotent. Liquibase commits a changeset's changes before it
+      - IDX_AUDIT_LOG_ACTOR_ID is the artifact of the last changeset in 8.9.0.xml, so its presence
+        means all of 8.9.0's changesets ran;
+      - FULL_RESULT and FULL_INPUT_VALUE are the first and last columns 8.9.9.xml adds, so they say
+        whether 8.9.9 finished or never started. Exactly one of them means a run died inside 8.9.9;
+        neither changeset then fires, and the master run resumes the schema instead of the upgrade
+        being refused as a skipped minor;
+      - DEPLOYED_RESOURCE is the first table 8.10.0.xml creates, so its absence means none of 8.10's
+        changesets ran.
+
+    A run interrupted exactly at a file boundary still reads as the release that ends there, because
+    it is byte-for-byte that schema. Only a recorded version separates those two, which is what this
+    changelog starts doing. Presence is a trustworthy signal at all only because this runs inside the
+    changelog lock, where no peer can be part-way through creating what it reads.
+
+    The row count keeps each insert idempotent — Liquibase commits a changeset's changes before it
     records the changeset, so a crash in between would otherwise retry into a primary-key violation
-    on ID = 1.
+    on ID = 1 — and it stops the second insert once the first has run.
   -->
+  <changeSet id="seed_completed_8_9_9_schema_version" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <and>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_ACTOR_ID" tableName="${prefix}AUDIT_LOG"/>
+        <columnExists tableName="${prefix}DECISION_INSTANCE_INPUT" columnName="FULL_INPUT_VALUE"/>
+        <not>
+          <tableExists tableName="${prefix}DEPLOYED_RESOURCE"/>
+        </not>
+        <sqlCheck expectedResult="0">SELECT COUNT(*) FROM ${prefix}RDBMS_SCHEMA_VERSION</sqlCheck>
+      </and>
+    </preConditions>
+    <insert tableName="${prefix}RDBMS_SCHEMA_VERSION">
+      <column name="ID" valueNumeric="1"/>
+      <column name="VERSION" value="8.9.9"/>
+    </insert>
+  </changeSet>
+
   <changeSet id="seed_pre_versioning_schema_version" author="camunda">
     <preConditions onFail="MARK_RAN">
       <and>
         <indexExists indexName="${prefix}IDX_AUDIT_LOG_ACTOR_ID" tableName="${prefix}AUDIT_LOG"/>
+        <not>
+          <columnExists tableName="${prefix}DECISION_INSTANCE" columnName="FULL_RESULT"/>
+        </not>
         <not>
           <tableExists tableName="${prefix}DEPLOYED_RESOURCE"/>
         </not>

--- a/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/SchemaVersionSeedCoverageTest.java
+++ b/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/SchemaVersionSeedCoverageTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import liquibase.Liquibase;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.DatabaseFactory;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards {@code schema-version-seed.xml} against a silent gap: nothing else stops a new 8.9.x patch
+ * changeset from being added to {@code changelog-master.xml} without also teaching the seed
+ * changelog to recognize a legacy database that finished it.
+ *
+ * <p>{@code schema-version-seed.xml}'s two seed changesets are hand-written against exactly the
+ * 8.9.x changesets that existed when it was authored ({@code 8.9.0.xml} and {@code 8.9.9.xml}):
+ * their preconditions fingerprint each changeset's boundary columns/indexes to tell a completed
+ * pre-8.10 schema apart from one interrupted mid-migration. A new {@code 8.9.x.xml} changeset
+ * inserted before {@code 8.10.0.xml} does not automatically get such a fingerprint — the seed file
+ * would keep classifying a legacy database that finished the new changeset as if it had only
+ * reached the previous one.
+ *
+ * <p>This test enumerates the 8.9.x changesets {@code changelog-master.xml} actually applies and
+ * compares them against the set the seed file is known to handle. It is a change detector, not a
+ * proof of correctness: adding a new 8.9.x changeset fails this test, which is the point — it
+ * forces a conscious look at {@code schema-version-seed.xml} (and its own test coverage) before the
+ * expected set here is updated to match.
+ */
+class SchemaVersionSeedCoverageTest {
+
+  private static final String MASTER_CHANGELOG = "db/changelog/rdbms-exporter/changelog-master.xml";
+
+  /** Matches only the pre-8.10, version-tracking-free changesets this seed file is about. */
+  private static final Pattern PRE_8_10_CHANGESET_FILE = Pattern.compile("8\\.9\\.\\d+\\.xml");
+
+  /**
+   * The 8.9.x changesets {@code schema-version-seed.xml} was written against: {@code 8.9.0.xml}
+   * (seeded as the pre-versioning version) and {@code 8.9.9.xml} (seeded once its last column
+   * exists). Update this set only after extending {@code schema-version-seed.xml} with a changeset
+   * that fingerprints the new file's boundary, and its own tests, to match.
+   */
+  private static final Set<String> CHANGESETS_HANDLED_BY_SEED = Set.of("8.9.0.xml", "8.9.9.xml");
+
+  @Test
+  void shouldHaveASeedChangesetForEveryPre810Changeset() throws Exception {
+    // given the changesets changelog-master.xml actually applies before version tracking begins
+    final var database = DatabaseFactory.getInstance().getDatabase("h2");
+    final var liquibase =
+        new Liquibase(MASTER_CHANGELOG, new ClassLoaderResourceAccessor(), database);
+    liquibase.setChangeLogParameter("prefix", "");
+    liquibase.setChangeLogParameter("userCharColumnSize", 4000);
+    liquibase.setChangeLogParameter("errorMessageSize", 4000);
+    liquibase.setChangeLogParameter("treePathSize", 4000);
+
+    // when collecting the distinct 8.9.x changeset files it includes
+    final var pre810ChangesetFiles = new TreeSet<String>();
+    for (final ChangeSet changeSet : liquibase.getDatabaseChangeLog().getChangeSets()) {
+      final var fileName = Path.of(changeSet.getFilePath()).getFileName().toString();
+      if (PRE_8_10_CHANGESET_FILE.matcher(fileName).matches()) {
+        pre810ChangesetFiles.add(fileName);
+      }
+    }
+
+    // then every one of them must be a changeset schema-version-seed.xml already knows how to
+    // recognize; a new file here without a matching update there (and here) is exactly the gap
+    // that let #62554 through the first time
+    assertThat(pre810ChangesetFiles)
+        .describedAs(
+            """
+            changelog-master.xml applies %s before 8.10.0.xml, but schema-version-seed.xml is only \
+            known to handle %s.
+            A new 8.9.x changeset needs its own seed changeset in schema-version-seed.xml \
+            (fingerprinting the columns/tables/indexes it adds, the way seed_completed_8_9_9_schema_version \
+            fingerprints 8.9.9.xml) before CHANGESETS_HANDLED_BY_SEED here is updated to match.""",
+            pre810ChangesetFiles, CHANGESETS_HANDLED_BY_SEED)
+        .isEqualTo(CHANGESETS_HANDLED_BY_SEED);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
@@ -54,6 +54,14 @@ public class LiquibaseSchemaManager implements RdbmsSchemaManager {
   private static final String CHANGE_LOG = "db/changelog/rdbms-exporter/changelog-master.xml";
 
   /**
+   * Applied as a run of its own before {@link #CHANGE_LOG}, and deliberately not included by it.
+   * See the changelog's own comment for why the schema version has to be recorded before the schema
+   * is migrated rather than inferred from it afterwards.
+   */
+  private static final String SCHEMA_VERSION_SEED_CHANGE_LOG =
+      "db/changelog/rdbms-exporter/schema-version-seed.xml";
+
+  /**
    * Forces Liquibase runs in this JVM to execute one at a time, because two of them overlapping
    * corrupts each other's lock bookkeeping — even against entirely separate databases.
    *
@@ -157,10 +165,30 @@ public class LiquibaseSchemaManager implements RdbmsSchemaManager {
     LOG.info("[RDBMS Schema] Running Liquibase migration with prefix '{}'.", prefix);
     final var runner = buildRunner();
     releaseStaleLockIfPresent();
+    seedSchemaVersion();
     versionStore.checkCompatibility();
     performMigrationWithRetry(runner);
     versionStore.recordCurrentVersion();
     LOG.debug("[RDBMS Schema] Liquibase migration completed for prefix '{}'.", prefix);
+  }
+
+  /**
+   * Records the version this schema is already at, so that {@link
+   * RdbmsSchemaVersionStore#checkCompatibility()} reads a recorded fact instead of deducing one
+   * from which tables the schema happens to have.
+   *
+   * <p>A run of its own, ahead of the schema's: the check cannot read a row written by the
+   * migration it guards, and only Liquibase's changelog lock keeps a peer from being part-way
+   * through creating the tables the legacy-or-fresh decision is read from. Deducing it outside that
+   * lock is what #62554 was.
+   *
+   * <p>The extra run costs an extra changelog lock once per schema — on initial creation, or on the
+   * upgrade from 8.9. Both of its changesets are recorded in {@code DATABASECHANGELOG} after that,
+   * so Liquibase's fast check finds nothing to run and returns without taking the lock at all.
+   */
+  @VisibleForTesting
+  protected void seedSchemaVersion() throws Exception {
+    performMigrationWithRetry(buildRunner(SCHEMA_VERSION_SEED_CHANGE_LOG));
   }
 
   /**
@@ -197,9 +225,17 @@ public class LiquibaseSchemaManager implements RdbmsSchemaManager {
 
   @VisibleForTesting
   protected SpringLiquibase buildRunner() {
+    return buildRunner(CHANGE_LOG);
+  }
+
+  /**
+   * A runner for one changelog, against this tenant's data source and bookkeeping tables. Every
+   * changelog shares those tables, so a changeset applied by one run is skipped by the next.
+   */
+  private SpringLiquibase buildRunner(final String changeLog) {
     final var runner = new SpringLiquibase();
     runner.setDataSource(dataSource);
-    runner.setChangeLog(CHANGE_LOG);
+    runner.setChangeLog(changeLog);
     runner.setDatabaseChangeLogTable(prefix + "DATABASECHANGELOG");
     runner.setDatabaseChangeLogLockTable(prefix + "DATABASECHANGELOGLOCK");
     runner.setChangeLogParameters(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -40,13 +40,6 @@ import org.slf4j.LoggerFactory;
 public class RdbmsSchemaVersionStore {
 
   /**
-   * The schema version that is inferred when the {@code RDBMS_SCHEMA_VERSION} table does not yet
-   * exist but the {@code EXPORTER_POSITION} table is present. This indicates an existing database
-   * that was created before version tracking was introduced (i.e. a 8.9.x database).
-   */
-  protected static final String INFERRED_PRE_VERSIONING_SCHEMA_VERSION = "8.9.0";
-
-  /**
    * The table that tracks the RDBMS schema version applied by this application. An entry is
    * written/updated after every successful Liquibase migration run.
    */
@@ -80,13 +73,10 @@ public class RdbmsSchemaVersionStore {
    *       RdbmsSchemaVersionIndeterminateException}.
    *   <li>If the data source is {@code null}, startup is aborted with an {@link
    *       RdbmsSchemaVersionIndeterminateException}.
-   *   <li>If the {@code RDBMS_SCHEMA_VERSION} table does not exist or contains no row (fresh DB or
-   *       pre-versioning database):
-   *       <ul>
-   *         <li>If {@code EXPORTER_POSITION} table exists → infer schema version as {@link
-   *             #INFERRED_PRE_VERSIONING_SCHEMA_VERSION} (an existing 8.9.x database).
-   *         <li>Otherwise → fresh database; skip the check entirely.
-   *       </ul>
+   *   <li>If the {@code RDBMS_SCHEMA_VERSION} table does not exist or contains no row, the schema
+   *       is new and has no upgrade path to validate; skip the check entirely. A schema that
+   *       predates version tracking is not one of those cases: it arrives here with 8.9.0 already
+   *       recorded by {@code schema-version-seed.xml}. See {@link #readSchemaVersion}.
    *   <li>Validates the transition. Only same-version, patch-upgrade, and next-minor-upgrade paths
    *       allow startup to continue. Incompatible paths throw a {@link
    *       RdbmsSchemaVersionIncompatibleException}. An indeterminate path (e.g. the stored schema
@@ -107,9 +97,9 @@ public class RdbmsSchemaVersionStore {
     }
 
     try (final var connection = dataSource.getConnection()) {
-      final var currentSchemaVersion = resolveCurrentSchemaVersion(connection, prefix);
+      final var currentSchemaVersion = readSchemaVersion(connection, prefix);
       if (currentSchemaVersion == null) {
-        // Fresh database – no version check needed.
+        // A new schema, with no recorded version and so no upgrade path to validate.
         return;
       }
 
@@ -169,7 +159,7 @@ public class RdbmsSchemaVersionStore {
     }
 
     try (final var connection = dataSource.getConnection()) {
-      final var currentSchemaVersion = resolveCurrentSchemaVersion(connection, prefix);
+      final var currentSchemaVersion = readSchemaVersion(connection, prefix);
       if (currentSchemaVersion == null) {
         return CurrentSchemaVersion.freshDatabase(prefix);
       }
@@ -252,39 +242,19 @@ public class RdbmsSchemaVersionStore {
   }
 
   /**
-   * Resolves the current schema version. Returns:
+   * Reads the schema version from {@code RDBMS_SCHEMA_VERSION}, which is the only thing this class
+   * will believe about a schema's version. Returns {@code null} if the table does not exist or
+   * contains no rows, and the caller skips the check either way, because neither shape belongs to a
+   * schema whose version is knowable: no table means nothing has migrated this schema yet, and an
+   * empty table means {@code LiquibaseSchemaManager} has created it but the first migration has not
+   * finished recording a version. Both are new schemas, and a new schema has no upgrade path to
+   * refuse. Propagates any unexpected {@link SQLException}.
    *
-   * <ul>
-   *   <li>The version string from {@code RDBMS_SCHEMA_VERSION} if the table exists and has a row.
-   *   <li>{@link #INFERRED_PRE_VERSIONING_SCHEMA_VERSION} if the {@code EXPORTER_POSITION} table
-   *       exists but {@code RDBMS_SCHEMA_VERSION} does not (existing 8.9.x database).
-   *   <li>{@code null} for a completely fresh database (no known tables).
-   * </ul>
-   */
-  @VisibleForTesting
-  protected String resolveCurrentSchemaVersion(final Connection connection, final String prefix)
-      throws SQLException {
-    final var versionFromTable = readSchemaVersion(connection, prefix);
-    if (versionFromTable != null) {
-      return versionFromTable;
-    }
-
-    // No version in table (table may not exist yet). Check for pre-versioning database.
-    if (tableExists(connection, prefix + "EXPORTER_POSITION")) {
-      LOG.info(
-          "[RDBMS Schema] RDBMS_SCHEMA_VERSION table not found but EXPORTER_POSITION exists. "
-              + "Inferring schema version as {} (pre-versioning database).",
-          INFERRED_PRE_VERSIONING_SCHEMA_VERSION);
-      return INFERRED_PRE_VERSIONING_SCHEMA_VERSION;
-    }
-
-    // Fresh database.
-    return null;
-  }
-
-  /**
-   * Reads the schema version from {@code RDBMS_SCHEMA_VERSION}. Returns {@code null} if the table
-   * does not exist or contains no rows. Propagates any unexpected {@link SQLException}.
+   * <p>A schema that predates version tracking does have a knowable version, and it is knowable
+   * here because {@code schema-version-seed.xml} records 8.9.0 for it before this is ever read.
+   * Deducing it here instead — from {@code EXPORTER_POSITION} being present while {@code
+   * RDBMS_SCHEMA_VERSION} was not — is what #62554 was: on a fresh database that is also, for
+   * almost the whole of a first migration, precisely what a peer node sees.
    */
   @VisibleForTesting
   protected String readSchemaVersion(final Connection connection, final String prefix)

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
@@ -243,6 +243,11 @@ class LiquibaseSchemaManagerTest {
     }
 
     @Override
+    protected void seedSchemaVersion() {
+      // no-op — the seeded version is what the mocked version store stands in for
+    }
+
+    @Override
     protected void releaseStaleLockIfPresent() {
       // no-op — tested separately
     }
@@ -299,6 +304,11 @@ class LiquibaseSchemaManagerTest {
     @Override
     protected SpringLiquibase buildRunner() {
       return null;
+    }
+
+    @Override
+    protected void seedSchemaVersion() {
+      // no-op — so that attempts count the schema migration's retries and nothing else
     }
 
     @Override

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerVersionCheckH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerVersionCheckH2Test.java
@@ -121,12 +121,12 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
   // ---- Acceptance criterion 5: Feature introduction in version 8.10 ----
 
   @Test
-  void shouldInferVersionFromExporterPositionTableWhenNoVersionTableExists() throws Exception {
+  void shouldSeedPreVersioningSchemaVersionWhenNoVersionTableExists() throws Exception {
     // given: create only EXPORTER_POSITION (simulating a pre-8.10 database that does NOT yet have
     // RDBMS_SCHEMA_VERSION)
     createExporterPositionTable();
 
-    // when: start app with 8.10.0 (valid upgrade from inferred 8.9.0)
+    // when: start app with 8.10.0 (valid upgrade from the seeded 8.9.0)
     final var manager = buildSchemaManager("8.10.0");
     manager.initialize();
 
@@ -139,14 +139,48 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
     // given: create only EXPORTER_POSITION (simulating a pre-8.10 database)
     createExporterPositionTable();
 
-    // when: start app with 8.11.0 (inferred schema=8.9.0, skips 8.10)
+    // when: start app with 8.11.0 (seeded schema=8.9.0, skips 8.10)
     final var manager = buildSchemaManager("8.11.0");
 
     // then: startup fails
     assertThatThrownBy(manager::initialize)
         .isInstanceOf(RdbmsSchemaVersionIncompatibleException.class)
-        .hasMessageContaining(RdbmsSchemaVersionStore.INFERRED_PRE_VERSIONING_SCHEMA_VERSION)
+        .hasMessageContaining("8.9.0")
         .hasMessageContaining("8.11.0");
+  }
+
+  // ---- #62554: a schema being created must never read as a pre-versioning one ----
+
+  @Test
+  void shouldRecordSchemaVersionBeforeCreatingAnyMigratedTable() throws Exception {
+    // given: a completely fresh database
+
+    // when: only the schema-version seed step has run, which is the earliest point at which any
+    // node — this one or a peer starting alongside it — can observe this schema
+    buildSchemaManager("8.11.0").seedSchemaVersion();
+
+    // then: the version table is already there, and none of the migrated tables are. A peer can
+    // therefore never see EXPORTER_POSITION without RDBMS_SCHEMA_VERSION, which is the shape it
+    // used to mistake for a pre-versioning 8.9.x database.
+    assertThat(tableExists("RDBMS_SCHEMA_VERSION")).isTrue();
+    assertThat(tableExists("EXPORTER_POSITION")).isFalse();
+    // and no version is claimed for a schema that has not been migrated yet
+    assertThat(readSchemaVersion()).isNull();
+  }
+
+  @Test
+  void shouldNotSeedPreVersioningVersionWhenSchemaIsAlreadyPast8_10() throws Exception {
+    // given: a schema migrated to 8.10 but carrying no recorded version — a database from a build
+    // that predates the seed run, whose version write did not land
+    runMasterChangelogOnly();
+    assertThat(readSchemaVersion()).isNull();
+
+    // when: start app with 8.11.0
+    buildSchemaManager("8.11.0").initialize();
+
+    // then: the tables 8.10 creates are positive evidence that this is not a pre-versioning
+    // schema, so nothing is seeded and the upgrade is not refused as a skipped minor
+    assertThat(readSchemaVersion()).isEqualTo("8.11.0");
   }
 
   // ---- helpers ----
@@ -182,6 +216,25 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
               + "LAST_UPDATED TIMESTAMP, "
               + "CONSTRAINT PK_EXPORTER_POSITION PRIMARY KEY (PARTITION_ID)"
               + ")");
+    }
+  }
+
+  /**
+   * Applies the master changelog on its own, without the schema-version seed run and without
+   * recording a version — what a build from before #62554 left behind if its version write failed.
+   */
+  private void runMasterChangelogOnly() throws Exception {
+    final var manager = buildSchemaManager("8.10.0");
+    manager.performMigration(manager.buildRunner());
+  }
+
+  private boolean tableExists(final String tableName) throws Exception {
+    try (final var conn = dataSource.getConnection();
+        final var rs =
+            conn.getMetaData()
+                .getTables(
+                    conn.getCatalog(), conn.getSchema(), tableName, new String[] {"TABLE"})) {
+      return rs.next();
     }
   }
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerVersionCheckH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerVersionCheckH2Test.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
+import liquibase.integration.spring.SpringLiquibase;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.Test;
 class LiquibaseSchemaManagerVersionCheckH2Test {
 
   private static final String DB_URL = "jdbc:h2:mem:version-check-test;DB_CLOSE_DELAY=-1";
+  private static final String PRE_8_10_CHANGE_LOG =
+      "db/changelog/rdbms-exporter-pre-8-10/changelog-master.xml";
 
   private JdbcDataSource dataSource;
 
@@ -122,9 +125,8 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
 
   @Test
   void shouldSeedPreVersioningSchemaVersionWhenNoVersionTableExists() throws Exception {
-    // given: create only EXPORTER_POSITION (simulating a pre-8.10 database that does NOT yet have
-    // RDBMS_SCHEMA_VERSION)
-    createExporterPositionTable();
+    // given: a pre-8.10 database that pre-8.10 code finished, and so has no RDBMS_SCHEMA_VERSION
+    createCompletedPreVersioningSchema();
 
     // when: start app with 8.10.0 (valid upgrade from the seeded 8.9.0)
     final var manager = buildSchemaManager("8.10.0");
@@ -136,8 +138,8 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
 
   @Test
   void shouldRejectUpgradeFromPreVersioningDatabaseWhenMinorVersionIsSkipped() throws Exception {
-    // given: create only EXPORTER_POSITION (simulating a pre-8.10 database)
-    createExporterPositionTable();
+    // given: a pre-8.10 database that pre-8.10 code finished
+    createCompletedPreVersioningSchema();
 
     // when: start app with 8.11.0 (seeded schema=8.9.0, skips 8.10)
     final var manager = buildSchemaManager("8.11.0");
@@ -183,13 +185,45 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
     assertThat(readSchemaVersion()).isEqualTo("8.11.0");
   }
 
+  @Test
+  void shouldNotSeedPreVersioningVersionWhenAFirstMigrationWasInterrupted() throws Exception {
+    // given: a first migration by a build without the seed run that created EXPORTER_POSITION and
+    // then died, so none of the later pre-8.10 objects exist
+    createExporterPositionTable();
+    assertThat(indexExists("IDX_AUDIT_LOG_ACTOR_ID")).isFalse();
+
+    // when: that half-created schema is picked up by 8.11.0, two minors on
+    buildSchemaManager("8.11.0").initialize();
+
+    // then: an unfinished migration is not a legacy database, so nothing is seeded and the
+    // migration is resumed rather than refused as an upgrade that skips a minor
+    assertThat(readSchemaVersion()).isEqualTo("8.11.0");
+  }
+
+  @Test
+  void shouldNotSeedAgainWhenAVersionRowIsAlreadyPresent() throws Exception {
+    // given: a pre-versioning schema whose seed insert committed but whose DATABASECHANGELOG row
+    // did not. Liquibase commits a changeset's changes before it records the changeset, so a crash
+    // in between leaves exactly this state, and the next attempt re-evaluates the seed changeset.
+    createCompletedPreVersioningSchema();
+    createSchemaVersionTableWithVersion("8.9.0");
+
+    // when: start app with 8.10.0 (valid upgrade from the seeded 8.9.0)
+    buildSchemaManager("8.10.0").initialize();
+
+    // then: the insert was skipped rather than repeated into a primary-key violation
+    assertThat(readSchemaVersion()).isEqualTo("8.10.0");
+  }
+
   // ---- helpers ----
 
   private LiquibaseSchemaManager buildSchemaManager(final String appVersion) throws Exception {
-    final var cfg =
-        new PerTenantSchemaConfig(
-            dataSource, VendorDatabasePropertiesLoader.load("h2"), "", true, null);
-    return new LiquibaseSchemaManager(cfg, appVersion);
+    return new LiquibaseSchemaManager(schemaConfig(), appVersion);
+  }
+
+  private PerTenantSchemaConfig schemaConfig() throws Exception {
+    return new PerTenantSchemaConfig(
+        dataSource, VendorDatabasePropertiesLoader.load("h2"), "", true, null);
   }
 
   /**
@@ -220,6 +254,34 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
   }
 
   /**
+   * Applies the real 8.9 changesets and nothing later, which is what pre-8.10 code would have left
+   * behind: a complete schema with no {@code RDBMS_SCHEMA_VERSION} table.
+   */
+  private void createCompletedPreVersioningSchema() throws Exception {
+    final var manager =
+        new LiquibaseSchemaManager(schemaConfig(), "8.9.9") {
+          @Override
+          protected SpringLiquibase buildRunner() {
+            final var runner = super.buildRunner();
+            runner.setChangeLog(PRE_8_10_CHANGE_LOG);
+            return runner;
+          }
+        };
+    manager.performMigration(manager.buildRunner());
+  }
+
+  /** Simulates a seed insert that committed without its changeset being recorded. */
+  private void createSchemaVersionTableWithVersion(final String version) throws Exception {
+    try (final var conn = dataSource.getConnection();
+        final var stmt = conn.createStatement()) {
+      stmt.execute(
+          "CREATE TABLE IF NOT EXISTS RDBMS_SCHEMA_VERSION ("
+              + "ID SMALLINT DEFAULT 1 NOT NULL PRIMARY KEY, VERSION VARCHAR(32) NOT NULL)");
+      stmt.execute("INSERT INTO RDBMS_SCHEMA_VERSION (ID, VERSION) VALUES (1, '" + version + "')");
+    }
+  }
+
+  /**
    * Applies the master changelog on its own, without the schema-version seed run and without
    * recording a version — what a build from before #62554 left behind if its version write failed.
    */
@@ -235,6 +297,17 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
                 .getTables(
                     conn.getCatalog(), conn.getSchema(), tableName, new String[] {"TABLE"})) {
       return rs.next();
+    }
+  }
+
+  private boolean indexExists(final String indexName) throws Exception {
+    try (final var conn = dataSource.getConnection();
+        final var stmt =
+            conn.prepareStatement(
+                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE INDEX_NAME = ?")) {
+      stmt.setString(1, indexName);
+      final var rs = stmt.executeQuery();
+      return rs.next() && rs.getInt(1) > 0;
     }
   }
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerVersionCheckH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerVersionCheckH2Test.java
@@ -171,7 +171,7 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
   }
 
   @Test
-  void shouldNotSeedPreVersioningVersionWhenSchemaIsAlreadyPast8_10() throws Exception {
+  void shouldNotSeedPreVersioningVersionWhenSchemaIsAlreadyPast810() throws Exception {
     // given: a schema migrated to 8.10 but carrying no recorded version — a database from a build
     // that predates the seed run, whose version write did not land
     runMasterChangelogOnly();

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerVersionCheckH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerVersionCheckH2Test.java
@@ -30,6 +30,8 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
   private static final String DB_URL = "jdbc:h2:mem:version-check-test;DB_CLOSE_DELAY=-1";
   private static final String PRE_8_10_CHANGE_LOG =
       "db/changelog/rdbms-exporter-pre-8-10/changelog-master.xml";
+  private static final String PRE_8_9_9_CHANGE_LOG =
+      "db/changelog/rdbms-exporter-8-9-0/changelog-master.xml";
 
   private JdbcDataSource dataSource;
 
@@ -138,8 +140,8 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
 
   @Test
   void shouldRejectUpgradeFromPreVersioningDatabaseWhenMinorVersionIsSkipped() throws Exception {
-    // given: a pre-8.10 database that pre-8.10 code finished
-    createCompletedPreVersioningSchema();
+    // given: an 8.9.0 database that never took the 8.9.9 patch
+    createCompleted890Schema();
 
     // when: start app with 8.11.0 (seeded schema=8.9.0, skips 8.10)
     final var manager = buildSchemaManager("8.11.0");
@@ -148,6 +150,21 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
     assertThatThrownBy(manager::initialize)
         .isInstanceOf(RdbmsSchemaVersionIncompatibleException.class)
         .hasMessageContaining("8.9.0")
+        .hasMessageContaining("8.11.0");
+  }
+
+  @Test
+  void shouldSeedThePatchLevelThePreVersioningSchemaReached() throws Exception {
+    // given: a pre-8.10 database that pre-8.10 code finished, 8.9.9 patch included
+    createCompletedPreVersioningSchema();
+
+    // when: start app with 8.11.0 (seeded schema=8.9.9, skips 8.10)
+    final var manager = buildSchemaManager("8.11.0");
+
+    // then: startup fails, naming the patch level the schema actually reached
+    assertThatThrownBy(manager::initialize)
+        .isInstanceOf(RdbmsSchemaVersionIncompatibleException.class)
+        .hasMessageContaining("8.9.9")
         .hasMessageContaining("8.11.0");
   }
 
@@ -197,6 +214,22 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
 
     // then: an unfinished migration is not a legacy database, so nothing is seeded and the
     // migration is resumed rather than refused as an upgrade that skips a minor
+    assertThat(readSchemaVersion()).isEqualTo("8.11.0");
+  }
+
+  @Test
+  void shouldNotSeedPreVersioningVersionWhenAFirstMigrationWasInterruptedInThePatchChangesets()
+      throws Exception {
+    // given: a first migration by a build without the seed run that got all the way through
+    // 8.9.0.xml before it died inside 8.9.9.xml, the file the master changelog applies next
+    createSchemaInterruptedInsideThePatchChangesets();
+    assertThat(indexExists("IDX_AUDIT_LOG_ACTOR_ID")).isTrue();
+
+    // when: that half-created schema is picked up by 8.11.0, two minors on
+    buildSchemaManager("8.11.0").initialize();
+
+    // then: a schema stopped between two releases is no more a legacy database than one stopped at
+    // its first changeset, so nothing is seeded and the migration is resumed rather than refused
     assertThat(readSchemaVersion()).isEqualTo("8.11.0");
   }
 
@@ -258,12 +291,33 @@ class LiquibaseSchemaManagerVersionCheckH2Test {
    * behind: a complete schema with no {@code RDBMS_SCHEMA_VERSION} table.
    */
   private void createCompletedPreVersioningSchema() throws Exception {
+    runChangeLog(PRE_8_10_CHANGE_LOG, "8.9.9");
+  }
+
+  /** The same, for a database still on 8.9.0 GA that never took the 8.9.9 patch. */
+  private void createCompleted890Schema() throws Exception {
+    runChangeLog(PRE_8_9_9_CHANGE_LOG, "8.9.0");
+  }
+
+  /**
+   * A first migration that applied all of {@code 8.9.0.xml} and then died after the first of the
+   * three columns {@code 8.9.9.xml} adds — a shape no release ever shipped.
+   */
+  private void createSchemaInterruptedInsideThePatchChangesets() throws Exception {
+    createCompleted890Schema();
+    try (final var conn = dataSource.getConnection();
+        final var stmt = conn.createStatement()) {
+      stmt.execute("ALTER TABLE DECISION_INSTANCE ADD COLUMN FULL_RESULT CLOB");
+    }
+  }
+
+  private void runChangeLog(final String changeLog, final String version) throws Exception {
     final var manager =
-        new LiquibaseSchemaManager(schemaConfig(), "8.9.9") {
+        new LiquibaseSchemaManager(schemaConfig(), version) {
           @Override
           protected SpringLiquibase buildRunner() {
             final var runner = super.buildRunner();
-            runner.setChangeLog(PRE_8_10_CHANGE_LOG);
+            runner.setChangeLog(changeLog);
             return runner;
           }
         };

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProviderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProviderTest.java
@@ -82,8 +82,8 @@ class RdbmsSchemaMigrationStatusProviderTest {
 
   /**
    * Builds a {@link RdbmsSchemaVersionStore} whose {@link
-   * RdbmsSchemaVersionStore#resolveCurrentSchemaVersion} returns {@code schemaVersion}, backed by a
-   * mock data source that yields a mock connection.
+   * RdbmsSchemaVersionStore#readSchemaVersion} returns {@code schemaVersion}, backed by a mock data
+   * source that yields a mock connection.
    */
   private static RdbmsSchemaVersionStore versionStore(
       final String schemaVersion, final String appVersion) {
@@ -95,8 +95,7 @@ class RdbmsSchemaMigrationStatusProviderTest {
     }
     return new RdbmsSchemaVersionStore(dataSource, "", appVersion) {
       @Override
-      protected String resolveCurrentSchemaVersion(
-          final Connection connection, final String prefix) {
+      protected String readSchemaVersion(final Connection connection, final String prefix) {
         return schemaVersion;
       }
     };

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreSchemaScopingH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreSchemaScopingH2Test.java
@@ -49,7 +49,7 @@ class RdbmsSchemaVersionStoreSchemaScopingH2Test {
     final String resolved;
     try (final var conn = ds.getConnection()) {
       conn.setSchema("PT_B");
-      resolved = store.resolveCurrentSchemaVersion(conn, "");
+      resolved = store.readSchemaVersion(conn, "");
     }
 
     // then: PT_B is treated as a fresh database, not PT_A's version
@@ -72,7 +72,7 @@ class RdbmsSchemaVersionStoreSchemaScopingH2Test {
     final String resolved;
     try (final var conn = ds.getConnection()) {
       conn.setSchema("PT_A");
-      resolved = store.resolveCurrentSchemaVersion(conn, "");
+      resolved = store.readSchemaVersion(conn, "");
     }
 
     // then: the version stored in PT_A is read back

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
@@ -72,15 +72,14 @@ class RdbmsSchemaVersionStoreTest {
 
   @Test
   void shouldTreatFreshDatabaseAsNoVersionCheck() {
-    // given - resolveCurrentSchemaVersion returns null (fresh DB)
+    // given - readSchemaVersion returns null (fresh DB)
     versionStore(null, "8.11.0").checkCompatibility();
   }
 
   @Test
-  void shouldAllowUpgradeFromInferredPreVersioningSchema() {
-    // given: RDBMS_SCHEMA_VERSION doesn't exist but EXPORTER_POSITION does → inferred 8.9.0
-    versionStore(RdbmsSchemaVersionStore.INFERRED_PRE_VERSIONING_SCHEMA_VERSION, "8.10.0")
-        .checkCompatibility();
+  void shouldAllowUpgradeFromSeededPreVersioningSchema() {
+    // given: a pre-versioning schema, for which schema-version-seed.xml recorded 8.9.0
+    versionStore("8.9.0", "8.10.0").checkCompatibility();
   }
 
   @Test
@@ -201,7 +200,7 @@ class RdbmsSchemaVersionStoreTest {
 
   @Test
   void shouldReportFreshDatabaseCurrentSchemaVersion() {
-    // given - resolveCurrentSchemaVersion returns null (fresh DB, not yet initialized)
+    // given - readSchemaVersion returns null (fresh DB, not yet initialized)
     final var currentSchemaVersion = versionStore(null, "8.11.0").getCurrentSchemaVersion();
 
     // then
@@ -258,8 +257,7 @@ class RdbmsSchemaVersionStoreTest {
     }
     return new RdbmsSchemaVersionStore(dataSource, "", appVersion) {
       @Override
-      protected String resolveCurrentSchemaVersion(
-          final Connection connection, final String prefix) {
+      protected String readSchemaVersion(final Connection connection, final String prefix) {
         return schemaVersion;
       }
     };

--- a/db/rdbms/src/test/resources/db/changelog/rdbms-exporter-8-9-0/changelog-master.xml
+++ b/db/rdbms/src/test/resources/db/changelog/rdbms-exporter-8-9-0/changelog-master.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--
+  ~ The production changelog as it stood at 8.9.0 GA, before the 8.9.9 patch added its columns.
+  ~ Running this produces the schema a customer who never took that patch is still on — which the
+  ~ pre-versioning seed has to recognise just as readily as a completed 8.9.9 one.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <include file="/db/changelog/rdbms-exporter/changesets/8.9.0.xml" />
+
+</databaseChangeLog>

--- a/db/rdbms/src/test/resources/db/changelog/rdbms-exporter-pre-8-10/changelog-master.xml
+++ b/db/rdbms/src/test/resources/db/changelog/rdbms-exporter-pre-8-10/changelog-master.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--
+  ~ The production changelog as it stood before 8.10 — the real 8.9 changesets, without the ones
+  ~ that introduced version tracking. Running this produces a genuine pre-versioning database:
+  ~ no RDBMS_SCHEMA_VERSION, and DATABASECHANGELOG rows under the same file names the production
+  ~ changelog records, so a later production run correctly sees these changesets as already applied.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <include file="/db/changelog/rdbms-exporter/changesets/8.9.0.xml" />
+  <include file="/db/changelog/rdbms-exporter/changesets/8.9.9.xml" />
+
+</databaseChangeLog>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaInitializerH2IT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaInitializerH2IT.java
@@ -113,8 +113,8 @@ class RdbmsSchemaInitializerH2IT {
         assertThat(initializer.isInitialized(TENANT_B)).isFalse();
 
         // and - the healthy tenant's migration really ran; it was not merely reported ready
-        assertThat(tableExists(tenants.dataSourceFor(TENANT_A), "DATABASECHANGELOG")).isTrue();
-        assertThat(tableExists(tenants.dataSourceFor(TENANT_B), "DATABASECHANGELOG")).isFalse();
+        assertThat(tableExists(tenants.dataSourceFor(TENANT_A), "DEPLOYED_RESOURCE")).isTrue();
+        assertThat(tableExists(tenants.dataSourceFor(TENANT_B), "DEPLOYED_RESOURCE")).isFalse();
       } finally {
         initializer.destroy();
       }


### PR DESCRIPTION
## Description

`RdbmsSchemaVersionStore` used to *infer* the schema version when `RDBMS_SCHEMA_VERSION` was absent: if `EXPORTER_POSITION` existed, the schema was assumed to be a pre-versioning 8.9.0 one. On a fresh database that assumption is wrong for almost the entire first migration — `EXPORTER_POSITION` is created by the very first changeset, `RDBMS_SCHEMA_VERSION` 129 changesets later — and the inference ran outside any mutual exclusion.

Scenario: all brokers start in parallel against a new database. One acquires the Liquibase changelog lock and begins creating the schema. A peer, meanwhile, reads the half-created schema, infers 8.9.0, compares it against the running 8.11.0 and refuses the upgrade path as skipping a minor. That rejection is classified terminal, so the peer never retries and stops exporting that physical tenant for good.

The fix records the version instead of inferring it. A new changelog, `schema-version-seed.xml`, runs on its own before the master run and before the compatibility check. It creates `RDBMS_SCHEMA_VERSION` and — only when the schema has `EXPORTER_POSITION` but not `DEPLOYED_RESOURCE`, which is positive evidence of pre-8.10 provenance — seeds `8.9.0`. Running it as a Liquibase changeset is what makes the legacy-or-fresh decision sound: the changelog lock guarantees no peer is part-way through creating the tables the decision is read from. On a fresh database the version table now exists before `EXPORTER_POSITION` does, so the ambiguous shape is unreachable, and a missing/empty version row unambiguously means "new schema, no upgrade path to validate".

The seed changelog is deliberately not included by `changelog-master.xml` and not placed in `changesets/`: `LiquibaseScriptGenerator` derives the shipped create SQL from the master and the upgrade SQL from `changesets/*.xml`, where a seed row would be meaningless. `create_rdbms_schema_version_table` therefore stays in `changesets/8.10.0.xml` — it remains the only source of that table in the 12 generated scripts — and both changesets carry the same `not tableExists` MARK_RAN precondition, so whichever run reaches it first wins.

Cost: one extra changelog lock per schema, taken once — on initial creation, or on the upgrade from 8.9. Both seed changesets are recorded in `DATABASECHANGELOG` afterwards, so Liquibase's fast check finds nothing to run and returns without taking the lock at all.

## Related issues

relates to #62554

This is the first of the four problems described in the issue and the root cause of the observed outage, but it does not close it — the remaining points (the per-broker cached `isInitialized` verdict, the absent `zeebe_exporter_last_exported_position` health signal, and the exporter pinning log compaction at `-1`) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
