### PR TITLE
feat: scale REST API executor pool with physical-tenant count

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Executor.java
+++ b/configuration/src/main/java/io/camunda/configuration/Executor.java
@@ -68,6 +68,57 @@ public class Executor {
    */
   private int queueCapacity = 64;
 
+  /**
+   * Additional core threads to add per physical tenant beyond the first, on top of the vCPU-derived
+   * {@link #corePoolSizeMultiplier} term. Each physical tenant is an independent traffic source, so
+   * this term is additive rather than folded into the vCPU multiplier.
+   *
+   * <p>Effective value: {@code corePoolSize = min(corePoolSizeCeiling, availableProcessors *
+   * corePoolSizeMultiplier + max(0, physicalTenantCount - 1) * corePoolSizePerTenant)}.
+   *
+   * <p>Default value: 1
+   */
+  private int corePoolSizePerTenant = 1;
+
+  /**
+   * Additional max threads to add per physical tenant beyond the first, on top of the vCPU-derived
+   * {@link #maxPoolSizeMultiplier} term. See {@link #corePoolSizePerTenant}.
+   *
+   * <p>Default value: 2
+   */
+  private int maxPoolSizePerTenant = 2;
+
+  /**
+   * Additional queue capacity to add per physical tenant beyond the first. See {@link
+   * #corePoolSizePerTenant}.
+   *
+   * <p>Default value: 16
+   */
+  private int queueCapacityPerTenant = 16;
+
+  /**
+   * Flat ceiling on {@code corePoolSize} regardless of vCPU count or physical-tenant count. Not
+   * vCPU-relative, since these threads are I/O-bound (parked waiting on RDBMS/ES) and cheap to keep
+   * idle.
+   *
+   * <p>Default value: 256
+   */
+  private int corePoolSizeCeiling = 256;
+
+  /**
+   * Flat ceiling on {@code maxPoolSize}. See {@link #corePoolSizeCeiling}.
+   *
+   * <p>Default value: 512
+   */
+  private int maxPoolSizeCeiling = 512;
+
+  /**
+   * Flat ceiling on {@code queueCapacity}. See {@link #corePoolSizeCeiling}.
+   *
+   * <p>Default value: 4096
+   */
+  private int queueCapacityCeiling = 4096;
+
   public int getCorePoolSizeMultiplier() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".core-pool-size-multiplier",
@@ -120,5 +171,53 @@ public class Executor {
 
   public void setQueueCapacity(final int queueCapacity) {
     this.queueCapacity = queueCapacity;
+  }
+
+  public int getCorePoolSizePerTenant() {
+    return corePoolSizePerTenant;
+  }
+
+  public void setCorePoolSizePerTenant(final int corePoolSizePerTenant) {
+    this.corePoolSizePerTenant = corePoolSizePerTenant;
+  }
+
+  public int getMaxPoolSizePerTenant() {
+    return maxPoolSizePerTenant;
+  }
+
+  public void setMaxPoolSizePerTenant(final int maxPoolSizePerTenant) {
+    this.maxPoolSizePerTenant = maxPoolSizePerTenant;
+  }
+
+  public int getQueueCapacityPerTenant() {
+    return queueCapacityPerTenant;
+  }
+
+  public void setQueueCapacityPerTenant(final int queueCapacityPerTenant) {
+    this.queueCapacityPerTenant = queueCapacityPerTenant;
+  }
+
+  public int getCorePoolSizeCeiling() {
+    return corePoolSizeCeiling;
+  }
+
+  public void setCorePoolSizeCeiling(final int corePoolSizeCeiling) {
+    this.corePoolSizeCeiling = corePoolSizeCeiling;
+  }
+
+  public int getMaxPoolSizeCeiling() {
+    return maxPoolSizeCeiling;
+  }
+
+  public void setMaxPoolSizeCeiling(final int maxPoolSizeCeiling) {
+    this.maxPoolSizeCeiling = maxPoolSizeCeiling;
+  }
+
+  public int getQueueCapacityCeiling() {
+    return queueCapacityCeiling;
+  }
+
+  public void setQueueCapacityCeiling(final int queueCapacityCeiling) {
+    this.queueCapacityCeiling = queueCapacityCeiling;
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -111,16 +111,25 @@ public class CamundaServicesConfiguration {
     return new SecurityContextProvider();
   }
 
-  // Cluster-wide executor, uses the node's availableProcessors
+  // Cluster-wide executor, uses the node's availableProcessors plus a per-physical-tenant term
+  // (see ApiServicesExecutorProvider for why the two are additive, not multiplicative)
   @Bean
   public ApiServicesExecutorProvider apiServicesExecutor(
-      final UnifiedConfiguration unifiedConfiguration) {
+      final UnifiedConfiguration unifiedConfiguration,
+      final PhysicalTenantResolver physicalTenantResolver) {
     final var executor = unifiedConfiguration.getCamunda().getApi().getRest().getExecutor();
     return new ApiServicesExecutorProvider(
         executor.getCorePoolSizeMultiplier(),
         executor.getMaxPoolSizeMultiplier(),
         executor.getKeepAlive().getSeconds(),
-        executor.getQueueCapacity());
+        executor.getQueueCapacity(),
+        physicalTenantResolver.known().size(),
+        executor.getCorePoolSizePerTenant(),
+        executor.getMaxPoolSizePerTenant(),
+        executor.getQueueCapacityPerTenant(),
+        executor.getCorePoolSizeCeiling(),
+        executor.getMaxPoolSizeCeiling(),
+        executor.getQueueCapacityCeiling());
   }
 
   /**

--- a/service/src/main/java/io/camunda/service/ApiServicesExecutorProvider.java
+++ b/service/src/main/java/io/camunda/service/ApiServicesExecutorProvider.java
@@ -22,11 +22,52 @@ public final class ApiServicesExecutorProvider {
       final int maxPoolSizeMultiplier,
       final long keepAliveSeconds,
       final int queueCapacity) {
+    this(
+        corePoolSizeMultiplier,
+        maxPoolSizeMultiplier,
+        keepAliveSeconds,
+        queueCapacity,
+        0,
+        0,
+        0,
+        0,
+        Integer.MAX_VALUE,
+        Integer.MAX_VALUE,
+        Integer.MAX_VALUE);
+  }
+
+  /**
+   * @param physicalTenantCount total number of physical tenants configured on this node; each
+   *     tenant beyond the first adds an independent slice of headroom on top of the vCPU-derived
+   *     terms (see {@link #create}).
+   */
+  public ApiServicesExecutorProvider(
+      final int corePoolSizeMultiplier,
+      final int maxPoolSizeMultiplier,
+      final long keepAliveSeconds,
+      final int queueCapacity,
+      final int physicalTenantCount,
+      final int corePoolSizePerTenant,
+      final int maxPoolSizePerTenant,
+      final int queueCapacityPerTenant,
+      final int corePoolSizeCeiling,
+      final int maxPoolSizeCeiling,
+      final int queueCapacityCeiling) {
     executor =
         new PhysicalTenantPropagatingExecutorService(
             Objects.requireNonNull(
                 create(
-                    corePoolSizeMultiplier, maxPoolSizeMultiplier, keepAliveSeconds, queueCapacity),
+                    corePoolSizeMultiplier,
+                    maxPoolSizeMultiplier,
+                    keepAliveSeconds,
+                    queueCapacity,
+                    Math.max(0, physicalTenantCount - 1),
+                    corePoolSizePerTenant,
+                    maxPoolSizePerTenant,
+                    queueCapacityPerTenant,
+                    corePoolSizeCeiling,
+                    maxPoolSizeCeiling,
+                    queueCapacityCeiling),
                 "REST API Executor Service must not be null"));
   }
 
@@ -47,27 +88,57 @@ public final class ApiServicesExecutorProvider {
   /**
    * Create a customizable dynamic ThreadPoolExecutor.
    *
+   * <p>Pool sizes are the sum of two independent terms: a vCPU-derived term (general node
+   * compute/dispatch capacity) and a physical-tenant-derived term (each extra physical tenant is an
+   * independent traffic source needing its own slice of headroom). The two are additive, not
+   * multiplicative, because they size unrelated dimensions — scaling vCPUs shouldn't scale the
+   * tenant term and vice versa. A flat ceiling bounds the total regardless of which dimension is
+   * large.
+   *
    * @param corePoolSizeMultiplier multiplier for the number of core threads based on available
    *     processors
    * @param maxPoolSizeMultiplier multiplier for the maximum number of threads based on available
    *     processors
    * @param keepAliveSeconds how long to keep idle threads above core alive
    * @param queueCapacity tiny bounded queue capacity for short bursts (e.g., 32–128)
+   * @param extraTenants number of physical tenants beyond the first
+   * @param corePoolSizePerTenant additional core threads per extra tenant
+   * @param maxPoolSizePerTenant additional max threads per extra tenant
+   * @param queueCapacityPerTenant additional queue capacity per extra tenant
+   * @param corePoolSizeCeiling flat ceiling on the computed core pool size
+   * @param maxPoolSizeCeiling flat ceiling on the computed max pool size
+   * @param queueCapacityCeiling flat ceiling on the computed queue capacity
    */
   private static ExecutorService create(
       final int corePoolSizeMultiplier,
       final int maxPoolSizeMultiplier,
       final long keepAliveSeconds,
-      final int queueCapacity) {
+      final int queueCapacity,
+      final int extraTenants,
+      final int corePoolSizePerTenant,
+      final int maxPoolSizePerTenant,
+      final int queueCapacityPerTenant,
+      final int corePoolSizeCeiling,
+      final int maxPoolSizeCeiling,
+      final int queueCapacityCeiling) {
 
     final int availableProcessors = Runtime.getRuntime().availableProcessors();
-    final int corePoolSize = availableProcessors * corePoolSizeMultiplier;
-    final int maxPoolSize = availableProcessors * maxPoolSizeMultiplier;
+    final int corePoolSize =
+        Math.min(
+            corePoolSizeCeiling,
+            availableProcessors * corePoolSizeMultiplier + extraTenants * corePoolSizePerTenant);
+    final int maxPoolSize =
+        Math.min(
+            maxPoolSizeCeiling,
+            availableProcessors * maxPoolSizeMultiplier + extraTenants * maxPoolSizePerTenant);
     final ThreadFactory threadFactory =
         Thread.ofPlatform().name(API_SERVICE_THREAD_NAME, 0).daemon(true).factory();
 
     // Tiny bounded buffer to absorb micro-bursts
-    final int cap = Math.max(1, queueCapacity);
+    final int cap =
+        Math.max(
+            1,
+            Math.min(queueCapacityCeiling, queueCapacity + extraTenants * queueCapacityPerTenant));
     final BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(cap);
 
     final ThreadPoolExecutor executor =


### PR DESCRIPTION
ApiServicesExecutorProvider sizes camunda.api.rest.executor purely from available processors, shared cluster-wide across every physical tenant on a node. Under load, aggregate REST search volume from all tenants' independent pollers outgrows this fixed capacity as tenant count rises, causing periodic saturation events where every tenant's pending REST search stalls together (root-caused via S1 load-test data: 3.35-7.32% of process instances exceeded the 90s data-availability bucket on the 8- and 24-tenant shapes, 0% on the 1-tenant control).

Add an additive per-physical-tenant term to the pool-size formula alongside the existing vCPU-derived term:

  extraTenants = max(0, N - 1)
  corePoolSize = min(ceiling, vCPUs * corePoolSizeMultiplier + extraTenants * corePoolSizePerTenant)
  maxPoolSize  = min(ceiling, vCPUs * maxPoolSizeMultiplier  + extraTenants * maxPoolSizePerTenant)
  queueCapacity = min(ceiling, queueCapacity + extraTenants * queueCapacityPerTenant)

Additive rather than multiplicative because the two terms size unrelated dimensions: the vCPU term covers general node compute/dispatch capacity, while the tenant term covers thread demand from each tenant's independent traffic source (by Little's Law, thread demand for this I/O-bound pool is arrival_rate * hold_time summed per source). Multiplying them would arbitrarily couple the two - doubling vCPUs would double the tenant budget for no reason, and a low-vCPU/many-tenant node would be under-provisioned. A flat ceiling bounds the total regardless of which dimension is large. N=1 (no physical tenants) reproduces today's exact numbers unchanged.

PhysicalTenantResolver is already injected into the same configuration class for serviceRegistry(), so tenant count is available at apiServicesExecutor() bean-construction time with no new plumbing.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [ ] This PR does not need a linked issue

