### PR TITLE
test: retry test schema creation

### DIFF
--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
@@ -90,13 +90,20 @@ public abstract class SearchDBExtension implements BeforeAllCallback, AfterAllCa
     if (openSearchAwsInstanceUrl.isEmpty()) {
       return new ContainerizedSearchDBExtension();
     } else {
-      final Duration dataAvailabilityTimeout =
-          Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
-              .map(val -> Duration.ofSeconds(Long.parseLong(val)))
-              .orElse(Duration.ofSeconds(60));
-
-      return new AWSSearchDBExtension(openSearchAwsInstanceUrl, dataAvailabilityTimeout);
+      return new AWSSearchDBExtension(
+          openSearchAwsInstanceUrl, awsDataAvailabilityTimeout(Duration.ofSeconds(60)));
     }
+  }
+
+  /**
+   * Timeout for data to become available in the AWS OpenSearch instance, read from the {@value
+   * #TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT} system property with the given fallback when unset.
+   * Single parse point for the property — callers pick their own fallback.
+   */
+  public static Duration awsDataAvailabilityTimeout(final Duration fallback) {
+    return Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
+        .map(val -> Duration.ofSeconds(Long.parseLong(val)))
+        .orElse(fallback);
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -23,6 +23,7 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
+import io.camunda.exporter.utils.CamundaExporterSchemaUtils;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.search.schema.SchemaManager;
@@ -1711,13 +1712,16 @@ final class OpenSearchArchiverRepositoryIT {
                     .connect(connectConfig)
                     .retention(retention)
                     .schemaManager(schemaManagerConfig));
-    new SchemaManager(
+
+    try (final SchemaManager schemaManager =
+        new SchemaManager(
             searchEngineClient,
             resourceProvider.getIndexDescriptors(),
             resourceProvider.getIndexTemplateDescriptors(),
             searchEngineConfiguration,
-            MAPPER)
-        .startupOnce();
+            MAPPER)) {
+      CamundaExporterSchemaUtils.startupSchemaWithRetries(schemaManager);
+    }
   }
 
   private void createBatchOperationIndex() throws IOException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterSchemaUtils.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterSchemaUtils.java
@@ -11,10 +11,23 @@ import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import java.io.IOException;
+import java.time.Duration;
+import org.awaitility.Awaitility;
 
 public final class CamundaExporterSchemaUtils {
+
+  /**
+   * SchemaManager.startupOnce() is a single attempt by design; on prod we retry schema creation
+   * with backoff so we can complete initialization in a loaded managed cluster taking more than one
+   * attempt. Similarly, we will retry schema creation in tests to avoid flakiness and the timeout
+   * will control how/long we would retry.
+   */
+  private static final Duration SCHEMA_CREATION_TIMEOUT =
+      SearchDBExtension.awsDataAvailabilityTimeout(Duration.ofSeconds(120));
+
   private CamundaExporterSchemaUtils() {}
 
   public static void createSchemas(final ExporterConfiguration config) throws IOException {
@@ -22,18 +35,27 @@ public final class CamundaExporterSchemaUtils {
         new IndexDescriptors(
             config.getConnect().getIndexPrefix(),
             config.getConnect().getTypeEnum().isElasticSearch());
-    try (final ClientAdapter clientAdapter = ClientAdapter.of(config.getConnect())) {
-      new SchemaManager(
-              clientAdapter.getSearchEngineClient(),
-              indexDescriptors.indices(),
-              indexDescriptors.templates(),
-              SearchEngineConfiguration.of(
-                  b ->
-                      b.connect(config.getConnect())
-                          .index(config.getIndex())
-                          .retention(config.getHistory().getRetention())),
-              clientAdapter.objectMapper())
-          .startupOnce();
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(config.getConnect());
+        final SchemaManager schemaManager =
+            new SchemaManager(
+                clientAdapter.getSearchEngineClient(),
+                indexDescriptors.indices(),
+                indexDescriptors.templates(),
+                SearchEngineConfiguration.of(
+                    b ->
+                        b.connect(config.getConnect())
+                            .index(config.getIndex())
+                            .retention(config.getHistory().getRetention())),
+                clientAdapter.objectMapper())) {
+      startupSchemaWithRetries(schemaManager);
     }
+  }
+
+  public static void startupSchemaWithRetries(final SchemaManager schemaManager) {
+    Awaitility.await("schema manager startup & initialization completes")
+        .ignoreExceptions()
+        .atMost(SCHEMA_CREATION_TIMEOUT)
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(schemaManager::startupOnce);
   }
 }


### PR DESCRIPTION
## Description

The schema creation is meant to be retryable and in our app we retry the operation multiple times during startup. However, in some tests we only attempt to initialise it once, and if it fails accept as test failure. The schema creation can fail due to multiple reasons, and one is overused and slow clusters, pretty much the AWS OS test instance. Instead now it will try to schema creation within a timelimit we set.

Also refactor parsing the AWS OS timeout property so that we dont read it from multiple places.

## Related issues

relates to #52892
