### PR TITLE
ci: temporarily disable aurora async replication IT

### DIFF
--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -82,12 +82,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions: {}
+    # Temporarily disabled while the Aurora async replication IT is buggy. The job remains
+    # available for manual re-enablement through the repository variable.
     if: |
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       (github.event.action == 'labeled' && github.event.label.name == 'run-aurora-tests' ||
-        github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-aurora-tests')))
+      vars.CI_ENABLE_AURORA_ASYNC_REPLICATION == 'true' &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'pull_request' &&
+        (github.event.action == 'labeled' && github.event.label.name == 'run-aurora-tests' ||
+         github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-aurora-tests'))))
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description
Disable Aurora async replication IT until they are working again. The cause is a change in terraform upstream.

`vars.CI_ENABLE_AURORA_ASYNC_REPLICATION == 'true'` added so actionlint
is green. Will be removed when it's fixed

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

