### PR TITLE
test: prevent one job-stream race from failing all JobStreamAuthorizationIT tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.enums.JobState;
@@ -35,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
@@ -94,10 +96,13 @@ public class JobStreamAuthorizationIT {
 
   @AfterEach
   void cleanUp() {
-    // cancel all process instances to ensure no jobs are left in the system
-    STARTED_PROCESS_INSTANCES.forEach(
-        processInstanceKey -> cancelProcessInstance(adminClient, processInstanceKey));
+    // cancel all process instances to ensure no jobs are left in the system.
+    // Take a snapshot and clear up front: if a cancellation fails, the keys must not stay
+    // behind, or every later test in this class fails in tear-down on the same stale key.
+    final var startedProcessInstances = List.copyOf(STARTED_PROCESS_INSTANCES);
     STARTED_PROCESS_INSTANCES.clear();
+    startedProcessInstances.forEach(
+        processInstanceKey -> cancelProcessInstance(adminClient, processInstanceKey));
   }
 
   @Disabled("We don't have a broker mechanism to reject unauthorized job streams yet")
@@ -133,7 +138,7 @@ public class JobStreamAuthorizationIT {
     deployProcess(PROCESS_ID_1, jobType, TENANT_A);
     deployProcess(PROCESS_ID_1, jobType, TENANT_B);
     // a job set for collecting jobs in the client
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final Set<ActivatedJob> jobCollector = ConcurrentHashMap.newKeySet();
     // and a job stream created by the user1 client, with their authorizations
     final var stream =
         user1Client
@@ -149,7 +154,7 @@ public class JobStreamAuthorizationIT {
     try {
       startProcessInstance(adminClient, PROCESS_ID_1, TENANT_A);
       startProcessInstance(adminClient, PROCESS_ID_1, TENANT_B);
-      waitForJobsBeingExported(adminClient, 2, JobState.CREATED, PROCESS_ID_1);
+      waitForJobsBeingExported(adminClient, 2, JobState.CREATED, jobType);
 
       // then
       // expect that  the camunda client of user1 receives no job
@@ -169,7 +174,7 @@ public class JobStreamAuthorizationIT {
     deployProcess(PROCESS_ID_1, jobType, TENANT_B);
     deployProcess(PROCESS_ID_2, jobType, TENANT_B);
     // a job set for collecting jobs in the client
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final Set<ActivatedJob> jobCollector = ConcurrentHashMap.newKeySet();
     // and a job stream created by the user2 client, with their authorizations
     final var stream =
         user2Client
@@ -177,9 +182,10 @@ public class JobStreamAuthorizationIT {
             .jobType(jobType)
             .consumer(
                 job -> {
-                  user2Client.newCompleteCommand(job).send().join();
+                  // record before completing: the test waits on the completed job being
+                  // exported, which must not be observable before the job is collected
                   jobCollector.add(job);
-                  STARTED_PROCESS_INSTANCES.remove(job.getProcessInstanceKey());
+                  user2Client.newCompleteCommand(job).send().join();
                 })
             .tenantIds(TENANT_A, TENANT_B)
             .send();
@@ -194,7 +200,7 @@ public class JobStreamAuthorizationIT {
 
       // then
       // expect that only one job is completed
-      waitForJobsBeingExported(adminClient, 1, JobState.COMPLETED, PROCESS_ID_1, PROCESS_ID_2);
+      waitForJobsBeingExported(adminClient, 1, JobState.COMPLETED, jobType);
       // expect that  the camunda client of user2 receives and completes that one job
       assertThat(jobCollector).hasSize(1);
       assertThat(jobCollector.iterator().next().getTenantId()).isEqualTo(TENANT_B);
@@ -211,7 +217,7 @@ public class JobStreamAuthorizationIT {
     final var jobType = uniqueJobType();
     deployProcess(PROCESS_ID_3, jobType, TENANT_A);
     deployProcess(PROCESS_ID_3, jobType, TENANT_B);
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final Set<ActivatedJob> jobCollector = ConcurrentHashMap.newKeySet();
     // a job stream created by user1 with ASSIGNED tenant filter (resolves to tenantA only)
     final var stream =
         user1Client
@@ -226,7 +232,7 @@ public class JobStreamAuthorizationIT {
     try {
       startProcessInstance(adminClient, PROCESS_ID_3, TENANT_A);
       startProcessInstance(adminClient, PROCESS_ID_3, TENANT_B);
-      waitForJobsBeingExported(adminClient, 2, JobState.CREATED, PROCESS_ID_3);
+      waitForJobsBeingExported(adminClient, 2, JobState.CREATED, jobType);
 
       // then
       // user1 has no permissions, so no jobs should be received
@@ -244,7 +250,7 @@ public class JobStreamAuthorizationIT {
     deployProcess(PROCESS_ID_3, jobType, TENANT_A);
     deployProcess(PROCESS_ID_3, jobType, TENANT_B);
     deployProcess(PROCESS_ID_4, jobType, TENANT_B);
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final Set<ActivatedJob> jobCollector = ConcurrentHashMap.newKeySet();
     // a job stream created by user2 with ASSIGNED tenant filter (resolves to tenantA and tenantB)
     final var stream =
         user2Client
@@ -252,9 +258,10 @@ public class JobStreamAuthorizationIT {
             .jobType(jobType)
             .consumer(
                 job -> {
-                  user2Client.newCompleteCommand(job).send().join();
+                  // record before completing: the test waits on the completed job being
+                  // exported, which must not be observable before the job is collected
                   jobCollector.add(job);
-                  STARTED_PROCESS_INSTANCES.remove(job.getProcessInstanceKey());
+                  user2Client.newCompleteCommand(job).send().join();
                 })
             .tenantFilter(TenantFilter.ASSIGNED)
             .send();
@@ -268,7 +275,7 @@ public class JobStreamAuthorizationIT {
 
       // then
       // user2 is only authorized for PROCESS_ID_4 on tenantB
-      waitForJobsBeingExported(adminClient, 1, JobState.COMPLETED, PROCESS_ID_3, PROCESS_ID_4);
+      waitForJobsBeingExported(adminClient, 1, JobState.COMPLETED, jobType);
       assertThat(jobCollector).hasSize(1);
       assertThat(jobCollector.iterator().next().getTenantId()).isEqualTo(TENANT_B);
     } finally {
@@ -282,7 +289,7 @@ public class JobStreamAuthorizationIT {
     // given
     final var jobType = uniqueJobType();
     deployProcess(PROCESS_ID_5, jobType, TENANT_B);
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final Set<ActivatedJob> jobCollector = ConcurrentHashMap.newKeySet();
     // a job stream with ASSIGNED filter AND an explicit tenantId(TENANT_A) —
     // the ASSIGNED filter should override the provided tenant IDs, so the broker
     // resolves from all assigned tenants (both A and B), not just tenantA
@@ -292,9 +299,10 @@ public class JobStreamAuthorizationIT {
             .jobType(jobType)
             .consumer(
                 job -> {
-                  user2Client.newCompleteCommand(job).send().join();
+                  // record before completing: the test waits on the completed job being
+                  // exported, which must not be observable before the job is collected
                   jobCollector.add(job);
-                  STARTED_PROCESS_INSTANCES.remove(job.getProcessInstanceKey());
+                  user2Client.newCompleteCommand(job).send().join();
                 })
             .tenantId(TENANT_A)
             .tenantFilter(TenantFilter.ASSIGNED)
@@ -308,7 +316,7 @@ public class JobStreamAuthorizationIT {
       // then
       // if ASSIGNED didn't override the tenant IDs, the stream would be limited to tenantA
       // and would miss this job on tenantB
-      waitForJobsBeingExported(adminClient, 1, JobState.COMPLETED, PROCESS_ID_5);
+      waitForJobsBeingExported(adminClient, 1, JobState.COMPLETED, jobType);
       assertThat(jobCollector).hasSize(1);
       assertThat(jobCollector.iterator().next().getTenantId()).isEqualTo(TENANT_B);
     } finally {
@@ -369,14 +377,22 @@ public class JobStreamAuthorizationIT {
 
   private static void cancelProcessInstance(
       final CamundaClient camundaClient, final long processInstanceKey) {
-    camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
+    try {
+      camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
+    } catch (final ProblemException e) {
+      // A test that completes a streamed job runs its instance to completion, so by tear-down
+      // there is nothing left to cancel. Any other rejection is a real failure.
+      if (e.code() != 404) {
+        throw e;
+      }
+    }
   }
 
   private static void waitForJobsBeingExported(
       final CamundaClient camundaClient,
       final int expectedJobs,
       final JobState state,
-      final String... resourceIds) {
+      final String jobType) {
     Awaitility.await("should receive data from secondary storage")
         .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -385,9 +401,7 @@ public class JobStreamAuthorizationIT {
               assertThat(
                       camundaClient
                           .newJobSearchRequest()
-                          .filter(
-                              filter ->
-                                  filter.processDefinitionId(fn -> fn.in(resourceIds)).state(state))
+                          .filter(filter -> filter.type(jobType).state(state))
                           .send()
                           .join()
                           .items())


### PR DESCRIPTION
## Description

`JobStreamAuthorizationIT` reported four failing tests on `main`, with all eight Surefire reruns
failing identically on the same process instance key. One intermittent race was the trigger; three
separate defects in the test turned it into an unrecoverable class-wide failure. No product code is
implicated.

- **`cleanUp()` cleared its static set after cancelling, not before.** A cancellation that throws
  skips `clear()`, so the stale key survives for the rest of the class and every later test fails in
  `@AfterEach` on that same key — including every rerun. This is why rerun-on-flake never recovered,
  and why one race showed up as four red tests.
- **The collectors shared with the job-stream consumer thread were plain `HashSet`s.** One run failed
  with a `ConcurrentModificationException` suppressed under the assertion error. The consumer also
  completed the job *before* recording it, so the signal the test waits on — an exported `COMPLETED`
  job — could be observed before `jobCollector.add()` ran (`Expected size: 1 but was: 0`).
- **`waitForJobsBeingExported` filtered only on `processDefinitionId` + `state`**, but
  `service_tasks_v1` / `service_tasks_v3` are shared across test methods, so leftovers from a test
  whose tear-down failed were counted (`Expected size: 2 but was: 3`).

The fix makes tear-down idempotent and failure-tolerant, makes the collectors concurrent, records
each job before completing it, and scopes the exported-job wait to the per-test `jobType` (a fresh
UUID per test).

**Alternative considered:** having the consumer deregister its instance so cleanup never tries to
cancel a finished one. That deregistration is precisely what raced with `startProcessInstance`'s
`add()` in the first place — tolerating `404` in cleanup removes the coordination entirely rather
than tightening it.

This class has been de-flaked twice before (`test: remove flakiness from job stream authorization
test`, `test: attempt to resolve flakiness by asserting a streams status/visibility`). Both addressed
timing; neither addressed the tear-down cascade.

**Verification:** ran the class three consecutive times against the CI configuration
(`rdbms_h2`, physical tenant `tenanta`, `physical-tenant-identity` profile, reruns disabled) —
`Tests run: 6, Failures: 0, Errors: 0, Skipped: 1` each time (the skip is the pre-existing
`@Disabled` test). Full-repo `./mvnw install -Dquickly` is green.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #62623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
