### PR TITLE
fix: prevent orchestration broker crash-loop in main's release load test

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
@@ -225,10 +225,6 @@ orchestration:
         zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
         zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
 
-        # Camunda Exporter configuration
-        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-        zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
-
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000
@@ -253,6 +249,10 @@ orchestration:
     minimumAge: 3d # Optimize needs time to import data before ILM cleanup (see #56443)
   # Retention for the Camunda Exporter
   history:
+    ## @param core.history.rolloverBatchSize defines the maximum number of process instances per batch during archiving.
+    rolloverBatchSize: 500
+    ## @param core.history.waitPeriodBeforeArchiving defines the grace period for processes to be excluded from archiving.
+    waitPeriodBeforeArchiving: "1m"
     retention:
       ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
       enabled: true

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"
@@ -261,10 +261,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"
@@ -274,10 +274,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"
@@ -274,10 +274,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"
@@ -274,10 +274,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/common/configmap-warnings.yaml
@@ -35,8 +35,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/none-physical-tenants/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/none-physical-tenants/platform/templates/common/configmap-warnings.yaml
@@ -35,8 +35,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/none/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/common/configmap-warnings.yaml
@@ -35,8 +35,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"
@@ -261,10 +261,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"
@@ -277,10 +277,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"
@@ -277,10 +277,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"
@@ -277,10 +277,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/common/configmap-warnings.yaml
@@ -81,8 +81,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/configmap.yaml
@@ -118,8 +118,8 @@ data:
             history:
               els-rollover-date-format: "date"
               rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
+              rollover-batch-size: 500
+              wait-period-before-archiving: "1m"
               delay-between-runs: 2000
               max-delay-between-runs: 60000
               policy-name: "camunda-retention-policy"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/common/configmap-warnings.yaml
@@ -81,8 +81,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/common/configmap-warnings.yaml
@@ -81,8 +81,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/common/configmap-warnings.yaml
@@ -81,8 +81,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         


### PR DESCRIPTION
## Description

main's scheduled release load test (namespace `c8-schedule-release-main`) crash-looped on 2026-09-10 (INC-7949): every orchestration replica failed to start with `Expected to find a 'className' configured for the exporter. Couldn't find a valid one for the following exporters [camundaexporter]`.

Root cause: `load-tests/setup/main/values/camunda-platform-values-defaults.yaml` tuned Camunda Exporter archiving (`rolloverBatchSize`/`waitPeriodBeforeArchiving`) via a raw `zeebe.broker.exporters.camundaexporter.args.history.*` property override in an `application.yml` `extraConfiguration` block, without a `className`. Under `camunda-platform` chart v15.0.0-alpha4 this coexisted fine with the chart's own `camundaexporter` autoconfiguration. Once main's pinned chart version was bumped to v15.0.0-alpha5 (`load-tests/setup/newLoadTest.sh`, 2026-09-08), setting anything under that key path stopped the chart from autoconfiguring `className`, leaving a partial exporter config that the broker rejects at startup.

`stable-89` and `stable-810` hit the same class of issue earlier and were already fixed in [7e6b78f876b](https://github.com/camunda/camunda/commit/7e6b78f876b1bd348348d47c5314653bfd73bdf1), by configuring the same two settings through the chart's structured `core.history.*` values instead of a raw exporter override — flagging the same upstream `camunda-platform-helm#6454` change as the cause — but that commit only touched `stable-89`/`stable-810`, not `main` (main was still pinned to alpha4 at the time and unaffected). This applies the identical fix to `main`, now that it's on the same chart line.

Verified live: reproduced the crash by dispatching a fresh release load test against unfixed `main` (`camunda-0/1/2` crash-looped, exit 255, same exception), then confirmed `stable/8.10`'s own load test (which already carries this fix) starts clean on the same chart version. Golden files regenerated via `make update-golden PATTERN=main` in `load-tests/setup/test/` — all `main` scenarios pass.

Note: the regenerated golden output surfaces a chart deprecation notice for `core.history.rolloverBatchSize`/`waitPeriodBeforeArchiving` (removal targeted for chart v16, in favor of `extraConfiguration`) — the same warning `stable-89`/`stable-810` already carry. Left as-is: `extraConfiguration` is exactly the mechanism that broke under alpha5 without an explicit `className`, so switching back isn't safe until the chart's own autoconfiguration gap is addressed upstream.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

- [x] This PR does not need a linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)