### PR TITLE
fix: await completion of identity redistribution records

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -35,6 +35,8 @@ import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -94,6 +96,7 @@ class BackupMultiPartitionTest {
   private ZeebeResourcesHelper resourcesHelper;
   private BackupRequestHandler backupRequestHandler;
   private BackupActuator backupActuator;
+  private int lastSeenDistributionRecordCount = -1;
 
   @TestZeebe
   private final TestCluster cluster =
@@ -360,6 +363,7 @@ class BackupMultiPartitionTest {
   void canRetrieveCheckpointStateFromPartialPartitions()
       throws ExecutionException, InterruptedException, TimeoutException {
     // given
+    awaitCommandDistributionsDrained();
     final long processKey = resourcesHelper.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
     createProcessInstanceOnPartitionOne(processKey);
 
@@ -481,6 +485,40 @@ class BackupMultiPartitionTest {
                 .limit(1)
                 .findFirst())
         .isPresent();
+  }
+
+  private void awaitCommandDistributionsDrained() {
+    lastSeenDistributionRecordCount = -1;
+    Awaitility.await("no command distribution is in flight")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(100))
+        .during(Duration.ofSeconds(5))
+        .until(this::commandDistributionsDrained);
+  }
+
+  private boolean commandDistributionsDrained() {
+    final var distributionRecords =
+        RecordingExporter.getRecords().stream()
+            .filter(record -> record.getValueType() == ValueType.COMMAND_DISTRIBUTION)
+            .toList();
+
+    final var unchanged = distributionRecords.size() == lastSeenDistributionRecordCount;
+    lastSeenDistributionRecordCount = distributionRecords.size();
+    if (!unchanged) {
+      return false;
+    }
+
+    final Set<Long> pending = new HashSet<>();
+    final Set<Long> finished = new HashSet<>();
+    for (final var record : distributionRecords) {
+      if (record.getIntent() == CommandDistributionIntent.STARTED) {
+        pending.add(record.getKey());
+      } else if (record.getIntent() == CommandDistributionIntent.FINISHED) {
+        finished.add(record.getKey());
+      }
+    }
+    pending.removeAll(finished);
+    return pending.isEmpty();
   }
 
   private void createProcessInstanceOnPartitionOne(final long processKey) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On `io.camunda.zeebe.it.cluster.backup.BackupMultiPartitionTest.canRetrieveCheckpointStateFromPartialPartitions` we explicitly expect a backup to be present on a single partition, rather than the whole cluster. Command redistribution is able to propagate checkpoints to other partitions which can cause a race when querying the checkpoint state of the cluster. Most of command redistribution is caused by Identity creating it's relevant entities at startup, for this scenario we explicitly await the draining of the command redistribution records before proceeding to take the backup.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [ ] This PR does not need a linked issue

