### PR TITLE
fix: cancel suspended process instances in batch operations

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceIT.java
@@ -13,6 +13,7 @@ import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,5 +120,58 @@ public class BatchOperationCancelProcessInstanceIT {
     assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())
         .containsExactly(BatchOperationItemState.COMPLETED);
     assertThat(itemKeys).containsExactlyInAnyOrder(activeKeys.toArray(Long[]::new));
+  }
+
+  @Test
+  void shouldCancelSuspendedProcessInstancesWithBatch() {
+    final List<Long> activeProcessInstanceKeys =
+        activeProcessInstances.stream().map(ProcessInstanceEvent::getProcessInstanceKey).toList();
+
+    // given
+    camundaClient
+        .newCreateBatchOperationCommand()
+        .processInstanceSuspend()
+        .filter(f -> f.processInstanceKey(k -> k.in(activeProcessInstanceKeys)))
+        .send()
+        .join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient,
+        f -> f.variables(getScopedVariables(testScopeId)),
+        activeProcessInstances.size());
+
+    // when
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(b -> b.variables(getScopedVariables(testScopeId)))
+            .send()
+            .join();
+    final var batchOperationKey = result.getBatchOperationKey();
+
+    // then
+    assertThat(result).isNotNull();
+
+    waitForBatchOperationWithCorrectTotalCount(
+        camundaClient, batchOperationKey, activeProcessInstances.size());
+    waitForBatchOperationCompleted(
+        camundaClient, batchOperationKey, activeProcessInstances.size(), 0);
+
+    for (final Long key : activeProcessInstanceKeys) {
+      waitForProcessInstanceToBeTerminated(camundaClient, key);
+    }
+
+    final var itemsObj =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(f -> f.batchOperationKey(batchOperationKey))
+            .send()
+            .join();
+    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();
+
+    assertThat(itemsObj.items()).hasSize(activeProcessInstances.size());
+    assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())
+        .containsExactly(BatchOperationItemState.COMPLETED);
+    assertThat(itemKeys).containsExactlyInAnyOrder(activeProcessInstanceKeys.toArray(Long[]::new));
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/cache/rest-api.yaml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/cache/rest-api.yaml
@@ -2010,8 +2010,8 @@ paths:
       operationId: cancelProcessInstancesBatchOperation
       summary: Create a batch operation to cancel process instances
       description: |
-        Cancels multiple running process instances.
-        Since only ACTIVE root instances can be cancelled, any given filters for state and
+        Cancels multiple active or suspended process instances.
+        Since only ACTIVE and SUSPENDED root instances can be cancelled, any given filters for state and
         parentProcessInstanceKey are ignored and overridden during this batch operation.
         This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
       requestBody:

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
@@ -81,8 +81,9 @@ public class ItemProviderFactory {
         metrics,
         filter.toBuilder()
             .partitionId(partitionId)
-            .states(ProcessInstanceState.ACTIVE.name())
-            .parentProcessInstanceKeyOperations(Operation.exists(false))
+            .replaceStates(
+                ProcessInstanceState.ACTIVE.name(), ProcessInstanceState.SUSPENDED.name())
+            .replaceParentProcessInstanceKeyOperations(Operation.exists(false))
             .build(),
         authentication);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CancelProcessInstanceBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CancelProcessInstanceBatchExecutorTest.java
@@ -82,6 +82,56 @@ public final class CancelProcessInstanceBatchExecutorTest extends AbstractBatchO
   }
 
   @Test
+  public void shouldCancelSuspendedProcessInstance() {
+    // given
+    final var user = createUser();
+    addProcessDefinitionPermissionsToUser(user, PermissionType.CANCEL_PROCESS_INSTANCE);
+    final Map<String, Object> claims = Map.of(AUTHORIZED_USERNAME, user.getUsername());
+
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "failingTask", t -> t.zeebeJobType(JOB_TYPE).zeebeInputExpression("foo", "foo"))
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withVariables(Maps.of(entry("foo", "bar")))
+            .create();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    final var batchOperationKey =
+        createNewCancelProcessInstanceBatchOperation(Set.of(processInstanceKey), claims);
+
+    // then we have completed event
+    assertThat(
+            RecordingExporter.batchOperationLifecycleRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents()
+                .limit(r -> r.getIntent() == BatchOperationIntent.COMPLETED))
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationIntent.COMPLETED);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(ProcessInstanceIntent.CANCEL, ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withRecordKey(processInstanceKey)
+                .limit(
+                    r ->
+                        r.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATED
+                            && r.getValue().getBpmnElementType() == BpmnElementType.PROCESS))
+        .extracting(Record::getIntent)
+        .containsSequence(ProcessInstanceIntent.CANCEL, ProcessInstanceIntent.ELEMENT_TERMINATED);
+  }
+
+  @Test
   public void shouldRejectNonExistingProcessInstance() {
     // given
     final Map<String, Object> claims = Map.of("claim1", "value1", "claim2", "value2");

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
@@ -46,8 +46,38 @@ class ItemProviderFactoryTest {
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
     final var usedFilter = ((ProcessInstanceItemProvider) itemProvider).getFilter();
-    assertThat(usedFilter.parentProcessInstanceKeyOperations()).contains(Operation.exists(false));
-    assertThat(usedFilter.stateOperations()).contains(Operation.eq("ACTIVE"));
+    assertThat(usedFilter.parentProcessInstanceKeyOperations())
+        .containsExactly(Operation.exists(false));
+    assertThat(usedFilter.stateOperations()).containsExactly(Operation.in("ACTIVE", "SUSPENDED"));
+    assertThat(usedFilter.partitionId()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldOverrideFiltersForCancelProcessInstance() {
+    // given
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .states("COMPLETED")
+            .parentProcessInstanceKeys(12345L)
+            .processInstanceKeys(67890L)
+            .build();
+    final var batchOperation = mock(PersistedBatchOperation.class);
+    when(batchOperation.getBatchOperationType())
+        .thenReturn(BatchOperationType.CANCEL_PROCESS_INSTANCE);
+    when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
+
+    // when
+    final var itemProvider = factory.fromBatchOperation(batchOperation);
+
+    // then
+    assertThat(itemProvider).isNotNull();
+    assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
+
+    final var usedFilter = ((ProcessInstanceItemProvider) itemProvider).getFilter();
+    assertThat(usedFilter.parentProcessInstanceKeyOperations())
+        .containsExactly(Operation.exists(false));
+    assertThat(usedFilter.stateOperations()).containsExactly(Operation.in("ACTIVE", "SUSPENDED"));
+    assertThat(usedFilter.processInstanceKeyOperations()).containsExactly(Operation.eq(67890L));
     assertThat(usedFilter.partitionId()).isEqualTo(1);
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -440,8 +440,8 @@ paths:
         - basicAuth: []
       summary: Cancel process instances (batch)
       description: |
-        Cancels multiple running process instances.
-        Since only ACTIVE root instances can be cancelled, any given filters for state and
+        Cancels multiple active or suspended process instances.
+        Since only ACTIVE and SUSPENDED root instances can be cancelled, any given filters for state and
         parentProcessInstanceKey are ignored and overridden during this batch operation.
         This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
       requestBody:


### PR DESCRIPTION
## Description

Cancelling a suspended process instance is permitted via single instance cancellation, but batch cancellation silently skipped suspended instances because `ItemProviderFactory.forCancelProcessInstance()` hardcoded the process instance search state filter to `ACTIVE`. In addition, caller-provided filters for `state` and `parentProcessInstanceKey` were appended rather than replaced, preventing caller filters from being ignored and overridden as documented.

This PR:
- Updates `ItemProviderFactory.forCancelProcessInstance()` to search for both `ACTIVE` and `SUSPENDED` states using `replaceStates(ACTIVE, SUSPENDED)`.
- Replaces caller `parentProcessInstanceKey` filters with `exists(false)`.
- Updates API specification documentation in `process-instances.yaml` and cached schemas to reflect that `ACTIVE` and `SUSPENDED` root instances can be cancelled in batch operations.
- Adds unit tests in `ItemProviderFactoryTest`, an engine execution test in `CancelProcessInstanceBatchExecutorTest`, and multi-database acceptance integration coverage in `BatchOperationCancelProcessInstanceIT`.

## Related issues

closes #61253