### PR TITLE
test: harden partition scaling tests by testing authorizations and DMNs

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -20,11 +20,16 @@ import com.sun.management.HotSpotDiagnosticMXBean.ThreadDumpFormat;
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.CreateGroupResponse;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Filesystem;
 import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.management.backups.StateCode;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationUtil;
+import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
@@ -35,8 +40,12 @@ import io.camunda.zeebe.management.cluster.RoutingState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.AbstractStartEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
@@ -44,6 +53,7 @@ import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -94,6 +104,8 @@ public class ScaleUpPartitionsTest {
   // broker that hangs is reported with a thread dump instead of the method timing out first.
   private static final Duration RESTORE_TIMEOUT = Duration.ofMinutes(2);
   @AutoClose CamundaClient camundaClient;
+  private String decisionUsername;
+  private String decisionPassword;
   private ClusterActuator clusterActuator;
   private BackupActuator backupActuator;
 
@@ -109,30 +121,90 @@ public class ScaleUpPartitionsTest {
             .withPartitionsCount(PARTITIONS_COUNT)
             .withReplicationFactor(3)
             .withBrokerConfig(
-                b ->
-                    b.withUnifiedConfig(
-                        cfg -> {
-                          final var backup = cfg.getData().getPrimaryStorage().getBackup();
-                          backup.setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
-                          backup.getFilesystem().setBasePath(backupPath.toString());
+                b -> {
+                  // Keep the cluster's internal topology checks unauthenticated while enabling
+                  // authorization checks for clients that provide credentials.
+                  b.withUnauthenticatedAccess();
+                  b.withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
+                  b.withUnifiedConfig(
+                      cfg -> {
+                        final var backup = cfg.getData().getPrimaryStorage().getBackup();
+                        backup.setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
+                        backup.getFilesystem().setBasePath(backupPath.toString());
 
-                          final var membership = cfg.getCluster().getMembership();
-                          membership.setSyncInterval(Duration.ofSeconds(1));
-                          membership.setGossipInterval(Duration.ofMillis(500));
+                        final var membership = cfg.getCluster().getMembership();
+                        membership.setSyncInterval(Duration.ofSeconds(1));
+                        membership.setGossipInterval(Duration.ofMillis(500));
 
-                          final var distribution =
-                              cfg.getProcessing().getEngine().getDistribution();
-                          distribution.setMaxBackoffDuration(Duration.ofSeconds(1));
-                          distribution.setRedistributionInterval(Duration.ofMillis(200));
-                        }))
+                        final var distribution = cfg.getProcessing().getEngine().getDistribution();
+                        distribution.setMaxBackoffDuration(Duration.ofSeconds(1));
+                        distribution.setRedistributionInterval(Duration.ofMillis(200));
+                      });
+                })
             .build();
   }
 
   @BeforeEach
   void createClient() {
-    camundaClient = cluster.availableGateway().newClientBuilder().build();
+    camundaClient =
+        AuthorizationsUtil.createClient(
+            cluster.availableGateway(),
+            InitializationConfiguration.DEFAULT_USER_USERNAME,
+            InitializationConfiguration.DEFAULT_USER_PASSWORD);
     clusterActuator = ClusterActuator.of(cluster.availableGateway());
     backupActuator = BackupActuator.of(cluster.availableGateway());
+    initializeIdentityState();
+  }
+
+  private void initializeIdentityState() {
+    cluster.awaitHealthyTopology();
+    decisionUsername = Strings.newRandomValidUsername();
+    decisionPassword = "password";
+
+    camundaClient
+        .newCreateUserCommand()
+        .username(decisionUsername)
+        .password(decisionPassword)
+        .name("Decision user")
+        .email("decision-user@example.com")
+        .send()
+        .join();
+    final var authorizationKey =
+        camundaClient
+            .newCreateAuthorizationCommand()
+            .ownerId(decisionUsername)
+            .ownerType(OwnerType.USER)
+            .resourceId("*")
+            .resourceType(ResourceType.DECISION_DEFINITION)
+            .permissionTypes(PermissionType.CREATE_DECISION_INSTANCE)
+            .send()
+            .join()
+            .getAuthorizationKey();
+    final var deploymentKey =
+        camundaClient
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("dmn/decision-table.dmn")
+            .send()
+            .join()
+            .getKey();
+    new ZeebeResourcesHelper(camundaClient).waitUntilDeploymentIsDone(deploymentKey);
+
+    Awaitility.await("until identity state is distributed")
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      RecordingExporter.userRecords(UserIntent.CREATED)
+                          .withUsername(decisionUsername)
+                          .limit(PARTITIONS_COUNT)
+                          .count())
+                  .isEqualTo(PARTITIONS_COUNT);
+              assertThat(
+                      RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
+                          .withAuthorizationKey(authorizationKey)
+                          .limit(PARTITIONS_COUNT)
+                          .count())
+                  .isEqualTo(PARTITIONS_COUNT);
+            });
   }
 
   private Camunda getRestoreConfig(final Camunda brokerCfg, final Path workingDirectory) {
@@ -163,6 +235,7 @@ public class ScaleUpPartitionsTest {
     // given
     final var desiredPartitionCount = PARTITIONS_COUNT + 1;
     cluster.awaitHealthyTopology();
+
     // when
     executeScaling(desiredPartitionCount);
 
@@ -699,6 +772,38 @@ public class ScaleUpPartitionsTest {
               final var allPartitions = (RequestHandlingAllPartitions) requestHandling;
               assertThat(allPartitions.getPartitionCount()).isEqualTo(desiredPartitionCount);
             });
+    verifyExistingDecisionCanBeEvaluatedOnPartition(desiredPartitionCount);
+  }
+
+  private void verifyExistingDecisionCanBeEvaluatedOnPartition(final int partitionId) {
+    try (final var decisionClient =
+        AuthorizationsUtil.createClient(
+            cluster.availableGateway(), decisionUsername, decisionPassword)) {
+      Awaitility.await("until the new partition evaluates the existing decision")
+          .atMost(Duration.ofMinutes(2))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final var response =
+                    decisionClient
+                        .newEvaluateDecisionCommand()
+                        .decisionId("jedi_or_sith")
+                        .variable("lightsaberColor", "blue")
+                        .send()
+                        .toCompletableFuture()
+                        .join();
+                assertThat(response.getDecisionOutput()).isEqualTo("\"Jedi\"");
+                assertThat(Protocol.decodePartitionId(response.getDecisionEvaluationKey()))
+                    .isEqualTo(partitionId);
+                assertThat(
+                        RecordingExporter.decisionEvaluationRecords(
+                                DecisionEvaluationIntent.EVALUATED)
+                            .withPartitionId(partitionId)
+                            .withDecisionId("jedi_or_sith")
+                            .findAny())
+                    .isPresent();
+              });
+    }
   }
 
   static class CorrelationKeyVariableProvider {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -26,8 +26,9 @@ import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Filesystem;
 import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.management.backups.StateCode;
-import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
@@ -49,6 +50,7 @@ import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -64,6 +66,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -85,9 +88,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @ZeebeIntegration
 // Interrupt any test method hanging longer than 10 minutes so the remaining tests still run and
 // the failure is attributed with a stack trace, instead of the CI job timing out with no test
@@ -109,10 +110,12 @@ public class ScaleUpPartitionsTest {
   private ClusterActuator clusterActuator;
   private BackupActuator backupActuator;
 
-  @TestZeebe(awaitCompleteTopology = false)
+  @TestZeebe(autoStart = false, awaitCompleteTopology = false)
   private final TestCluster cluster;
 
   ScaleUpPartitionsTest(@TempDir final Path backupPath) {
+    final var h2Url =
+        "jdbc:h2:mem:scale-up-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
     cluster =
         TestCluster.builder()
             .useRecordingExporter(true)
@@ -122,12 +125,16 @@ public class ScaleUpPartitionsTest {
             .withReplicationFactor(3)
             .withBrokerConfig(
                 b -> {
-                  // Keep the cluster's internal topology checks unauthenticated while enabling
-                  // authorization checks for clients that provide credentials.
-                  b.withUnauthenticatedAccess();
-                  b.withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
+                  b.withSecondaryStorageType(SecondaryStorageType.rdbms);
+                  b.withAuthenticationMethod(AuthenticationMethod.BASIC);
+                  b.withAuthorizationsEnabled();
                   b.withUnifiedConfig(
                       cfg -> {
+                        final var rdbms = cfg.getData().getSecondaryStorage().getRdbms();
+                        rdbms.setUrl(h2Url);
+                        rdbms.setUsername("sa");
+                        rdbms.setPassword("");
+
                         final var backup = cfg.getData().getPrimaryStorage().getBackup();
                         backup.setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
                         backup.getFilesystem().setBasePath(backupPath.toString());
@@ -146,11 +153,10 @@ public class ScaleUpPartitionsTest {
 
   @BeforeEach
   void createClient() {
-    camundaClient =
-        AuthorizationsUtil.createClient(
-            cluster.availableGateway(),
-            InitializationConfiguration.DEFAULT_USER_USERNAME,
-            InitializationConfiguration.DEFAULT_USER_PASSWORD);
+    cluster.start();
+    cluster.await(TestHealthProbe.READY);
+
+    camundaClient = cluster.newClientBuilder().build();
     clusterActuator = ClusterActuator.of(cluster.availableGateway());
     backupActuator = BackupActuator.of(cluster.availableGateway());
     initializeIdentityState();
@@ -190,6 +196,7 @@ public class ScaleUpPartitionsTest {
     new ZeebeResourcesHelper(camundaClient).waitUntilDeploymentIsDone(deploymentKey);
 
     Awaitility.await("until identity state is distributed")
+        .atMost(Duration.ofMinutes(2))
         .untilAsserted(
             () -> {
               assertThat(
@@ -779,6 +786,7 @@ public class ScaleUpPartitionsTest {
     try (final var decisionClient =
         AuthorizationsUtil.createClient(
             cluster.availableGateway(), decisionUsername, decisionPassword)) {
+
       Awaitility.await("until the new partition evaluates the existing decision")
           .atMost(Duration.ofMinutes(2))
           .ignoreExceptions()


### PR DESCRIPTION


## Description

Extend existing test cases by including authorizations and decisions to the resources deployed before scaling, verifying that those resources are available in the new partitions after scaling

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

