### PR TITLE
deps: bump Optimize jetty to 12.0.39 to resolve CVE-2026-19203 and CVE-2026-19204

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -158,6 +158,20 @@
       <!-- Must be declared before spring-boot-dependencies so this version wins,
            per Maven's first-import-wins BOM merge rule. -->
       <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-bom</artifactId>
         <version>${spring.security.version}</version>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -45,7 +45,7 @@
     <previous.optimize.opensearch.version>2.9.0</previous.optimize.opensearch.version>
     <awssdk.version>2.28.13</awssdk.version>
 
-    <jetty.version>12.0.36</jetty.version>
+    <jetty.version>12.0.39</jetty.version>
     <jackson.version>2.21.6</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <apache.http5-client.version>5.6.4</apache.http5-client.version>


### PR DESCRIPTION
Bumps Optimize Jetty to 12.0.39 to address:
- CVE-2026-19203: HTTP request smuggling in chunked request parsing
- CVE-2026-19204: Denial of Service via large WebSocket payload with unknown opcode (not affected)

Closes https://github.com/camunda/camunda/issues/62672