### PR TITLE
feat: make debug-cli topology version aware

### DIFF
--- a/debug-cli/src/main/java/io/camunda/debug/cli/TopologyMetaCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/TopologyMetaCommand.java
@@ -7,16 +7,23 @@
  */
 package io.camunda.debug.cli;
 
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.Timestamps;
 import io.camunda.zeebe.dynamic.config.PersistedClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.PersistedClusterConfiguration.Header;
+import io.camunda.zeebe.dynamic.config.PersistedCurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.protocol.Topology;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Scanner;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
@@ -95,69 +102,106 @@ public class TopologyMetaCommand extends CommonOptions implements Callable<Integ
     return builder.build();
   }
 
+  public static Topology.CurrentClusterConfiguration parseCurrentClusterConfiguration(
+      final String json) throws InvalidProtocolBufferException {
+    final var builder = Topology.CurrentClusterConfiguration.newBuilder();
+    JsonFormat.parser().merge(json, builder);
+    return builder.build();
+  }
+
+  /**
+   * Saves the input JSON under the header version the file already has, so that an edit hands the
+   * broker back the same format it wrote and a print/edit/save round-trip stays lossless.
+   */
   private void saveFile(final Path file) throws IOException {
     final var json = source == null ? readInputFromStdin() : readInputFromFile();
+    final var version = versionOf(file);
 
-    final var protobuf = parseTopology(json);
+    final Message protobuf =
+        switch (version) {
+          case PersistedClusterConfiguration.VERSION -> parseTopology(json);
+          case PersistedCurrentClusterConfiguration.VERSION ->
+              parseCurrentClusterConfiguration(json);
+          default -> throw unsupportedVersion(file, version);
+        };
 
-    final var bytes = protobuf.toByteArray();
-    PersistedClusterConfiguration.writeToFile(bytes, file);
+    PersistedClusterConfiguration.writeToFile(protobuf.toByteArray(), file, version);
   }
 
   private void printFile(final Path path) throws IOException {
     final var content = Files.readAllBytes(path);
-    final var header = PersistedClusterConfiguration.Header.parseFrom(content, path);
+    final var header = Header.parseAnyVersion(content, path);
     spec.commandLine().getErr().println("Header: " + header);
     final var buffer =
         ByteBuffer.wrap(content, Header.HEADER_LENGTH, content.length - Header.HEADER_LENGTH);
 
-    final var protobuf = Topology.ClusterTopology.parseFrom(buffer);
+    final Message protobuf =
+        switch (header.version()) {
+          case PersistedClusterConfiguration.VERSION -> Topology.ClusterTopology.parseFrom(buffer);
+          case PersistedCurrentClusterConfiguration.VERSION ->
+              Topology.CurrentClusterConfiguration.parseFrom(buffer);
+          default -> throw unsupportedVersion(path, header.version());
+        };
+
     final var json = convertToJson(protobuf);
     spec.commandLine().getOut().println(json);
   }
 
-  public String convertToJson(final Topology.ClusterTopology topology) throws IOException {
-    try {
-      return JsonFormat.printer()
-          .includingDefaultValueFields()
-          .preservingProtoFieldNames()
-          .print(topology);
-    } catch (final IllegalArgumentException e) {
+  private byte versionOf(final Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return PersistedCurrentClusterConfiguration.VERSION;
+    }
+    return Header.parseAnyVersion(Files.readAllBytes(path), path).version();
+  }
+
+  private static IllegalArgumentException unsupportedVersion(final Path path, final byte version) {
+    return new IllegalArgumentException(
+        "Topology file %s has header version '%s', but only versions '%s' and '%s' are supported"
+            .formatted(
+                path,
+                version,
+                PersistedClusterConfiguration.VERSION,
+                PersistedCurrentClusterConfiguration.VERSION));
+  }
+
+  public String convertToJson(final Message message) throws InvalidProtocolBufferException {
+    final var printable = withPrintableTimestamps(message);
+    if (!printable.equals(message)) {
       spec.commandLine()
           .getErr()
-          .println(
-              "Invalid timestamp detected, fixing by setting lastUpdated to 0 for all members");
-
-      final var builder = Topology.ClusterTopology.newBuilder(topology);
-
-      // Create a new members map with lastUpdated set to 0
-      builder.clearMembers();
-      topology
-          .getMembersMap()
-          .forEach(
-              (memberId, memberState) -> {
-                final var fixedMemberState =
-                    Topology.MemberState.newBuilder(memberState)
-                        .setLastUpdated(
-                            com.google.protobuf.Timestamp.newBuilder()
-                                .setSeconds(0)
-                                .setNanos(0)
-                                .build())
-                        .build();
-                builder.putMembers(memberId, fixedMemberState);
-              });
-
-      final var fixedTopology = builder.build();
-
-      try {
-        return JsonFormat.printer()
-            .includingDefaultValueFields()
-            .preservingProtoFieldNames()
-            .print(fixedTopology);
-      } catch (final InvalidProtocolBufferException e2) {
-        throw new IOException("Failed to parse JSON into ClusterTopology: " + e2.getMessage(), e2);
-      }
+          .println("Out-of-range timestamp detected, printing it as the epoch instead");
     }
+
+    return JsonFormat.printer()
+        .includingDefaultValueFields()
+        .preservingProtoFieldNames()
+        .print(printable);
+  }
+
+  private static Message withPrintableTimestamps(final Message message) {
+    if (message instanceof final Timestamp timestamp) {
+      return Timestamps.isValid(timestamp) ? timestamp : Timestamp.getDefaultInstance();
+    }
+
+    final var builder = message.toBuilder();
+    message
+        .getAllFields()
+        .forEach(
+            (field, value) -> {
+              if (field.getJavaType() == JavaType.MESSAGE) {
+                builder.setField(field, withPrintableTimestamps(field, value));
+              }
+            });
+    return builder.build();
+  }
+
+  /** A map field arrives here as its list of entry messages, so map values are covered as well. */
+  private static Object withPrintableTimestamps(final FieldDescriptor field, final Object value) {
+    if (!field.isRepeated()) {
+      return withPrintableTimestamps((Message) value);
+    }
+    return ((List<?>) value)
+        .stream().map(entry -> withPrintableTimestamps((Message) entry)).toList();
   }
 
   private Path validateArguments() {

--- a/debug-cli/src/test/java/io/camunda/debug/cli/TopologyMetaCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/TopologyMetaCommandTest.java
@@ -10,16 +10,22 @@ package io.camunda.debug.cli;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import com.google.protobuf.Timestamp;
+import io.camunda.zeebe.dynamic.config.PersistedClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.PersistedCurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.protocol.Topology;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -32,12 +38,16 @@ public class TopologyMetaCommandTest {
   StringWriter err;
   StringWriter out;
 
+  /** A per-test copy of the legacy (header version 1) file, since some tests overwrite it. */
+  Path legacyFile;
+
   @BeforeEach
-  public void setup() {
+  public void setup() throws IOException {
     err = new StringWriter();
     out = new StringWriter();
     commandLine =
         new CommandLine(new Main()).setErr(new PrintWriter(err)).setOut(new PrintWriter(out));
+    legacyFile = copyLegacyFile();
   }
 
   @ParameterizedTest
@@ -59,37 +69,164 @@ public class TopologyMetaCommandTest {
   public void shouldUpdateTopologyFile(final String method) throws IOException {
     // given
     runWithMethod(method);
-    final var json = out.toString();
-    // convert the json to protobuf
-    final var protobuf = TopologyMetaCommand.parseTopology(json);
-    final var builder = protobuf.toBuilder();
-    builder.setVersion(999L);
-    final var modifiedJson = new TopologyMetaCommand().convertToJson(builder.build());
-
-    final var file = tempDir.resolve("scratch.json").toFile();
-    file.createNewFile();
-    Files.write(file.toPath(), modifiedJson.getBytes());
-    out.close();
-    out = new StringWriter();
+    final var protobuf = TopologyMetaCommand.parseTopology(out.toString());
+    final var modifiedJson =
+        new TopologyMetaCommand().convertToJson(protobuf.toBuilder().setVersion(999L).build());
+    final var source = Files.writeString(tempDir.resolve("scratch.json"), modifiedJson);
 
     // when
-    runWithMethod(method, "-s", "--source", file.toPath().toString());
+    runWithMethod(method, "-s", "--source", source.toString());
 
-    // then
-    out.close();
+    // then the legacy header version is kept, and the edit round-trips
+    assertThat(Files.readAllBytes(legacyFile)[0]).isEqualTo(PersistedClusterConfiguration.VERSION);
+
     out = new StringWriter();
     commandLine.setOut(new PrintWriter(out));
     runWithMethod(method);
-    final var changedJson = out.toString();
     // there's a newline difference, so trim() is needed
-    assertThat(changedJson.trim()).isEqualTo(modifiedJson.trim());
+    assertThat(out.toString().trim()).isEqualTo(modifiedJson.trim());
   }
 
-  public void runWithMethod(final String method, final String... extraArgs) {
-    // Get the file path from test resources
+  @ParameterizedTest
+  @ValueSource(strings = {"f", "file", "r", "root"})
+  public void shouldReadConfigurationFileWithHeaderVersion2(final String method)
+      throws IOException {
+    // given
+    final var configuration = configurationWith(timestamp(1758000000L));
+    final var file =
+        writeConfigurationFile(configuration, PersistedCurrentClusterConfiguration.VERSION);
+
+    // when
+    final var exitCode = runWithMethod(file, method);
+
+    // then
+    assertThat(exitCode).isZero();
+    assertThat(TopologyMetaCommand.parseCurrentClusterConfiguration(out.toString()))
+        .isEqualTo(configuration);
+  }
+
+  @Test
+  public void shouldUpdateConfigurationFileWithHeaderVersion2() throws IOException {
+    // given
+    final var file =
+        writeConfigurationFile(
+            configurationWith(timestamp(1758000000L)),
+            PersistedCurrentClusterConfiguration.VERSION);
+    final var updated =
+        configurationWith(timestamp(1758000000L)).toBuilder().setVersion(999L).build();
+    final var source =
+        Files.writeString(
+            tempDir.resolve("scratch.json"), new TopologyMetaCommand().convertToJson(updated));
+
+    // when
+    final var exitCode =
+        commandLine.execute("topology", "-s", "-f", file.toString(), "--source", source.toString());
+
+    // then
+    assertThat(exitCode).isZero();
+    assertThat(Files.readAllBytes(file)[0]).isEqualTo(PersistedCurrentClusterConfiguration.VERSION);
+
+    out = new StringWriter();
+    commandLine.setOut(new PrintWriter(out));
+    commandLine.execute("topology", "-f", file.toString());
+    assertThat(TopologyMetaCommand.parseCurrentClusterConfiguration(out.toString()))
+        .isEqualTo(updated);
+  }
+
+  @Test
+  public void shouldWriteHeaderVersion2ForNewFile() throws IOException {
+    // given
+    final var configuration = configurationWith(timestamp(1758000000L));
+    final var source =
+        Files.writeString(
+            tempDir.resolve("new.json"), new TopologyMetaCommand().convertToJson(configuration));
+    final var file = tempDir.resolve("new.topology.meta");
+
+    // when
+    final var exitCode =
+        commandLine.execute("topology", "-s", "-f", file.toString(), "--source", source.toString());
+
+    // then
+    assertThat(exitCode).isZero();
+    assertThat(Files.readAllBytes(file)[0]).isEqualTo(PersistedCurrentClusterConfiguration.VERSION);
+  }
+
+  @Test
+  public void shouldPrintConfigurationWithOutOfRangeTimestamp() throws IOException {
+    // given
+    final var file =
+        writeConfigurationFile(
+            configurationWith(timestamp(Long.MAX_VALUE)),
+            PersistedCurrentClusterConfiguration.VERSION);
+
+    // when
+    final var exitCode = commandLine.execute("topology", "-f", file.toString());
+
+    // then
+    assertThat(exitCode).isZero();
+    assertThat(
+            TopologyMetaCommand.parseCurrentClusterConfiguration(out.toString())
+                .getGlobalConfiguration()
+                .getMembersMap()
+                .get("0")
+                .getLastUpdated())
+        .isEqualTo(Timestamp.getDefaultInstance());
+  }
+
+  @Test
+  public void shouldRejectUnknownHeaderVersion() throws IOException {
+    // given
+    final var file = writeConfigurationFile(configurationWith(timestamp(1758000000L)), (byte) 3);
+
+    // when
+    final var exitCode = commandLine.execute("topology", "-f", file.toString());
+
+    // then
+    assertThat(exitCode).isEqualTo(2);
+  }
+
+  private Timestamp timestamp(final long seconds) {
+    return Timestamp.newBuilder().setSeconds(seconds).build();
+  }
+
+  private Topology.CurrentClusterConfiguration configurationWith(final Timestamp lastUpdated) {
+    return Topology.CurrentClusterConfiguration.newBuilder()
+        .setGlobalConfiguration(
+            Topology.GlobalConfiguration.newBuilder()
+                .setVersion(2L)
+                .setClusterId("3ebb310d-d796-4200-a3f6-1c2ce2a1b64a")
+                .putMembers(
+                    "0",
+                    Topology.BrokerState.newBuilder()
+                        .setVersion(1L)
+                        .setState(Topology.State.ACTIVE)
+                        .setLastUpdated(lastUpdated)
+                        .build()))
+        .build();
+  }
+
+  private Path writeConfigurationFile(
+      final Topology.CurrentClusterConfiguration configuration, final byte headerVersion)
+      throws IOException {
+    final var file = Files.createDirectories(tempDir.resolve("current")).resolve(".topology.meta");
+    PersistedClusterConfiguration.writeToFile(configuration.toByteArray(), file, headerVersion);
+    return file;
+  }
+
+  private Path copyLegacyFile() throws IOException {
     final var resourceUrl = getClass().getClassLoader().getResource(".topology.meta");
     Assertions.assertThat(resourceUrl).isNotNull();
-    final var filePath = resourceUrl.getPath();
+    final var target = tempDir.resolve(".topology.meta");
+    Files.copy(Path.of(resourceUrl.getPath()), target, StandardCopyOption.REPLACE_EXISTING);
+    return target;
+  }
+
+  public int runWithMethod(final String method, final String... extraArgs) {
+    return runWithMethod(legacyFile, method, extraArgs);
+  }
+
+  public int runWithMethod(final Path file, final String method, final String... extraArgs) {
+    final var filePath = file.toString();
 
     final var args = new ArrayList<String>();
     args.add("topology");
@@ -110,6 +247,6 @@ public class TopologyMetaCommandTest {
         throw new IllegalArgumentException("Unknown method: " + method);
     }
     args.addAll(Arrays.stream(extraArgs).toList());
-    commandLine.execute(args.toArray(new String[0]));
+    return commandLine.execute(args.toArray(new String[0]));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfiguration.java
@@ -28,7 +28,7 @@ import java.util.zip.CRC32C;
 public final class PersistedClusterConfiguration {
   // Header is a single byte for the version, followed by a long for the checksum.
   // Constant version, to be incremented if the format changes.
-  private static final byte VERSION = 1;
+  public static final byte VERSION = 1;
   private final Path topologyFile;
   private final ClusterConfigurationSerializer serializer;
   private ClusterConfiguration clusterConfiguration;
@@ -110,11 +110,16 @@ public final class PersistedClusterConfiguration {
    * @param path the path where to save the file
    */
   public static void writeToFile(final byte[] body, final Path path) throws IOException {
+    writeToFile(body, path, VERSION);
+  }
+
+  public static void writeToFile(final byte[] body, final Path path, final byte version)
+      throws IOException {
     final var checksum = checksum(body, 0, body.length);
     final var buffer =
         ByteBuffer.allocate(HEADER_LENGTH + body.length)
             .order(ByteOrder.LITTLE_ENDIAN)
-            .put(VERSION)
+            .put(version)
             .putLong(checksum)
             .put(body);
     Files.write(
@@ -162,18 +167,23 @@ public final class PersistedClusterConfiguration {
     public static final int HEADER_LENGTH = Byte.BYTES + Long.BYTES;
 
     public static Header parseFrom(final byte[] content, final Path topologyFile) {
+      final var header = parseAnyVersion(content, topologyFile);
+      if (header.version != VERSION) {
+        throw new UnexpectedVersion(topologyFile, header.version);
+      }
+      return header;
+    }
+
+    /**
+     * Parses the header without rejecting unknown versions, so a caller that can read more than one
+     * on-disk format dispatches on {@link #version()} itself.
+     */
+    public static Header parseAnyVersion(final byte[] content, final Path topologyFile) {
       if (content.length < HEADER_LENGTH) {
         throw new MissingHeader(topologyFile, content.length);
       }
       final var header = ByteBuffer.wrap(content, 0, HEADER_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
-      final var version = header.get();
-      final var expectedChecksum = header.getLong();
-
-      if (version != VERSION) {
-        throw new UnexpectedVersion(topologyFile, version);
-      }
-
-      return new Header(version, expectedChecksum);
+      return new Header(header.get(), header.getLong());
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
@@ -44,8 +44,8 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public final class PersistedCurrentClusterConfiguration {
 
+  public static final byte VERSION = 2;
   static final byte VERSION_LEGACY = 1;
-  static final byte VERSION = 2;
   private static final int HEADER_LENGTH = Byte.BYTES + Long.BYTES;
 
   private final Path configurationFile;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->


Read dispatches on the header version — version 1 keeps yielding `ClusterTopology` JSON, version 2
yields `CurrentClusterConfiguration` JSON. A save writes back the version the file already has, so
the JSON you print is the JSON you can edit and save; only a file that does not exist yet is created
as version 2. An unknown version now fails with a message naming the versions that are supported
instead of a confusing "expected version '1'".

The alternative — migrating legacy files to version 2 on save — was rejected: the broker already
migrates on its next read, and silently rewriting an operator's file into a different format is the
last thing a debug tool should do.

Supporting changes in `zeebe/dynamic-config`, both additive:

- `Header.parseAnyVersion` parses the header without rejecting unknown versions. `parseFrom` keeps
  its strict version 1 check by delegating to it, so the broker path is unchanged.
- `writeToFile` gains an overload taking the header version to stamp.

Printing also no longer dies on a corrupted timestamp. The previous fallback was specific to
`ClusterTopology` and blanked every member's `lastUpdated` whenever any timestamp was unprintable;
it is replaced by a walk that resets only the timestamps `JsonFormat` refuse

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [ ] This PR does not need a linked issue

