### PR TITLE
Fix nested vars merged to parent scope

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -95,7 +95,8 @@ public final class BpmnVariableMappingBehavior {
             context.getElementInstanceKey(),
             context.getProcessInstanceKey(),
             context.getProcessDefinitionKey(),
-            context.getTenantId());
+            context.getTenantId(),
+            context.getElementInstanceKey());
     final var result =
         inputMappingResolver.resolve(
             inputMappings.get(),
@@ -160,13 +161,15 @@ public final class BpmnVariableMappingBehavior {
         }
       }
 
+      final var mergeTargetScopeKey = getVariableScopeKey(context);
       final var mappingContext =
           new MappingContext(
               element.getId(),
               elementInstanceKey,
               processInstanceKey,
               processDefinitionKey,
-              tenantId);
+              tenantId,
+              mergeTargetScopeKey);
       final var resolveResult =
           outputMappingResolver.resolve(
               outputMappings.get(),
@@ -174,8 +177,7 @@ public final class BpmnVariableMappingBehavior {
       if (resolveResult.isLeft()) {
         return Either.left(resolveResult.getLeft());
       }
-      return propagateVariables(
-          context, element, getVariableScopeKey(context), resolveResult.get());
+      return propagateVariables(context, element, mergeTargetScopeKey, resolveResult.get());
 
     } else if (hasVariables) {
       // merge/propagate the event variables by default

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingContext.java
@@ -18,6 +18,16 @@ import org.jspecify.annotations.NullMarked;
  *
  * <p>{@code elementId} is kept as a {@link DirectBuffer} to avoid a String allocation on every
  * activation; the conversion happens only when this context is included in a log message.
+ *
+ * @param scopeKey the element's own scope, used to evaluate mapping source expressions
+ * @param mergeTargetScopeKey the scope the resolved result will be merged into: the element's own
+ *     scope for an input mapping, or the flow-scope key for an output mapping (unless the element
+ *     is an inner multi-instance activity, where it is again the element's own scope). Only {@code
+ *     OrderedOutputMappingResolver} reads this field, to seed a nested output target's merge from
+ *     the value already in that target scope instead of from the completing element's own,
+ *     about-to-be-discarded scope — see <a
+ *     href="https://github.com/camunda/camunda/issues/35251">#35251</a>. Every other resolver
+ *     ({@code CombinedOutputMappingResolver} and both input-mapping resolvers) ignores it.
  */
 @NullMarked
 public record MappingContext(
@@ -25,7 +35,8 @@ public record MappingContext(
     long scopeKey,
     long processInstanceKey,
     long processDefinitionKey,
-    String tenantId) {
+    String tenantId,
+    long mergeTargetScopeKey) {
 
   @Override
   public String toString() {
@@ -39,6 +50,8 @@ public record MappingContext(
         + processDefinitionKey
         + ", tenantId="
         + tenantId
+        + ", mergeTargetScopeKey="
+        + mergeTargetScopeKey
         + "]";
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingExpressionProcessor.java
@@ -68,6 +68,24 @@ public final class MappingExpressionProcessor {
   }
 
   /**
+   * Returns an evaluation context scoped to {@link MappingContext#mergeTargetScopeKey()} instead of
+   * the element instance: the scope an output mapping's result is merged into, as opposed to the
+   * scope its source expressions are evaluated against.
+   *
+   * <p>Used by {@code OrderedOutputMappingResolver} only, to seed a nested output target's merge
+   * from whatever the merge-target scope already holds, not from the completing element's own,
+   * about-to-be-discarded scope — see <a
+   * href="https://github.com/camunda/camunda/issues/35251">#35251</a>. No other resolver calls this
+   * method.
+   */
+  public ScopedEvaluationContext getMergeTargetEvaluationContext() {
+    return processor
+        .getEvaluationContext()
+        .processScoped(mappingContext.mergeTargetScopeKey())
+        .tenantScoped(tenantId);
+  }
+
+  /**
    * Evaluates the given expression against this processor's pre-scoped context.
    *
    * <p>The result is returned un-serialized so that a later mapping reading it (via a resolver's

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OrderedOutputMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OrderedOutputMappingResolver.java
@@ -18,12 +18,17 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Resolves output mappings one by one in modeling order. Each mapping's source expression sees the
  * results of the earlier mappings (they take priority over same-named scope variables) and falls
- * back to the element's variable scope otherwise. A nested target merges with the existing scope
- * value at every path level. Resolution stops at the first failing mapping.
+ * back to the element's variable scope otherwise. A nested target's emitted value merges with the
+ * value already at that path in the scope the result is merged into (not with the completing
+ * element's own scope — see <a href="https://github.com/camunda/camunda/issues/35251">#35251</a>).
+ * Resolution stops at the first failing mapping.
  *
- * <p>The scope value for nested-target merges is obtained from the pre-scoped evaluation context
- * carried by the {@link MappingExpressionProcessor}: the top-level variable is looked up there,
- * then navigated along the remaining path segments via {@link MsgPackPath}.
+ * <p>The scope value for nested-target merges is obtained from {@link
+ * MappingExpressionProcessor#getMergeTargetEvaluationContext()}: the top-level variable is looked
+ * up there, then navigated along the remaining path segments via {@link MsgPackPath}. This is the
+ * only resolver that calls that method, or that reads {@link MappingContext#mergeTargetScopeKey()}
+ * at all — {@link CombinedOutputMappingResolver} and the input-mapping resolvers evaluate entirely
+ * against the element's own scope and never need it.
  */
 @NullMarked
 public final class OrderedOutputMappingResolver implements MappingResolver<OutputMappings> {
@@ -34,9 +39,10 @@ public final class OrderedOutputMappingResolver implements MappingResolver<Outpu
     final var resultBuilder =
         new OutputMappingResultBuilder(
             path -> {
-              // the raw scope chain, not yet layered with this builder's own results: always
-              // MessagePack, since nothing has been prepended to the context here
-              final var value = processor.getEvaluationContext().getVariable(path.getFirst());
+              // the scope the result is merged into, not the completing element's own scope:
+              // always MessagePack, since nothing has been prepended to this context
+              final var value =
+                  processor.getMergeTargetEvaluationContext().getVariable(path.getFirst());
               final DirectBuffer rootValue =
                   value.isLeft()
                           && value.getLeft() instanceof ContextValue.MsgPack(final var buffer)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilder.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.variable;
 import io.camunda.zeebe.el.ContextValue;
 import io.camunda.zeebe.msgpack.spec.MsgPackCodes;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -21,12 +22,21 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * {@link MappingResultBuilder} for output mappings: a nested target merges with the existing scope
- * variable at every path level while accumulating — a context that is absent or holds a plain value
- * is seeded from the current scope value at that path. A scope value that is not a context cannot
- * be merged into, so the entry is poisoned to null, matching FEEL's {@code context
- * merge(<non-context>, {...})} behavior. Reads are not layered — the merge is already in the
- * document.
+ * {@link MappingResultBuilder} for output mappings.
+ *
+ * <p>{@link #getVariable(String)} answers purely from what mappings explicitly wrote so far in this
+ * evaluation pass — a nested target is a plain accumulated structure, never merged with any
+ * external value. This is what lets a later mapping's source expression read back an earlier,
+ * still-partial nested target without seeing branches that were never mapped (see {@code
+ * VariableOutputMappingTransformerTest#shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference}).
+ *
+ * <p>{@link #toDocument()} builds a separate, throwaway tree by replaying the writes in the order
+ * they happened, this time merging each nested target with the value already at that path in the
+ * scope the result will be merged into: a level that is absent or holds a plain value is seeded
+ * from that scope value; a scope value that is not a context poisons the level to null, matching
+ * FEEL's {@code context merge(<non-context>, {...})} behavior. Replaying (rather than reusing the
+ * live tree) is what keeps this merge from ever seeing a branch that was never written — see <a
+ * href="https://github.com/camunda/camunda/issues/35251">#35251</a>.
  */
 @NullMarked
 public final class OutputMappingResultBuilder extends MappingResultBuilder {
@@ -40,39 +50,50 @@ public final class OutputMappingResultBuilder extends MappingResultBuilder {
   private static final ContextValue NIL =
       new ContextValue.MsgPack(new UnsafeBuffer(new byte[] {MsgPackCodes.NIL}));
 
+  /**
+   * What mappings explicitly wrote, structured by target path. Never merged with any external value
+   * — see the class doc.
+   */
   private final Map<String, Entry> entries = new LinkedHashMap<>();
 
-  /** Resolves a target-path prefix to the scope value to seed a context from. */
-  private final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver;
+  /**
+   * Every {@link #put} call, insertion-ordered, replayed by {@link #toDocument()} against {@link
+   * #mergeTargetResolver} so the emitted document merges with the scope it is written into instead
+   * of whatever this builder's own live tree happens to hold.
+   */
+  private final List<Map.Entry<List<String>, ContextValue>> writes = new ArrayList<>();
 
   /**
-   * @param scopeValueResolver resolves a target-path prefix to the current scope value at that
-   *     path, or {@code null} when there is none; invoked only when a context must be (re)created
+   * Resolves a target-path prefix to the value at that path in the scope the result is merged into.
+   */
+  private final Function<List<String>, @Nullable DirectBuffer> mergeTargetResolver;
+
+  /**
+   * @param mergeTargetResolver resolves a target-path prefix to the value the scope the result is
+   *     merged into gives it, or {@code null} when there is none; invoked only when a level must be
+   *     (re)created while replaying writes for {@link #toDocument()}
    */
   public OutputMappingResultBuilder(
-      final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver) {
-    this.scopeValueResolver = scopeValueResolver;
+      final Function<List<String>, @Nullable DirectBuffer> mergeTargetResolver) {
+    this.mergeTargetResolver = mergeTargetResolver;
   }
 
   @Override
   public void put(final List<String> targetPath, final ContextValue value) {
+    final var copy = copyIfMsgPack(value);
+    writes.add(Map.entry(targetPath, copy));
+
     Map<String, Entry> current = entries;
     for (int i = 0; i < targetPath.size() - 1; i++) {
-      final var next = getOrSeedContext(current, targetPath.subList(0, i + 1));
-      if (next == null) {
-        return; // entry is poisoned: the mapped value is discarded, the entry stays null
-      }
-      current = next.entries();
+      current = descendInto(current, targetPath.get(i)).entries();
     }
-    current.put(targetPath.getLast(), new Entry.Value(copyIfMsgPack(value)));
+    current.put(targetPath.getLast(), new Entry.Value(copy));
   }
 
   /**
    * Returns the accumulated value of the given top-level variable, or {@code null} if no mapping
-   * has produced it yet. A nested structure is materialized on lookup — output reads are not
-   * layered, the merge is already in the document. A poisoned top-level entry returns {@link #NIL}
-   * (not Java {@code null}, which would let the caller fall back to the scope lookup instead of
-   * seeing the poisoned null).
+   * has produced it yet — {@code null} tells the caller to fall back to the scope lookup. Never
+   * merged with any external value: a nested target is exactly what mappings wrote so far.
    */
   @Override
   public @Nullable ContextValue getVariable(final String name) {
@@ -81,25 +102,61 @@ public final class OutputMappingResultBuilder extends MappingResultBuilder {
       return null;
     } else if (entry instanceof Entry.Value(final var value)) {
       return value;
-    } else if (entry instanceof Entry.Poisoned) {
-      return NIL;
     } else {
       final var context = (Entry.Context) entry;
       return materialize(context.entries());
     }
   }
 
+  /**
+   * Descends into the nested context at the given key, creating a fresh (never seeded) one if the
+   * current entry is absent or a plain value — an earlier mapping that assigned this whole path a
+   * plain value is discarded structurally, last-wins, exactly like {@link
+   * InputMappingResultBuilder}. Never consults any external scope: that only happens later, when
+   * {@link #toDocument()} replays the writes.
+   */
+  private Entry.Context descendInto(final Map<String, Entry> parent, final String key) {
+    final var entry = parent.get(key);
+    if (entry instanceof final Entry.Context context) {
+      return context;
+    }
+    final var fresh = new Entry.Context(new LinkedHashMap<>());
+    parent.put(key, fresh);
+    return fresh;
+  }
+
   @Override
   protected ContextValue.Structure snapshot() {
-    return materialize(entries);
+    final Map<String, Entry> emitted = new LinkedHashMap<>();
+    for (final var write : writes) {
+      applyToReplay(emitted, write.getKey(), write.getValue());
+    }
+    return materialize(emitted);
   }
 
   /**
-   * Returns the context at the given path prefix, creating it if the current entry is absent or a
-   * plain value. A newly created context is seeded with the top-level entries of the existing scope
-   * value at that path (its entries stay opaque {@link ContextValue.MsgPack} values); a scope value
-   * that is not a context poisons the entry instead. Returns {@code null} when the entry is (or
-   * becomes) poisoned.
+   * Replays one recorded write into {@code root}, merging nested targets with the merge-target
+   * scope.
+   */
+  private void applyToReplay(
+      final Map<String, Entry> root, final List<String> targetPath, final ContextValue value) {
+    Map<String, Entry> current = root;
+    for (int i = 0; i < targetPath.size() - 1; i++) {
+      final var next = getOrSeedContext(current, targetPath.subList(0, i + 1));
+      if (next == null) {
+        return; // entry is poisoned: the mapped value is discarded, the entry stays null
+      }
+      current = next.entries();
+    }
+    current.put(targetPath.getLast(), new Entry.Value(value));
+  }
+
+  /**
+   * Returns the context at the given path prefix (within the replay tree being built by {@link
+   * #snapshot()}), creating it if the current entry is absent or a plain value. A newly created
+   * context is seeded with the top-level entries of the merge-target scope value at that path (its
+   * entries stay opaque {@link ContextValue.MsgPack} values); a scope value that is not a context
+   * poisons the entry instead. Returns {@code null} when the entry is (or becomes) poisoned.
    */
   private Entry.@Nullable Context getOrSeedContext(
       final Map<String, Entry> parent, final List<String> pathPrefix) {
@@ -111,9 +168,10 @@ public final class OutputMappingResultBuilder extends MappingResultBuilder {
     if (entry instanceof final Entry.Context context) {
       return context;
     }
-    // Absent, or a plain value from an earlier mapping. Either way the context is (re)created from
-    // scratch, seeded from the SCOPE value rather than whatever that earlier mapping assigned.
-    final var scopeValue = scopeValueResolver.apply(pathPrefix);
+    // Absent, or a plain value from an earlier replayed write. Either way the context is
+    // (re)created from scratch, seeded from the merge-target scope rather than whatever that
+    // earlier write assigned.
+    final var scopeValue = mergeTargetResolver.apply(pathPrefix);
     if (scopeValue == null || isNil(scopeValue)) {
       final var fresh = new Entry.Context(new LinkedHashMap<>());
       parent.put(key, fresh);
@@ -141,13 +199,12 @@ public final class OutputMappingResultBuilder extends MappingResultBuilder {
   }
 
   /**
-   * Materializes a context (and its nested contexts) as an immutable snapshot. Not layered — the
-   * merge with the scope value already happened while accumulating, so reading it back is a plain
-   * copy. It is iterative for the same reason {@link MappingResultBuilder}'s writer is — a {@code
-   * zeebe:output} target path can have an unbounded number of '.'-separated segments
-   * (ZeebeExpressionValidator's path pattern doesn't cap it), and plain recursion here previously
-   * let a deeply-nested target throw an uncaught StackOverflowError before NestingDepthValidator
-   * ever got a chance to reject the document gracefully.
+   * Materializes a context (and its nested contexts) as an immutable snapshot. It is iterative for
+   * the same reason {@link MappingResultBuilder}'s writer is — a {@code zeebe:output} target path
+   * can have an unbounded number of '.'-separated segments (ZeebeExpressionValidator's path pattern
+   * doesn't cap it), and plain recursion here previously let a deeply-nested target throw an
+   * uncaught StackOverflowError before NestingDepthValidator ever got a chance to reject the
+   * document gracefully.
    */
   private static ContextValue.Structure materialize(final Map<String, Entry> rootEntries) {
     final Map<String, ContextValue> root = new LinkedHashMap<>();
@@ -173,29 +230,25 @@ public final class OutputMappingResultBuilder extends MappingResultBuilder {
   }
 
   /**
-   * One entry of the accumulated tree: either a value at a whole name, a nested context built by
-   * one or more dotted targets and merged with any scope value it was seeded from, or an entry
-   * whose scope value was not a context and so could not be merged into.
+   * One entry of an accumulated tree: either a value at a whole name, a nested context built by one
+   * or more dotted targets, or (only in a replay tree — see {@link #getOrSeedContext}) an entry
+   * whose merge-target scope value was not a context and so could not be merged into.
    */
   private sealed interface Entry {
     record Value(ContextValue value) implements Entry {}
 
     /**
-     * No flag recording whether this context replaced a plain value: unlike input mappings, output
-     * never falls through to a shadowed value on read, so nothing would ever read it.
-     *
      * @param entries the context's own entries: a nested {@link Context} or a {@link Value}
      */
     record Context(Map<String, Entry> entries) implements Entry {}
 
-    /** An entry whose scope value was not a context — see {@link #NIL}. */
+    /** An entry whose merge-target scope value was not a context — see {@link #NIL}. */
     record Poisoned() implements Entry {}
   }
 
   /**
    * One context still to be copied: the accumulated entries to read, and the map to write them
-   * into. Nothing is layered here — output merges the scope value in while accumulating, so a read
-   * is a plain copy.
+   * into.
    *
    * <p>{@code into} is installed in its parent before the copy is queued, so a parent's key order
    * is fixed when a nested context is <em>discovered</em>, not when it is filled — which is why

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
@@ -39,7 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 final class ComparingMappingResolverTest {
 
   private static final MappingContext CONTEXT =
-      new MappingContext(BufferUtil.wrapString("element-1"), 100L, 200L, 300L, "default");
+      new MappingContext(BufferUtil.wrapString("element-1"), 100L, 200L, 300L, "default", 100L);
 
   private static final InputMappings INPUT_MAPPINGS = mock(InputMappings.class);
   private static final MappingExpressionProcessor PROCESSOR =
@@ -306,7 +306,7 @@ final class ComparingMappingResolverTest {
               final String formattedMessage = e.getMessage().getFormattedMessage();
               assertThat(formattedMessage)
                   .contains(
-                      "MappingContext[elementId=element-1, scopeKey=100, processInstanceKey=200, processDefinitionKey=300, tenantId=default]");
+                      "MappingContext[elementId=element-1, scopeKey=100, processInstanceKey=200, processDefinitionKey=300, tenantId=default, mergeTargetScopeKey=100]");
             });
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
@@ -708,7 +708,7 @@ class InputMappingResolverComparisonTest {
       return new MappingExpressionProcessor(
           new ExpressionProcessor(EXPRESSION_LANGUAGE, context, DEFAULT_TIMEOUT)
               .withSecretReferenceContext(),
-          new MappingContext(BufferUtil.wrapString("test-element"), -1L, -1L, -1L, ""));
+          new MappingContext(BufferUtil.wrapString("test-element"), -1L, -1L, -1L, "", -1L));
     }
 
     /** Asserts both resolvers gave the exact same result document. */

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolverComparisonTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.variable;
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 
 import io.camunda.zeebe.el.ContextValue;
+import io.camunda.zeebe.el.EvaluationContext;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
@@ -43,6 +44,11 @@ class OutputMappingResolverComparisonTest {
 
   private static final OrderedOutputMappingResolver ORDERED = new OrderedOutputMappingResolver();
   private static final CombinedOutputMappingResolver COMBINED = new CombinedOutputMappingResolver();
+
+  // arbitrary, distinct scope keys used only by MergeTargetScopeIsOrderedOnly below, to prove
+  // which resolver actually looks up MappingContext#mergeTargetScopeKey()
+  private static final long ELEMENT_SCOPE_KEY = 1L;
+  private static final long MERGE_TARGET_SCOPE_KEY = 2L;
 
   @Nested
   @DisplayName("Non-overlapping targets")
@@ -84,6 +90,29 @@ class OutputMappingResolverComparisonTest {
     }
   }
 
+  @Nested
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
+  // @DisplayName("mergeTargetScopeKey is read by ORDERED only")
+  class MergeTargetScopeIsOrderedOnly {
+    @Test
+    void shouldSeedOrderedFromMergeTargetScopeAndCombinedFromElementScope() {
+      // given: "a" holds a different sibling in the element's own scope than in the scope the
+      // output mapping result will be merged into
+      final var elementScope = Map.<String, Object>of("a", Map.of("onlyInElementScope", 1));
+      final var mergeTargetScope = Map.<String, Object>of("a", Map.of("onlyInMergeTarget", 2));
+
+      final var r =
+          Helpers.resolveWithDistinctMergeTarget(
+              List.of(Helpers.mapping("=42", "a.b")), elementScope, mergeTargetScope);
+
+      // then: ORDERED merges the nested target with the MERGE TARGET's sibling — see #35251 —
+      // while COMBINED has no notion of a merge target and merges with the element's own scope
+      // instead, proving mergeTargetScopeKey is meaningless to it
+      Helpers.assertDiffers(
+          r, "{'a':{'b':42,'onlyInMergeTarget':2}}", "{'a':{'b':42,'onlyInElementScope':1}}");
+    }
+  }
+
   static final class Helpers {
 
     static ResolverResults resolve(final List<ZeebeMapping> m, final Map<String, Object> jobVars) {
@@ -107,9 +136,53 @@ class OutputMappingResolverComparisonTest {
       final var ee = encode(elementScope);
       final ScopedEvaluationContext ctx =
           name -> Either.left(ContextValue.msgPack(ee.getOrDefault(name, ej.get(name))));
-      final var ctx2 = new MappingContext(BufferUtil.wrapString("t"), -1L, -1L, -1L, "");
+      final var ctx2 = new MappingContext(BufferUtil.wrapString("t"), -1L, -1L, -1L, "", -1L);
       return new MappingExpressionProcessor(
           new ExpressionProcessor(EXPRESSION_LANGUAGE, ctx, DEFAULT_TIMEOUT), ctx2);
+    }
+
+    /**
+     * Like {@link #resolve}, but the element's own scope and the scope the result is merged into
+     * are backed by two separate maps, so a test can tell which scope a resolver actually read.
+     */
+    static ResolverResults resolveWithDistinctMergeTarget(
+        final List<ZeebeMapping> m,
+        final Map<String, Object> elementScope,
+        final Map<String, Object> mergeTargetScope) {
+      final var outputMappings =
+          new VariableMappingTransformer().transformOutputMappings(m, EXPRESSION_LANGUAGE);
+      final var processor = buildProcessorWithDistinctMergeTarget(elementScope, mergeTargetScope);
+      return new ResolverResults(
+          ORDERED.resolve(outputMappings, processor), COMBINED.resolve(outputMappings, processor));
+    }
+
+    private static MappingExpressionProcessor buildProcessorWithDistinctMergeTarget(
+        final Map<String, Object> elementScope, final Map<String, Object> mergeTargetScope) {
+      final var ee = encode(elementScope);
+      final var em = encode(mergeTargetScope);
+      final ScopedEvaluationContext elementCtx =
+          name -> Either.left(ContextValue.msgPack(ee.get(name)));
+      final ScopedEvaluationContext mergeTargetCtx =
+          name -> Either.left(ContextValue.msgPack(em.get(name)));
+      // the default (unscoped) view mirrors the element's own scope, matching what
+      // MappingExpressionProcessor's constructor immediately re-scopes to via ELEMENT_SCOPE_KEY
+      final ScopedEvaluationContext base =
+          new ScopedEvaluationContext() {
+            @Override
+            public Either<ContextValue, EvaluationContext> getVariable(final String name) {
+              return elementCtx.getVariable(name);
+            }
+
+            @Override
+            public ScopedEvaluationContext processScoped(final long scopeKey) {
+              return scopeKey == MERGE_TARGET_SCOPE_KEY ? mergeTargetCtx : elementCtx;
+            }
+          };
+      final var mappingContext =
+          new MappingContext(
+              BufferUtil.wrapString("t"), ELEMENT_SCOPE_KEY, -1L, -1L, "", MERGE_TARGET_SCOPE_KEY);
+      return new MappingExpressionProcessor(
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, base, DEFAULT_TIMEOUT), mappingContext);
     }
 
     private static Map<String, DirectBuffer> encode(final Map<String, Object> vars) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilderTest.java
@@ -49,16 +49,19 @@ final class OutputMappingResultBuilderTest {
 
   @Test
   void shouldPoisonLevelWhenScopeValueIsNotAMap() {
-    // given: scope has a = 5
+    // given: merge target has a = 5
     final var builder =
         new OutputMappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when
     builder.put(List.of("a", "b"), msgPack("1"));
 
-    // then: the level is null, like FEEL's context merge(5, {...})
+    // then: the emitted level is null, like FEEL's context merge(5, {...}) — poisoning is a
+    // document-only concept: a read of "a" mid-evaluation sees exactly what was written, since it
+    // never merges with the merge target at all (see the class doc)
     assertEquality(builder.toDocument(), "{'a': null}");
-    assertEquality(((ContextValue.MsgPack) builder.getVariable("a")).buffer(), "null");
+    final var read = (ContextValue.Structure) builder.getVariable("a");
+    assertEquality(MappingResultBuilder.toMsgPack(read), "{'b': 1}");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -270,26 +269,13 @@ public final class VariableOutputMappingTransformerTest {
   }
 
   @Test
-  @Disabled(
-      "context merge() with the current scope leaks an untouched sibling ('p') into the merge "
-          + "target and a later back-reference to it, instead of building a mapping-only result "
-          + "(input mappings already do this post-#58801). Cannot be enabled without the #35251 "
-          + "fix: the desired drop-the-sibling result conflicts with the pinned 'merge target "
-          + "with variable' case, which requires the sibling to be kept — both go through the "
-          + "same seed-from-scope path. Tracked under "
-          + "https://github.com/camunda/camunda/issues/35251.")
   void shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference() {
     final var mappings = List.of(mapping("1", "a.b"), mapping("a", "d"));
     final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'p':0}"));
     final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when
-    final var resultBuilder =
-        new OutputMappingResultBuilder(
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null));
+    final var resultBuilder = new OutputMappingResultBuilder(path -> null);
     for (final var mapping : outputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -306,24 +292,13 @@ public final class VariableOutputMappingTransformerTest {
   }
 
   @Test
-  @Disabled(
-      "Same leak as shouldNotLeakUntouchedSiblingIntoMergeTargetOrBackReference, opposite "
-          + "mapping order: the back-reference runs before 'a' is ever written, so it correctly "
-          + "keeps 'p'; only the later merge target should drop it. Cannot be enabled without "
-          + "the #35251 fix (see the sibling case). Tracked under "
-          + "https://github.com/camunda/camunda/issues/35251.")
   void shouldNotLeakUntouchedSiblingIntoMergeTargetOppositeOrder() {
     final var mappings = List.of(mapping("a", "d"), mapping("1", "a.b"));
     final Map<String, DirectBuffer> variables = Map.of("a", asMsgPack("{'p':0}"));
     final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
 
     // when
-    final var resultBuilder =
-        new OutputMappingResultBuilder(
-            path ->
-                Optional.ofNullable(variables.get(path.getFirst()))
-                    .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                    .orElse(null));
+    final var resultBuilder = new OutputMappingResultBuilder(path -> null);
     for (final var mapping : outputMappings.mappings()) {
       final EvaluationContext context =
           name -> {


### PR DESCRIPTION
## Description

Ensure that only the mappings explicitly defined as outputs are propagated to the parent scope, while all other sibling elements remain isolated within the local scope.

## Related issues

closes #35251

