### PR TITLE
feat: add spectral rule to catch required entries redundant with allOf

### DIFF
--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -8,6 +8,7 @@ functions:
   - verifyKeyTypesSchemas
   - verifyEventuallyConsistent
   - verifyRequiredPropertiesExist
+  - verifyNoRedundantRequired
   - verifyArrayPropertiesRequired
   - verifyResponsePropertiesRequired
   - verifyDeprecatedEnumMembers
@@ -122,6 +123,14 @@ rules:
     given: "$.components.schemas[*]"
     then:
       function: verifyRequiredPropertiesExist
+
+  no-redundant-required:
+    description: "A schema's own `required` list must not duplicate a field already required by an allOf-composed schema."
+    severity: error
+    given: "$.components.schemas[*]"
+    message: "{{error}}"
+    then:
+      function: verifyNoRedundantRequired
 
   array-properties-must-be-required:
     description: "Response array properties must be `required` and not `nullable`."

--- a/zeebe/gateway-protocol/spectral-functions/verifyNoRedundantRequired.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyNoRedundantRequired.js
@@ -1,0 +1,50 @@
+// Spectral custom function to verify that a schema's own `required` array
+// does not redundantly re-list a field that is already required by one of
+// its `allOf`-composed schemas.
+//
+// A field required by an allOf member is already required for the composed
+// schema (JSON Schema `allOf` unions the required sets of all members), so
+// redeclaring it locally adds nothing and tends to drift — e.g. a rename or
+// removal of the field on the inherited schema needs a second edit here that
+// is easy to forget. See camunda/camunda#55914 for a case where four
+// statistics result schemas redundantly re-listed `page`, already required
+// via `SearchQueryResponse`.
+
+module.exports = (input, _opts, context) => {
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+
+  const { required, allOf } = input;
+
+  if (!Array.isArray(required) || !Array.isArray(allOf)) {
+    return [];
+  }
+
+  const inheritedRequired = new Set();
+
+  function collectInheritedRequired(schema) {
+    if (!schema || typeof schema !== 'object') return;
+    if (Array.isArray(schema.required)) {
+      schema.required.forEach((name) => inheritedRequired.add(name));
+    }
+    if (Array.isArray(schema.allOf)) {
+      schema.allOf.forEach(collectInheritedRequired);
+    }
+  }
+
+  allOf.forEach(collectInheritedRequired);
+
+  const errors = [];
+
+  required.forEach((name, index) => {
+    if (inheritedRequired.has(name)) {
+      errors.push({
+        message: `\`${name}\` is already required via an allOf-composed schema; remove the redundant entry from this schema's own \`required\` list.`,
+        path: [...context.path, 'required', index],
+      });
+    }
+  });
+
+  return errors;
+};

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/no-redundant-required/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/no-redundant-required/things.yaml
@@ -1,0 +1,97 @@
+# Domain file for no-redundant-required rule test fixture.
+# Schema-level rule (given: $.components.schemas[*]) — no paths needed, only
+# components.schemas exercising valid and invalid required/allOf shapes.
+openapi: "3.0.3"
+info:
+  title: No-redundant-required test schemas
+  version: "1.0"
+paths: {}
+
+components:
+  schemas:
+
+    # ── Base schemas used as allOf targets ────────────────────────────
+
+    BaseThing:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The identifier.
+
+    WrapperOfBase:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseThing'
+
+    # ── Valid: no allOf at all ─────────────────────────────────────────
+    ValidNoAllOf:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name.
+
+    # ── Valid: allOf present, no overlap with own required ─────────────
+    ValidNoOverlap:
+      type: object
+      required:
+        - items
+      allOf:
+        - $ref: '#/components/schemas/BaseThing'
+      properties:
+        items:
+          type: array
+          items:
+            type: string
+          description: The items.
+
+    # ── Invalid: own required duplicates a direct allOf member's required ──
+    InvalidDirectDuplicate:
+      type: object
+      required:
+        - id
+        - items
+      allOf:
+        - $ref: '#/components/schemas/BaseThing'
+      properties:
+        items:
+          type: array
+          items:
+            type: string
+          description: The items.
+
+    # ── Invalid: multiple redundant entries in one schema ───────────────
+    # (BaseThing requires `id`; this schema also redundantly requires
+    # a second field that happens to already be required elsewhere via a
+    # second allOf member.)
+    OtherBase:
+      type: object
+      required:
+        - otherId
+      properties:
+        otherId:
+          type: string
+          description: Another identifier.
+
+    InvalidMultipleDuplicates:
+      type: object
+      required:
+        - id
+        - otherId
+      allOf:
+        - $ref: '#/components/schemas/BaseThing'
+        - $ref: '#/components/schemas/OtherBase'
+      properties: {}
+
+    # ── Invalid: redundant against a transitive (allOf-of-allOf) parent ──
+    InvalidTransitiveDuplicate:
+      type: object
+      required:
+        - id
+      allOf:
+        - $ref: '#/components/schemas/WrapperOfBase'

--- a/zeebe/gateway-protocol/spectral-tests/verifyNoRedundantRequired.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyNoRedundantRequired.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixtureFile, filterByRule, filterByPathSegment } = require('./helpers');
+
+const RULE = 'no-redundant-required';
+const FIXTURE = 'no-redundant-required';
+
+describe('verifyNoRedundantRequired', () => {
+  let violations;
+
+  before(() => {
+    const allResults = lintFixtureFile(FIXTURE, 'things.yaml');
+    violations = filterByRule(allResults, RULE);
+  });
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid: schema with no allOf', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'ValidNoAllOf');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: allOf present but no overlap with own required', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'ValidNoOverlap');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid: own required duplicates a direct allOf member', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidDirectDuplicate');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the duplicated field name', () => {
+      const v = filterByPathSegment(violations, 'InvalidDirectDuplicate');
+      assert.match(v[0].message, /`id`/);
+      assert.match(v[0].message, /already required via an allOf-composed schema/);
+    });
+  });
+
+  describe('invalid: multiple redundant entries against separate allOf members', () => {
+    it('flags two violations', () => {
+      const v = filterByPathSegment(violations, 'InvalidMultipleDuplicates');
+      assert.equal(v.length, 2);
+    });
+
+    it('reports both duplicated field names', () => {
+      const v = filterByPathSegment(violations, 'InvalidMultipleDuplicates');
+      const messages = v.map((e) => e.message);
+      assert.ok(messages.some((m) => /`id`/.test(m)));
+      assert.ok(messages.some((m) => /`otherId`/.test(m)));
+    });
+  });
+
+  describe('invalid: redundant against a transitive (allOf-of-allOf) parent', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidTransitiveDuplicate');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the duplicated field name', () => {
+      const v = filterByPathSegment(violations, 'InvalidTransitiveDuplicate');
+      assert.match(v[0].message, /`id`/);
+    });
+  });
+
+  // ── Total count ──────────────────────────────────────────────────
+
+  it('produces exactly 4 violations across all schemas', () => {
+    assert.equal(violations.length, 4);
+  });
+});

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -903,7 +903,6 @@ components:
     JobWaitStateDetails:
       type: object
       required:
-        - waitStateType
         - jobKey
         - jobType
         - jobKind
@@ -937,7 +936,6 @@ components:
     MessageWaitStateDetails:
       type: object
       required:
-        - waitStateType
         - messageName
         - correlationKey
       allOf:
@@ -954,7 +952,6 @@ components:
     UserTaskWaitStateDetails:
       type: object
       required:
-        - waitStateType
         - taskKey
         - dueDate
       allOf:
@@ -973,7 +970,6 @@ components:
     TimerWaitStateDetails:
       type: object
       required:
-        - waitStateType
         - dueDate
         - repetitions
       allOf:
@@ -993,7 +989,6 @@ components:
     SignalWaitStateDetails:
       type: object
       required:
-        - waitStateType
         - signalName
       allOf:
         - $ref: '#/components/schemas/BaseWaitStateDetails'
@@ -1006,7 +1001,6 @@ components:
     ConditionWaitStateDetails:
       type: object
       required:
-        - waitStateType
         - expression
         - events
       allOf:


### PR DESCRIPTION
## Description

No existing Spectral rule catches a schema redundantly re-declaring a field in its own `required` list when that field is already required via `allOf` composition. The closest rule, `response-properties-must-be-required`, only checks the opposite direction (every property listed *somewhere* in required, not that it isn't duplicated). This let two independent instances of the same bug land undetected:

- `job-metrics.yaml` — `page` redundantly required in 4 statistics result schemas, fixed in #55914
- `element-instances.yaml` — `waitStateType` redundantly required in 6 `*WaitStateDetails` schemas, fixed in this PR

This PR:
1. Removes the 6 pre-existing redundant `waitStateType` entries in `element-instances.yaml` (separate commit) — required so the new rule can land at `severity: error` without immediately failing CI on `main`.
2. Adds a new `no-redundant-required` Spectral rule (`verifyNoRedundantRequired.js`) that walks a schema's `allOf` members (recursively, so it also catches allOf-of-allOf/transitive cases) and flags any of its own `required` entries that duplicate one already required by an inherited schema.

## Why this matters

Both redundant-`required` cases above only surfaced via an external bug report + fix PR (#55782 → #55914) or manual code review — nothing in CI caught them. This closes that gap going forward.

## Testing

- New unit tests (`verifyNoRedundantRequired.test.js` + fixture) covering: no-allOf, no-overlap, direct duplicate, multiple duplicates, and transitive (allOf-of-allOf) duplicates.
- Full `spectral-tests` suite: 204/204 pass.
- Both CI-mirroring lint passes (structural `rest-api.yaml` + file-level glob) run clean with zero errors against the current spec.
- Verified prior to fixing: without the `element-instances.yaml` cleanup, the new rule flagged exactly the 6 known instances there and nothing else across the entire spec.

## Checklist

- [ ] Enable backports when necessary (fex. for bug fixes, for CI changes, or for documentation changes).

## Related issues

closes #62560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
