### PR TITLE
fix: stop logging a false-positive suspension-gate bug on every command

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehavior.java
@@ -68,10 +68,10 @@ public final class SuspensionBehavior {
         switch (marker) {
           case SUSPENDED -> onSuspended(suspensionAware, command);
           case RESUMING -> onResuming(suspensionAware, command);
-          case null -> null;
+          case null -> SuspensionAction.PROCESS;
         };
 
-    // captures onSuspended and onResuming null return values along with null markers
+    // captures onSuspended/onResuming returning null in violation of their contract
     if (action == null) {
       LOG.error(
           "Processor '{}' implements SuspensionAware but returned a null suspension behavior for"


### PR DESCRIPTION
## Description

`SuspensionBehavior.process` gates a `SuspensionAware` processor's command on its target process instance's suspension marker. `getSuspensionState(long)` is `@Nullable` and returns `null` whenever the instance carries no suspension marker at all, which is the normal case for virtually every process instance (none of them call suspend/resume).

A prior refactor ([#62241](https://github.com/camunda/camunda/pull/62241), commit `f4b607efa0ac`) changed the switch's null-marker arm from `SuspensionAction.PROCESS` to `null`, which merged the harmless "no marker" case into the same `action == null` branch meant to catch a `SuspensionAware` processor that violates its `onSuspended`/`onResuming` contract by returning `null`. Since no processor implementation actually does that, every ERROR log line was coming from the harmless "no marker" case, firing on nearly all engine traffic and flooding logs on load-test clusters where suspend/resume is rarely exercised.

This restores the null-marker arm to `SuspensionAction.PROCESS` so it no longer trips the genuine-bug check, and rewords that check's comment to describe only what it still guards against.

Log volume only, no functional impact: the gate already fell back to processing normally in both the old and buggy code paths, so no commands were ever rejected, buffered, or misprocessed.

This bug only exists on `main` (introduced 2026-09-10, not yet on any `stable/*` branch), so no backport is needed.

## Checklist

- [x] Enable backports when necessary (not applicable - the regression only exists on `main`)

## Related issues

- [x] This PR does not need a linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)