### PR TITLE
fix: grant SECRET:REVEAL to the default Connectors role

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DefaultRolesIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DefaultRolesIT.java
@@ -102,13 +102,6 @@ final class DefaultRolesIT {
   }
 
   @RegressionTest("https://github.com/camunda/connectors/issues/8222")
-  @DisabledIfSystemProperty(
-      named = "test.integration.camunda.physical-tenant",
-      matches = ".+",
-      disabledReason =
-          "Secret authorization is resolved against root storage under a physical tenant, so the "
-              + "Connectors role grant is not visible in the tenant context; see "
-              + "https://github.com/camunda/camunda/issues/58393")
   void shouldResolveSecrets(@Authenticated(CONNECTORS_USERNAME) final CamundaClient client) {
     // when
     final var response =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DefaultRolesIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DefaultRolesIT.java
@@ -102,6 +102,13 @@ final class DefaultRolesIT {
   }
 
   @RegressionTest("https://github.com/camunda/connectors/issues/8222")
+  @DisabledIfSystemProperty(
+      named = "test.integration.camunda.physical-tenant",
+      matches = ".+",
+      disabledReason =
+          "Secret authorization is resolved against root storage under a physical tenant, so the "
+              + "Connectors role grant is not visible in the tenant context; see "
+              + "https://github.com/camunda/camunda/issues/58393")
   void shouldResolveSecrets(@Authenticated(CONNECTORS_USERNAME) final CamundaClient client) {
     // when
     final var response =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DefaultRolesIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DefaultRolesIT.java
@@ -22,6 +22,8 @@ import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -31,9 +33,19 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 final class DefaultRolesIT {
+
+  private static final String TOKEN_VALUE = "token-file-value";
+  private static final String KNOWN_REFERENCE = "camunda.secrets.token";
+
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
-      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withFileBasedSecretStore(
+              directory -> {
+                Files.writeString(directory.resolve("token"), TOKEN_VALUE, StandardCharsets.UTF_8);
+              });
 
   private static final String DEFAULT_PASSWORD = "password";
   private static final String CONNECTORS_USERNAME = "connectors";
@@ -87,5 +99,19 @@ final class DefaultRolesIT {
 
     // then
     assertThat((Future<?>) result).succeedsWithin(Duration.ofSeconds(30));
+  }
+
+  @RegressionTest("https://github.com/camunda/connectors/issues/8222")
+  void shouldResolveSecrets(@Authenticated(CONNECTORS_USERNAME) final CamundaClient client) {
+    // when
+    final var response =
+        client.newResolveSecretsCommand().references(List.of(KNOWN_REFERENCE)).send().join();
+
+    // then the connectors role's default SECRET:REVEAL grant lets it resolve without any
+    // additional authorization being configured
+    assertThat(response.isFullyResolved()).isTrue();
+    assertThat(response.getResolved()).hasSize(1);
+    assertThat(response.getResolved().get(0).getReference()).isEqualTo(KNOWN_REFERENCE);
+    assertThat(response.getResolved().get(0).getValue()).isEqualTo(TOKEN_VALUE);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/PlatformDefaultEntities.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/PlatformDefaultEntities.java
@@ -173,6 +173,14 @@ public class PlatformDefaultEntities {
             .setResourceMatcher(WILDCARD.getMatcher())
             .setResourceId(WILDCARD.getResourceId())
             .setPermissionTypes(Set.of(PermissionType.EVALUATE)));
+    setupRecord.addAuthorization(
+        new AuthorizationRecord()
+            .setOwnerType(AuthorizationOwnerType.ROLE)
+            .setOwnerId(connectorsRoleId)
+            .setResourceType(AuthorizationResourceType.SECRET)
+            .setResourceMatcher(WILDCARD.getMatcher())
+            .setResourceId(WILDCARD.getResourceId())
+            .setPermissionTypes(Set.of(PermissionType.REVEAL)));
     setupRecord.addTenantMember(
         new TenantRecord()
             .setTenantId(DEFAULT_TENANT_ID)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -393,7 +393,11 @@ public class IdentitySetupInitializeDefaultsTest {
                 Assertions.assertThat(auth)
                     .hasResourceType(AuthorizationResourceType.DOCUMENT)
                     .hasOnlyPermissionTypes(
-                        PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE));
+                        PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.SECRET)
+                    .hasOnlyPermissionTypes(PermissionType.REVEAL));
   }
 
   @Test


### PR DESCRIPTION
## Description

The Connector Runtime authenticates with the built-in **Connectors** role. Resolving
`camunda.secrets.<name>` references through `POST /v2/secrets/resolve` requires the
`SECRET:REVEAL` permission, but that permission is missing from the role's default
authorizations. As a result, centralized secret references do not work without manually
granting additional access.

This PR grants the Connectors role `REVEAL` access to all secrets by default. It deliberately
does not grant `READ`, because the runtime resolves known references but does not need to list
available secrets.

Default identities and authorizations are applied again when a broker starts, so existing
clusters receive the missing authorization after a broker restart; no migration or
reprovisioning is required.

## Test coverage

- Updates the engine test that verifies the Connectors role's complete set of default
  authorizations.
- Adds an acceptance test that authenticates as the Connectors user and resolves a real secret
  from a file-based secret store.

## Checklist

- [ ] Enable backports when necessary (for example, for bug fixes).

## Related issues

Relates to camunda/connectors#8222

- [x] This PR does not need a linked issue
