### PR TITLE
test: attribute the history purge to its instance and scope cancel's 404 swallow

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-draining-state.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-draining-state.spec.ts
@@ -85,7 +85,9 @@ test.describe('Process Definition Draining State', () => {
       [],
     );
 
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
 
     await expectDefinitionKeysForState(
       request,
@@ -136,7 +138,9 @@ test.describe('Process Definition Draining State', () => {
       expect(items[0]!.state).toBe('DRAINING');
     }).toPass(defaultAssertionOptions);
 
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
     await expectProcessDefinitionDeleted(request, v2.processDefinitionKey);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
@@ -126,7 +126,7 @@ test.describe('Process Definition Draining Deletion API', () => {
   // reuses it, so every instance started here has to be terminated.
   test.afterEach(async () => {
     for (const processInstanceKey of instancesToCancel.filter(Boolean)) {
-      await cancelProcessInstance(processInstanceKey, {ignoreNotFound: true});
+      await cancelProcessInstance(processInstanceKey);
     }
   });
 
@@ -178,7 +178,9 @@ test.describe('Process Definition Draining Deletion API', () => {
     await findUserTask(request, instance.processInstanceKey, 'CREATED');
     await drainProcessDefinition(request, processDefinitionKey);
 
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
 
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
   });
@@ -203,7 +205,9 @@ test.describe('Process Definition Draining Deletion API', () => {
     await drainProcessDefinition(request, processDefinitionKey);
 
     for (let ended = 1; ended < instances.length; ended++) {
-      await cancelProcessInstance(instances[ended - 1]!.processInstanceKey);
+      await cancelProcessInstance(instances[ended - 1]!.processInstanceKey, {
+        ignoreNotFound: false,
+      });
       await expectProcessInstanceCount(
         request,
         {processDefinitionId, state: 'ACTIVE'},
@@ -218,6 +222,9 @@ test.describe('Process Definition Draining Deletion API', () => {
 
     await cancelProcessInstance(
       instances[instances.length - 1]!.processInstanceKey,
+      {
+        ignoreNotFound: false,
+      },
     );
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
   });
@@ -261,7 +268,9 @@ test.describe('Process Definition Draining Deletion API', () => {
     await drainProcessDefinition(request, childKey);
     await expectProcessDefinitionState(request, parentKey, 'ACTIVE');
 
-    await cancelProcessInstance(parentInstance.processInstanceKey);
+    await cancelProcessInstance(parentInstance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
 
     await expectProcessDefinitionDeleted(request, childKey);
   });
@@ -546,7 +555,9 @@ test.describe('Process Definition Draining Deletion API', () => {
 
     // Cancelling keeps the test off the user-task index, the slowest propagation
     // path.
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
 
     await expectProcessInstanceCount(request, {processDefinitionId}, 1);
@@ -577,7 +588,9 @@ test.describe('Process Definition Draining Deletion API', () => {
     // History is retained for as long as the definition is draining.
     await expectProcessInstanceCount(request, {processDefinitionId}, 1);
 
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
 
     // The purge takes the definition record with it, so there is nothing left to
     // read back.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
@@ -23,6 +23,7 @@ import {
   expectProcessDefinitionDeleted,
   expectProcessDefinitionPurged,
   expectProcessDefinitionState,
+  expectBatchState,
   expectProcessInstanceCount,
   findUserTask,
   RESOURCE_DELETION_ENDPOINT,
@@ -67,32 +68,19 @@ async function startedInstanceOf(
   return res.json();
 }
 
-type HistoryBatchOperation = {batchOperationKey: string; state: string};
-
-/**
- * Every history-deletion batch operation currently known. The item names no
- * process definition, so the one a purge creates is only identifiable by
- * diffing against a snapshot taken before the delete.
- */
-async function historyBatchOperations(
+// Matched on the item, since parallel specs create DELETE_PROCESS_INSTANCE too.
+async function historyBatchOperationKeyFor(
   request: APIRequestContext,
-): Promise<HistoryBatchOperation[]> {
-  const res = await request.post(buildUrl('/batch-operations/search'), {
+  processInstanceKey: string,
+): Promise<string | undefined> {
+  const res = await request.post(buildUrl('/batch-operation-items/search'), {
     headers: jsonHeaders(),
-    data: {
-      filter: {operationType: 'DELETE_PROCESS_INSTANCE'},
-      // Newest first, so the operation this test is looking for is on the
-      // first page however many a shared cluster has already accumulated.
-      sort: [{field: 'startDate', order: 'DESC'}],
-      page: {limit: DEFAULT_PAGE_LIMIT},
-    },
+    data: {filter: {processInstanceKey}, page: {limit: DEFAULT_PAGE_LIMIT}},
   });
   await assertStatusCode(res, 200);
-  const items: HistoryBatchOperation[] = (await res.json()).items ?? [];
-  return items.map((item) => ({
-    batchOperationKey: String(item.batchOperationKey),
-    state: item.state,
-  }));
+  const items: Array<{batchOperationKey: string}> =
+    (await res.json()).items ?? [];
+  return items.length === 0 ? undefined : String(items[0]!.batchOperationKey);
 }
 
 async function partitionsCount(request: APIRequestContext): Promise<number> {
@@ -138,7 +126,7 @@ test.describe('Process Definition Draining Deletion API', () => {
   // reuses it, so every instance started here has to be terminated.
   test.afterEach(async () => {
     for (const processInstanceKey of instancesToCancel.filter(Boolean)) {
-      await cancelProcessInstance(processInstanceKey);
+      await cancelProcessInstance(processInstanceKey, {ignoreNotFound: true});
     }
   });
 
@@ -561,7 +549,7 @@ test.describe('Process Definition Draining Deletion API', () => {
     await cancelProcessInstance(instance.processInstanceKey);
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
 
-    expect(await instanceCountFor(request, processDefinitionId)).toBe(1);
+    await expectProcessInstanceCount(request, {processDefinitionId}, 1);
   });
 
   test('With deleteHistory the instance history is purged by a batch operation once the drain finishes', async ({
@@ -572,12 +560,6 @@ test.describe('Process Definition Draining Deletion API', () => {
       await deployUserTaskProcess(processDefinitionId);
     const instance = await createInstanceOnceDeployed(processDefinitionId, 1);
     instancesToCancel.push(instance.processInstanceKey);
-
-    const batchOperationKeysBefore = new Set(
-      (await historyBatchOperations(request)).map(
-        (item) => item.batchOperationKey,
-      ),
-    );
 
     const deletion = await deleteProcessDefinition(
       request,
@@ -593,7 +575,7 @@ test.describe('Process Definition Draining Deletion API', () => {
       'DRAINING',
     );
     // History is retained for as long as the definition is draining.
-    expect(await instanceCountFor(request, processDefinitionId)).toBe(1);
+    await expectProcessInstanceCount(request, {processDefinitionId}, 1);
 
     await cancelProcessInstance(instance.processInstanceKey);
 
@@ -608,15 +590,14 @@ test.describe('Process Definition Draining Deletion API', () => {
       extendedAssertionOptions,
     );
 
-    // The purge runs as a batch operation, and it has to reach COMPLETED —
-    // otherwise history lingers with nothing left to retry. Only the snapshot
-    // diff identifies it, so "created exactly once" stays a manual check.
+    // Must reach COMPLETED, or history lingers with nothing left to retry.
     await expect(async () => {
-      const created = (await historyBatchOperations(request)).filter(
-        (item) => !batchOperationKeysBefore.has(item.batchOperationKey),
+      const batchOperationKey = await historyBatchOperationKeyFor(
+        request,
+        instance.processInstanceKey,
       );
-      expect(created.length).toBeGreaterThan(0);
-      expect(created.map((item) => item.state)).toContain('COMPLETED');
+      expect(batchOperationKey).not.toBeUndefined();
+      await expectBatchState(request, batchOperationKey!, 'COMPLETED');
     }).toPass(extendedAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
@@ -290,7 +290,9 @@ test.describe('Operate Process Definition Draining — lifecycle and incidents',
 
     // The dashboard panel counts running instances, so the whole row goes, not
     // just the marker.
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
 
     await waitForAssertion({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -103,14 +103,19 @@ const createSingleInstance = async (
   });
 };
 
-const cancelProcessInstance = async (processInstanceKey: string) => {
+// Defaults to swallowing 404 -- the existing behaviour every other caller in
+// this suite already relies on for teardown. Pass ignoreNotFound: false when
+// the cancellation itself drives the assertion (e.g. finalizing a drain), so a
+// 404 there surfaces instead of letting the next assertion pass vacuously.
+const cancelProcessInstance = async (
+  processInstanceKey: string,
+  {ignoreNotFound = true}: {ignoreNotFound?: boolean} = {},
+) => {
   return zeebe.cancelProcessInstance({processInstanceKey}).catch((e) => {
-    if (e.status === 404) {
-      // an active process with this key was not found. It probably completed already.
-      // we swallow the error, because this is a common cleanup scenario.
+    const status = e?.status ?? e?.code ?? e?.response?.status;
+    if (ignoreNotFound && (status === 404 || status === 'NOT_FOUND')) {
       return;
     }
-    // Something else happened. Throw the error to surface the problem.
     throw e;
   });
 };


### PR DESCRIPTION
## Description

Two test-robustness issues found by Copilot review while backporting #62408 to `stable/8.9` (#62570), carried back to `main` since both are bugs in the test's own logic — not something specific to the backport branch, and `main` has the identical code.

1. **History-batch attribution.** The "with `deleteHistory`" purge test identified its batch operation by diffing a snapshot of `DELETE_PROCESS_INSTANCE` operations taken before the delete against the list afterward, and accepted any new entry. The API project runs four workers, and other specs create operations of the same type, so an unrelated one could satisfy the assertion even if this deletion scheduled no batch at all. It now looks up the item recorded against this test's own `processInstanceKey` via `/batch-operation-items/search` and asserts that operation reaches `COMPLETED`. Two one-shot instance-count reads in the same test are also now polled — neither `DELETED` nor `DRAINING` orders exporter progress for an instance on another partition, so a correct cluster could fail them.

2. **Unconditional 404 suppression.** `cancelProcessInstance` swallowed a 404 unconditionally, which is what every one of its other 135 call sites across 64 specs already relies on — an instance often completes on its own before teardown runs. The specs here also use it for a second purpose: ending the last running instance so a drain finalizes. There, a 404 means the instance was not where the test thought it was, and swallowing it would let the following `DELETED` assertion pass for the wrong reason. Suppression stays the default (`ignoreNotFound: true`), so every other caller is unaffected; the nine cancellations in these specs that finalize a drain instead pass `{ignoreNotFound: false}`, so a 404 there surfaces.

No test count or coverage change — same 34 tests, same behavior asserted, just without the two ways they could pass without proving it.

## Related issues

relates to #55930

