### PR TITLE
ci: retry failing Tasklist integration tests instead of failing the build

### DIFF
--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -48,6 +48,10 @@ env:
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Tasklist
   CLIENT_DIR: tasklist/client
+  # Capped at 3 rather than the usual 7 on stable/*: the container-based ITs below take ~5 minutes
+  # per failing attempt, so more retries would exceed their 30 minute job timeout and turn a plain
+  # failure into a timeout. ci.md asks for 3-5 retries "while staying in the timeout".
+  FLAKY_TEST_RERUN_COUNT: 3
 
 jobs:
   # run this test every time the workflow is triggered
@@ -395,6 +399,7 @@ jobs:
           -DskipTests=false
           -Dtasklist.currentVersion.docker.tag=${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }}
           -Dtasklist.currentVersion.docker.repo=${{ env.TASKLIST_TEST_DOCKER_IMAGE }}
+          -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Upload Test Report
@@ -479,6 +484,7 @@ jobs:
             -Dspring.profiles.active=docker-test \
             -Dtasklist.currentVersion.docker.tag=${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }} \
             -Dtasklist.currentVersion.docker.repo=${{ env.TASKLIST_TEST_DOCKER_IMAGE }} \
+            -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }} \
             test
       - name: Upload Test Report
         if: failure()

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Component;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -263,6 +264,9 @@ public class TestContainerUtil {
                 .withNetwork(Network.SHARED)
                 .withEnv("path.repo", "~/")
                 .withNetworkAliases(OS_NETWORK_ALIAS)
+                // attached before start() so that a container which dies during boot still leaves
+                // its output in the build log — followOutput() after start() would capture nothing
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER))
                 .withExposedPorts(OS_PORT);
     osContainer.setWaitStrategy(
         new HostPortWaitStrategy().withStartupTimeout(Duration.ofSeconds(240L)));
@@ -291,6 +295,7 @@ public class TestContainerUtil {
             .withEnv("path.repo", "~/")
             .withEnv("action.destructive_requires_name", "false")
             .withNetworkAliases(ELS_NETWORK_ALIAS)
+            .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withExposedPorts(ELS_PORT);
     elsContainer.setWaitStrategy(
         new HostPortWaitStrategy().withStartupTimeout(Duration.ofSeconds(240L)));


### PR DESCRIPTION
The `Tasklist / Integration / Backup Restore ITs (opensearch)` job went red on
`stable/8.9` ([run 34460766059](https://github.com/camunda/camunda/actions/runs/34460766059/job/102820229012))
because the OpenSearch testcontainer died during boot — `Wait strategy failed.
Container exited with code 1`. The commit under test only touched Playwright
specs, and the job passed in every other run that day.

What made a transient hiccup fail the build is that `ci-tasklist.yml` never
passed `surefire.rerunFailingTestsCount` and never declared
`FLAKY_TEST_RERUN_COUNT`. Workflow-level `env` in `ci.yml` does not propagate
into a called reusable workflow, so both container-based Tasklist IT jobs ran
with **zero** retries where `ci.md` promises up to 7 on `stable/*`. The Docker
ITs job has the same gap and failed the same way earlier that day.

## Changes

- **`ci:`** declare `FLAKY_TEST_RERUN_COUNT` and pass
  `-Dsurefire.rerunFailingTestsCount` in the Backup Restore ITs and Docker ITs
  steps. Capped at **3**, not the usual 7: a failing attempt costs ~5 minutes
  against a 30 minute job timeout that already spends ~5 minutes building, so 7
  retries would overrun it and turn a plain failure into a timeout. `ci.md` asks
  for 3-5 retries "while staying in the timeout".
- **`test:`** attach an `Slf4jLogConsumer` to the OpenSearch and Elasticsearch
  containers so a container that dies while booting leaves its output in the
  build log. Attached via `withLogConsumer()` *before* `start()` rather than
  `followOutput()` after it (what Operate's equivalent `TestContainerUtil` does),
  since `followOutput()` captures nothing in exactly the case that needs
  explaining.

### Alternatives considered

Raising the job timeout was rejected — timeouts are a contract, and the job is
not slow, it fails fast. Pinning a different OpenSearch image was not justified:
without container logs there is no evidence the image is at fault, which is why
the diagnostics change is in scope here.

## Related issues

- [ ] This PR does not need a linked issue