### PR TITLE
test: audit orchestration-cluster e2e skip comments on stable/8.7

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -544,7 +544,7 @@ test.describe('task details page', () => {
     await taskDetailsPage.assertItemChecked('Value2');
   });
 
-  // TODO issue #3719
+  // Skipped due to bug 60174: https://github.com/camunda/camunda/issues/60174
   // eslint-disable-next-line playwright/no-skipped-test
   test.skip('task completion with tag list form', async ({
     taskPanelPage,
@@ -569,7 +569,7 @@ test.describe('task details page', () => {
     await expect(taskDetailsPage.form.getByText('Value 2')).toBeVisible();
   });
 
-  // TODO issue #3719
+  // Skipped due to bug 60174: https://github.com/camunda/camunda/issues/60174
   // eslint-disable-next-line playwright/no-skipped-test
   test.skip('task completion with text template form', async ({
     taskPanelPage,


### PR DESCRIPTION
Stable-branch counterpart to camunda/camunda#62706 (same audit methodology, applied here to `stable/8.7` instead of `main`).

## Summary

Went through every `test.skip`/`test.describe.skip` in `qa/c8-orchestration-cluster-e2e-test-suite/tests` on `stable/8.7` that did not carry a `// Skipped due to bug NNN: link` comment. On this branch there are only **2 skips total** in that directory (both in the same file, both non-compliant) — this branch predates several of the skips that exist on `main` (e.g. `identity/roles.spec.ts` and the `task-panel.spec.ts` scrolling test don't exist here yet, and `v2-stateless-tests/` doesn't exist on this branch either — noted as out of scope per the task, confirmed absent).

| Test | Was | Now |
|---|---|---|
| `tasklist/task-details.spec.ts` — "task completion with tag list form" | `// TODO issue #3719` | Re-skipped citing `#60174` |
| `tasklist/task-details.spec.ts` — "task completion with text template form" | `// TODO issue #3719` | Re-skipped citing `#60174` |

**Both (re-pointed to #60174, kept skipped):** `#3719` is an unrelated, already-merged 2020 PR ("fix(broker): fixing interrupting event subprocesses") — not a real tracking issue for these tests. This is the exact same bogus reference found and resolved in the `main`-branch audit (#62706). Both tests follow the exact same fill → complete → reopen → assert-value-persisted shape as the sibling checkbox/select/radio-button tests a few lines above in the same file, which are already correctly skipped against `#60174` ("Tasklist: submitted form values shown as empty after completing a task", **open**) — a general client-side stale-variable-cache defect on task completion, not specific to one form widget type. Re-pointed both at `#60174` instead of the bogus `#3719`, keeping them skipped.

**No unskips on this PR.** `#60174` is still open upstream (not fixed anywhere yet, `main` included), so there was no backport question to resolve here — nothing to unskip.

**Out of scope:** `v2-stateless-tests/` does not exist on `stable/8.7` (it postdates this branch) — confirmed via a full sparse-checkout of the test tree, nothing to exclude.

## Backport-verification notes

Per the stable-branch task instructions, before unskipping anything I checked whether closing an issue upstream meant the fix reached `stable/8.7`. That check didn't end up mattering here: the one bug in play (`#60174`) is still **open**, not closed/fixed on any branch, so there's no fix to verify as backported — both affected tests stay skipped regardless of branch.

## Test plan
- [x] Sparse-checked-out `qa/c8-orchestration-cluster-e2e-test-suite` from `stable/8.7` and grepped all of `tests/**/*.spec.ts` for `.skip(` — confirmed only these 2 skips exist on this branch.
- [x] Verified `#3719` is an unrelated, already-merged 2020 PR (`gh pr view 3719`).
- [x] Verified `#60174` is open and its description (stale cached task variables shown after re-navigating to a completed task) matches these tests' symptom shape.
- [x] Checked commit history of `task-details.spec.ts` on `stable/8.7` (`gh api commits?path=...&sha=stable/8.7`) — the `#3719` comment predates every commit in this branch's file history (introduced before the `core apps -> c8 orchestration cluster` rename), so it was never accurate here either.
- [x] Re-fetched `stable/8.7` tip and the file's blob SHA immediately before committing via the GitHub Data API — no drift.
- [ ] Nightly/CI run on this branch to confirm no regressions (no unskips in this PR, so no new tests entering the suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
