### PR TITLE
fix: probe Camunda readiness without wget so fork-PR images turn healthy

### DIFF
--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -163,9 +163,20 @@ services:
       - "9600:9600"
       - "8080:8080"
     healthcheck:
-      test: ['CMD-SHELL', "wget -O - -q 'http://localhost:9600/actuator/health/readiness'"]
+      # Probes over bash's /dev/tcp rather than wget/curl: neither binary exists in the
+      # public base image that fork PRs build against (BASE=public, see
+      # .github/actions/build-platform-docker), so a wget probe exits 127 and the
+      # container can never turn healthy. Same technique as the keycloak service above.
+      test:
+        - CMD
+        - bash
+        - -c
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/9600 &&
+          printf 'GET /actuator/health/readiness HTTP/1.0\r\n\r\n' >&3 &&
+          grep -q '"status":"UP"' <&3
       interval: 30s
-      timeout: 1s
+      timeout: 5s
       retries: 5
       start_period: 30s
     depends_on:
@@ -202,9 +213,20 @@ services:
       - "9600:9600"
       - "8080:8080"
     healthcheck:
-      test: ['CMD-SHELL', "wget -O - -q 'http://localhost:9600/actuator/health/readiness'"]
+      # Probes over bash's /dev/tcp rather than wget/curl: neither binary exists in the
+      # public base image that fork PRs build against (BASE=public, see
+      # .github/actions/build-platform-docker), so a wget probe exits 127 and the
+      # container can never turn healthy. Same technique as the keycloak service above.
+      test:
+        - CMD
+        - bash
+        - -c
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/9600 &&
+          printf 'GET /actuator/health/readiness HTTP/1.0\r\n\r\n' >&3 &&
+          grep -q '"status":"UP"' <&3
       interval: 30s
-      timeout: 1s
+      timeout: 5s
       retries: 5
       start_period: 30s
     depends_on:


### PR DESCRIPTION
## Description

The `camunda` and `camunda-opensearch` healthchecks in the Optimize E2E compose stack probe readiness with `wget`:

```yaml
test: ['CMD-SHELL', "wget -O - -q 'http://localhost:9600/actuator/health/readiness'"]
```

Fork PRs build the image with `BASE=public` — [`build-platform-docker`](https://github.com/camunda/camunda/blob/1f0cad22d3b/.github/actions/build-platform-docker/action.yml#L137-L151) swaps the Minimus hardened base for `eclipse-temurin:*-jre-noble`, since forks cannot reach the private registry. That base ships neither `wget` nor `curl`, so the probe exits 127 on every attempt, the container never leaves `unhealthy`, the compose health gate times out after 300s, and `Optimize / E2E / Self-Managed (Smoke)` fails.

The application is healthy the whole time — readiness returns 200 with `{"status":"UP"}`. Only the probe is broken.

This affects **every fork PR** touching Java or Optimize paths. Internal branches keep passing because only forks get the public base, which is why the job looks green on `main`.

## Changes

Probe over bash's `/dev/tcp` instead. `bash` is present in both bases, so the check behaves identically for fork and internal builds without adding a package to a deliberately minimal image. It also reads the response body and matches `"status":"UP"` rather than only checking that the port accepts a connection, so a broker that is up but not yet ready still reports unhealthy. The `keycloak` service in the same file already probes this way.

Probe timeout raised from `1s` to `5s`: the first request initializes the management dispatcher servlet and runs `schemaReadinessCheck` against Elasticsearch, which is tight in 1s even once the missing-binary problem is gone.

Considered and rejected: installing `wget` in the public base stage of `camunda.Dockerfile` — it diverges the fork image from the hardened one and adds a package to an image kept intentionally minimal.

## Test Plan

Verified locally against an image built with `BASE=public`, running the exact CI sequence (`docker compose --project-name e2e --profile self-managed up -d`, then `.github/actions/compose/healthy.sh` with `TIMEOUT=300`).

Before:

```
Services are not healthy after 300 seconds
camunda         Up 5 minutes (unhealthy)
elasticsearch   Up 5 minutes (healthy)
identity        Up 5 minutes (healthy)
keycloak        Up 5 minutes (healthy)
```
```
docker inspect .State.Health.Log →  "ExitCode": 127, "Output": "/bin/sh: 1: wget: not found\n"
```

After — `healthy.sh` exits 0:

```
camunda         Up About a minute (healthy)
elasticsearch   Up About a minute (healthy)
identity        Up About a minute (healthy)
keycloak        Up About a minute (healthy)
```

Probe history shows the intended behaviour — connection refused while the JVM boots (inside `start_period`, so it does not count), then success:

```
15:57:26 exit=1  bash: connect: Connection refused
15:57:31 exit=1  bash: connect: Connection refused
15:57:36 exit=1  bash: connect: Connection refused
15:57:40 exit=1  bash: connect: Connection refused
15:58:10 exit=0
```

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

- [x] This PR does not need a linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
