### PR TITLE
feat: bump design-system to latest version in Admin

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@camunda/camunda-api-zod-schemas": "0.0.93",
         "@camunda/camunda-composite-components": "0.25.4",
-        "@camunda/design-system": "0.53.0",
+        "@camunda/design-system": "0.54.0",
         "@camunda/session-heartbeat": "0.0.1",
         "@carbon/elements": "11.96.0",
         "@carbon/react": "1.112.0",
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@camunda/design-system": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@camunda/design-system/-/design-system-0.53.0.tgz",
-      "integrity": "sha512-3IjFEGJ8xefXmOyZbZMq9n9mG1t1s3gPeA8NGphoG+pvwIic/gxAVcxonYMNa7efbpIp3I5XXMZVOInSLOwg1g==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@camunda/design-system/-/design-system-0.54.0.tgz",
+      "integrity": "sha512-EAxc7mP2v8iKHMAG6JAQcKMDrz3GgbUy0DCAe8eLKFFzNgMMSmngSLIX543DZm5Y1JF/jCwQB44rOBkE4NjA7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/react-table": "^8.20.5",
@@ -370,7 +370,7 @@
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
         "date-fns": "^4.4.0",
-        "lucide-react": "^1.34.0",
+        "lucide-react": "^1.42.0",
         "radix-ui": "1.4.3",
         "react-day-picker": "^10.0.1",
         "recharts": "^3.8.1",
@@ -12328,9 +12328,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.35.0.tgz",
-      "integrity": "sha512-yXCCWxGFYT6bLIPYC4SY6fPQPRs/d797rRIue+J9XP2Td6vQvD53gaQRBCnIVT1kTQRHtAtxlfOQNWAuIF8ELg==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.44.0.tgz",
+      "integrity": "sha512-2egNApH4hX4j/qdCgRublh88+9u3mEhz9iSlW5ckm4kaQEqZbXbMr0l5u5JZLy8nmWRx2dbHGQkEDYz6C9aCgw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@camunda/camunda-api-zod-schemas": "0.0.93",
     "@camunda/camunda-composite-components": "0.25.4",
-    "@camunda/design-system": "0.53.0",
+    "@camunda/design-system": "0.54.0",
     "@camunda/session-heartbeat": "0.0.1",
     "@carbon/elements": "11.96.0",
     "@carbon/react": "1.112.0",

--- a/identity/client/src/components/formV2/DropdownSearch.tsx
+++ b/identity/client/src/components/formV2/DropdownSearch.tsx
@@ -109,7 +109,7 @@ const DropdownSearch = <Item extends Record<string, unknown>>({
           <div
             className={cn(
               "relative",
-              invalid && "ring-2 ring-inset ring-danger-action-default",
+              invalid && "ring-2 ring-inset ring-danger-foreground-subtle",
             )}
           >
             <CommandInput

--- a/identity/client/src/components/formV2/EntitySearchSingleSelect.tsx
+++ b/identity/client/src/components/formV2/EntitySearchSingleSelect.tsx
@@ -98,7 +98,7 @@ const EntitySearchSingleSelect = <Entity extends Record<string, unknown>>({
         />
       )}
       {isEmpty && (
-        <p className="mt-1 text-xs text-danger-action-default">
+        <p className="mt-1 text-xs text-danger-foreground-subtle">
           {requiredText}
         </p>
       )}

--- a/identity/client/src/components/formV2/JSONEditor.tsx
+++ b/identity/client/src/components/formV2/JSONEditor.tsx
@@ -142,7 +142,7 @@ const JSONEditorField: FC<JSONEditorFieldProps> = ({
               as="p"
               variant="helper"
               role="alert"
-              className="text-danger-action-default"
+              className="text-danger-foreground-subtle"
             >
               {errors}
             </Text>

--- a/identity/client/src/pages/authorizations/modalsV2/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modalsV2/add-modal/AddModal.tsx
@@ -342,7 +342,7 @@ export const AddModal: FC<
                   as="p"
                   variant="helper"
                   role="alert"
-                  className="text-danger-action-default"
+                  className="text-danger-foreground-subtle"
                 >
                   {!hasPermissions
                     ? t("permissionsUnavailable")

--- a/identity/client/src/pages/global-task-listeners/modalsV2/AddModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modalsV2/AddModal.tsx
@@ -171,7 +171,7 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
                     as="p"
                     variant="helper"
                     role="alert"
-                    className="text-danger-action-default"
+                    className="text-danger-foreground-subtle"
                   >
                     {fieldState.error.message}
                   </Text>

--- a/identity/client/src/pages/global-task-listeners/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modalsV2/EditModal.tsx
@@ -169,7 +169,7 @@ const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
                     as="p"
                     variant="helper"
                     role="alert"
-                    className="text-danger-action-default"
+                    className="text-danger-foreground-subtle"
                   >
                     {fieldState.error.message}
                   </Text>

--- a/identity/client/src/pages/operations-log/ListV2.tsx
+++ b/identity/client/src/pages/operations-log/ListV2.tsx
@@ -287,13 +287,13 @@ const List: FC = () => {
                 log.result === "SUCCESS" ? (
                   <CircleCheck
                     role="img"
-                    className="h-5 w-5 text-success-action-default"
+                    className="h-5 w-5 text-success-foreground-subtle"
                     aria-label={spaceAndCapitalize(log.result)}
                   />
                 ) : (
                   <XCircle
                     role="img"
-                    className="h-5 w-5 text-danger-action-default"
+                    className="h-5 w-5 text-danger-foreground-subtle"
                     aria-label={spaceAndCapitalize(log.result)}
                   />
                 ),


### PR DESCRIPTION
## Description

This PR bumps the design-system to version 0.54.0 in Admin. It replaced `*-action-default` with `*-foreground-subtle` classes, because the former seems to no longer be shipped by the design system.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

- [X] This PR does not need a linked issue

