### PR TITLE
feat: load-test: configure Keycloak with HTTP access logs

### DIFF
--- a/load-tests/setup/charts/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/charts/load-test-setup/templates/keycloak/keycloak.yaml
@@ -55,6 +55,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/none-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/none-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/none/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/none-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -51,6 +51,9 @@ spec:
       value: json
     - name: log-level
       value: info
+    # Show HTTP access logs on each requests to Keycloak
+    - name: http-access-log-enabled
+      value: "true"
 
   ingress:
     enabled: false


### PR DESCRIPTION
## Description

This should help to diagnose authentication errors by logging every HTTP calls to Keycloak.

References:

* https://www.keycloak.org/server/logging#http-access-logging
* https://www.keycloak.org/operator/advanced-configuration#_additional_options

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->



