### PR TITLE
ci: replace Minimus with Echo as POC

### DIFF
--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -1,10 +1,17 @@
 {
+  "ai.echo.image.name": "eclipse-temurin-jre",
+  "ai.echo.image.tag": "25",
+  "ai.echo.image.upstream.tag": "25-jre",
+  "ai.echo.image.upstream.uri": "docker.io/library/eclipse-temurin",
+  "com.echohq.image.name": "eclipse-temurin-jre",
+  "com.echohq.image.tag": "25",
   "io.k8s.description": "Camunda platform: the universal process orchestrator",
   "io.openshift.min-cpu": "1",
   "io.openshift.min-memory": "512Mi",
   "io.openshift.non-scalable": "false",
   "io.openshift.tags": "bpmn,orchestration,workflow,operate,tasklist",
   "io.openshift.wants": "elasticsearch",
+  "org.opencontainers.image.author": "echohq.com",
   "org.opencontainers.image.authors": "community@camunda.com",
   "org.opencontainers.image.base.digest": $DIGEST,
   "org.opencontainers.image.base.name": $BASE_IMAGE,
@@ -12,12 +19,11 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "reg.mini.dev/1212/openjre-base:25-dev",
+  "org.opencontainers.image.ref.name": "reg.echohq.com/eclipse-temurin-jre:25",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",
   "org.opencontainers.image.url": "https://camunda.com/platform/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "25"
+  "org.opencontainers.image.version": $VERSION
 }

--- a/.ci/docker/test/verify.sh
+++ b/.ci/docker/test/verify.sh
@@ -126,9 +126,12 @@ fi
 
 # Extract the actual labels from the info - make sure to sort keys so we always have the same
 # ordering for maps to compare things properly
-# Exclude the minimus.images.version label, since it changes every time the image is patched, and
-# we can't really know in advance reliably what it will be.
-actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels | del(."io.minimus.images.version")')
+# Exclude labels that change every time the base image is patched, since we can't reliably know
+# in advance what they will be: minimus.images.version on Minimus-based images (Optimize), and
+# echo.image.upstream.digest on Echo-based ones, which tracks the upstream Temurin build.
+actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels
+  | del(."io.minimus.images.version")
+  | del(."ai.echo.image.upstream.digest")')
 
 if [[ -z "${actualLabels}" || "${actualLabels}" == "null" || "${actualLabels}" == "[]" ]]; then
   echo >&2 "No labels found in the given image ${imageName}; raw inspect output to follow"

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -141,7 +141,7 @@ runs:
         # Check if current workflow run is related to a fork PR
         if [[ "${{ steps.is-fork.outputs.is-fork }}" == "true" ]]; then
           echo "The current workflow run is related to a fork PR."
-          echo "As a result, private Minimus hardened base images will be replaced with public images."
+          echo "As a result, private hardened base images (Echo, Minimus) will be replaced with public images."
 
           {
             echo 'result<<EOF'

--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -35,23 +35,23 @@ Vault/WIF hang (see that action's README).
 
 ### Inputs
 
-|          Input           |                                  Description                                  | Required |  Default  |
-|--------------------------|-------------------------------------------------------------------------------|----------|-----------|
-| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)                   | false    | `"true"`  |
-| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)                  | false    | `"false"` |
-| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits              | false    | `"false"` |
-| harbor                   | Log into Harbor with a Harbor robot account (disabled for fork PRs)           | false    | `"false"` |
-| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)                    | false    | `"false"` |
-| echo                     | Log into Echo with a CI account (disabled for fork PRs); implied by `minimus` | false    | `"false"` |
-| java-distribution        | Java distribution to install                                                  | false    | `temurin` |
-| java-version             | JDK version to install                                                        | false    | `"21"`    |
-| maven-cache-key-modifier | Modifier for the Maven cache key                                              | false    | `shared`  |
-| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)              | false    | `'[]'`    |
-| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)              | false    | `'[]'`    |
-| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)            | false    |           |
-| vault-address            | Vault URL to retrieve secrets from                                            | false    |           |
-| vault-role-id            | Vault AppRole role id                                                         | false    |           |
-| vault-secret-id          | Vault AppRole secret id                                                       | false    |           |
+|          Input           |                             Description                             | Required |  Default  |
+|--------------------------|---------------------------------------------------------------------|----------|-----------|
+| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)         | false    | `"true"`  |
+| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)        | false    | `"false"` |
+| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits    | false    | `"false"` |
+| harbor                   | Log into Harbor with a Harbor robot account (disabled for fork PRs) | false    | `"false"` |
+| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)          | false    | `"false"` |
+| echo                     | Log into Echo with a CI account (disabled for fork PRs)             | false    | `"false"` |
+| java-distribution        | Java distribution to install                                        | false    | `temurin` |
+| java-version             | JDK version to install                                              | false    | `"21"`    |
+| maven-cache-key-modifier | Modifier for the Maven cache key                                    | false    | `shared`  |
+| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)    | false    | `'[]'`    |
+| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)    | false    | `'[]'`    |
+| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)  | false    |           |
+| vault-address            | Vault URL to retrieve secrets from                                  | false    |           |
+| vault-role-id            | Vault AppRole role id                                               | false    |           |
+| vault-secret-id          | Vault AppRole secret id                                             | false    |           |
 
 ### Outputs
 

--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -7,14 +7,14 @@ individual jobs don't repeat the same bootstrap. In one step it:
 
 - detects fork PRs (via [`is-fork`](../is-fork)) and disables all credential-dependent
   features when secrets aren't available;
-- imports CI secrets from Vault (Nexus, DockerHub, Minimus);
+- imports CI secrets from Vault (Nexus, DockerHub, Minimus, Echo);
 - installs the JDK (`actions/setup-java`);
 - registers the Maven problem matcher and configures the Maven cache
   (via [`setup-maven-cache`](../setup-maven-cache));
 - merges Camunda Nexus + Google Central mirrors with any extra mirrors/servers and
   writes `settings.xml`;
 - optionally sets the build time zone;
-- optionally logs into DockerHub, Harbor, and Minimus.
+- optionally logs into DockerHub, Harbor, Minimus, and Echo.
 
 All credential features are **automatically disabled for fork PRs**, since Vault
 secrets can't be retrieved there.
@@ -28,29 +28,30 @@ Vault/WIF hang (see that action's README).
 
 - The repository must be checked out first (e.g. `actions/checkout`), since this
   action and its nested actions are referenced by local path.
-- To use any Vault-backed feature (Nexus mirror, DockerHub/Harbor/Minimus login),
+- To use any Vault-backed feature (Nexus mirror, DockerHub/Harbor/Minimus/Echo login),
   pass `vault-address` / `vault-role-id` / `vault-secret-id`.
 
 ## Usage
 
 ### Inputs
 
-|          Input           |                             Description                             | Required |  Default  |
-|--------------------------|---------------------------------------------------------------------|----------|-----------|
-| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)         | false    | `"true"`  |
-| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)        | false    | `"false"` |
-| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits    | false    | `"false"` |
-| harbor                   | Log into Harbor with a Harbor robot account (disabled for fork PRs) | false    | `"false"` |
-| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)          | false    | `"false"` |
-| java-distribution        | Java distribution to install                                        | false    | `temurin` |
-| java-version             | JDK version to install                                              | false    | `"21"`    |
-| maven-cache-key-modifier | Modifier for the Maven cache key                                    | false    | `shared`  |
-| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)    | false    | `'[]'`    |
-| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)    | false    | `'[]'`    |
-| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)  | false    |           |
-| vault-address            | Vault URL to retrieve secrets from                                  | false    |           |
-| vault-role-id            | Vault AppRole role id                                               | false    |           |
-| vault-secret-id          | Vault AppRole secret id                                             | false    |           |
+|          Input           |                                  Description                                  | Required |  Default  |
+|--------------------------|-------------------------------------------------------------------------------|----------|-----------|
+| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)                   | false    | `"true"`  |
+| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)                  | false    | `"false"` |
+| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits              | false    | `"false"` |
+| harbor                   | Log into Harbor with a Harbor robot account (disabled for fork PRs)           | false    | `"false"` |
+| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)                    | false    | `"false"` |
+| echo                     | Log into Echo with a CI account (disabled for fork PRs); implied by `minimus` | false    | `"false"` |
+| java-distribution        | Java distribution to install                                                  | false    | `temurin` |
+| java-version             | JDK version to install                                                        | false    | `"21"`    |
+| maven-cache-key-modifier | Modifier for the Maven cache key                                              | false    | `shared`  |
+| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)              | false    | `'[]'`    |
+| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)              | false    | `'[]'`    |
+| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)            | false    |           |
+| vault-address            | Vault URL to retrieve secrets from                                            | false    |           |
+| vault-role-id            | Vault AppRole role id                                                         | false    |           |
+| vault-secret-id          | Vault AppRole secret id                                                       | false    |           |
 
 ### Outputs
 

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -41,11 +41,9 @@ inputs:
     description: |
       If enabled, logs into Echo (reg.echohq.com) with a CI account.
       Echo login is automatically disabled for fork PRs.
-      Implied by `minimus` while the Echo migration is in progress:
-      camunda.Dockerfile builds on Echo and optimize.Dockerfile still builds on
-      Minimus, and several workflows build both, so a caller asking for
-      hardened base images needs both registries. Set this on its own once a
-      workflow no longer needs Minimus.
+      Needed by any job that builds camunda.Dockerfile against a private base.
+      Jobs building only optimize.Dockerfile need `minimus` instead; jobs
+      building both need both, until Optimize also moves to Echo.
     required: false
     default: "false"
   java-distribution:
@@ -324,7 +322,7 @@ runs:
     # Echo login is disabled for fork PRs; those build with BASE=public.
     if: >-
       steps.is-fork.outputs.is-fork != 'true' &&
-      (inputs.echo == 'true' || inputs.minimus == 'true')
+      inputs.echo == 'true'
     uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
     env:
       DOCKER_USERNAME: ${{ steps.secrets.outputs.echo-username }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -37,6 +37,17 @@ inputs:
       Minimus login is automatically disabled for fork PRs.
     required: false
     default: "false"
+  echo:
+    description: |
+      If enabled, logs into Echo (reg.echohq.com) with a CI account.
+      Echo login is automatically disabled for fork PRs.
+      Implied by `minimus` while the Echo migration is in progress:
+      camunda.Dockerfile builds on Echo and optimize.Dockerfile still builds on
+      Minimus, and several workflows build both, so a caller asking for
+      hardened base images needs both registries. Set this on its own once a
+      workflow no longer needs Minimus.
+    required: false
+    default: "false"
   java-distribution:
     description: Java distribution to use
     required: false
@@ -149,6 +160,8 @@ runs:
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
         secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
+        secret/data/products/camunda/ci/github-actions REGISTRY_ECHO_USR | echo-username;
+        secret/data/products/camunda/ci/github-actions REGISTRY_ECHO_PSW | echo-token;
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
@@ -307,3 +320,20 @@ runs:
       command: |
         printf '%s' "${DOCKER_PASSWORD}" | docker login reg.mini.dev \
           --username minimus --password-stdin
+  - name: Logs on to Echo
+    # Echo login is disabled for fork PRs; those build with BASE=public.
+    if: >-
+      steps.is-fork.outputs.is-fork != 'true' &&
+      (inputs.echo == 'true' || inputs.minimus == 'true')
+    uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    env:
+      DOCKER_USERNAME: ${{ steps.secrets.outputs.echo-username }}
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.echo-token }}
+    with:
+      max_attempts: 3
+      retry_wait_seconds: 10
+      timeout_seconds: 60
+      shell: bash
+      command: |
+        printf '%s' "${DOCKER_PASSWORD}" | docker login reg.echohq.com \
+          --username "${DOCKER_USERNAME}" --password-stdin

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -386,6 +386,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       - uses: ./.github/actions/build-frontend
         name: Build Operate Frontend
         id: build-operate-fe

--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -62,6 +62,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       - id: image-tag
         name: Calculate image tag
         shell: bash

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -429,7 +429,9 @@ jobs:
           secrets: |
             secret/data/products/optimize/ci/camunda-optimize REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/optimize/ci/camunda-optimize REGISTRY_HUB_DOCKER_COM_PSW;
-            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
+            secret/data/products/camunda/ci/github-actions REGISTRY_ECHO_USR | echo-username;
+            secret/data/products/camunda/ci/github-actions REGISTRY_ECHO_PSW | echo-token
       - name: Login to DockerHub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -441,6 +443,12 @@ jobs:
           registry: reg.mini.dev
           username: minimus
           password: ${{ steps.secrets.outputs.minimus-token }}
+      - name: Login to Echo
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: reg.echohq.com
+          username: ${{ steps.secrets.outputs.echo-username }}
+          password: ${{ steps.secrets.outputs.echo-token }}
       - id: "auth"
         name: "Authenticate to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -564,7 +572,9 @@ jobs:
           secrets: |
             secret/data/products/camunda/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/camunda/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
-            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
+            secret/data/products/camunda/ci/github-actions REGISTRY_ECHO_USR | echo-username;
+            secret/data/products/camunda/ci/github-actions REGISTRY_ECHO_PSW | echo-token
       - name: Login to DockerHub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -576,6 +586,12 @@ jobs:
           registry: reg.mini.dev
           username: minimus
           password: ${{ steps.secrets.outputs.minimus-token }}
+      - name: Logs on to Echo
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: reg.echohq.com
+          username: ${{ steps.secrets.outputs.echo-username }}
+          password: ${{ steps.secrets.outputs.echo-token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -98,6 +98,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       - uses: ./.github/actions/build-frontend
         name: Build Operate Frontend
         with:

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -441,6 +441,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       # Same class of check as camunda.Dockerfile gets in the docker-checks job
       # (.github/workflows/ci.yml), but here it's a metadata-only resolve since this job never
       # builds the image. The pinned digest is content-addressable, so we must resolve it by digest

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -539,6 +539,7 @@ jobs:
         with:
           maven-cache-key-modifier: optimize-e2e-smoke
           minimus: true
+          echo: true
           time-zone: Europe/Berlin
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -70,6 +70,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}
+          echo: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -384,6 +385,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1621,6 +1621,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
       # of silently eating the whole job timeout-minutes budget -- see INC-6820.
       - name: Authenticate to GCS build-cache
@@ -1843,6 +1844,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       # Consume the shared distball instead of a ~15 min reactor build; GitHub-hosted,
       # so it stays on the GHA artifact API.
       - name: Download distball
@@ -2989,6 +2991,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       # Frontend bundles are built once in build-platform-frontend and downloaded here
       # instead of being rebuilt (issue #52693). build-zeebe runs with -PskipFrontendBuild below.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/data-layer-nightly-tests.yml
+++ b/.github/workflows/data-layer-nightly-tests.yml
@@ -68,6 +68,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: "true"
+          echo: "true"
 
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -426,6 +426,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
 
       - name: Get Maven project version
         id: maven-version

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -109,6 +109,7 @@ jobs:
         vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
         vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
         minimus: true
+        echo: true
 
     - uses: ./.github/actions/build-zeebe
       id: build-camunda

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -102,6 +102,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       - name: Import Snyk token from Vault
         id: snyk-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -74,6 +74,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       - id: image-tag
         name: Calculate image tag
         shell: bash

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -131,6 +131,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          echo: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -37,22 +37,27 @@ ARG BASE="hardened"
 ARG DIST="distball"
 
 ### Base Application Image ###
-# No packages are added on top. Echo's Temurin JRE image already supplies the
-# JRE, tzdata and ca-certificates, plus a shell and coreutils - which covers
-# everything the appassembler entrypoint calls (sh, env, dirname, expr, ls,
-# uname, which; see dist/src/main/scripts/unixBinTemplate).
+# Echo's Temurin JRE image already supplies the JRE, tzdata, ca-certificates,
+# and a shell plus coreutils, which covers everything the appassembler
+# entrypoint calls (sh, env, dirname, expr, ls, uname, which; see
+# dist/src/main/scripts/unixBinTemplate).
 #
-# The four extras Minimus's openjre-base bundled are deliberately NOT carried
-# over, because none of them apply to this image:
+# Of the four extras Minimus's openjre-base bundled, only wget is carried over:
+#   wget           - required. The camunda service healthcheck in
+#                    optimize/client/docker-compose.yml is
+#                    `wget -O - -q http://localhost:9600/actuator/health/readiness`,
+#                    so dropping it leaves the container permanently unhealthy.
+#   tzdata         - required, and already present in this base.
 #   busybox        - only needed for start/health checks on the non-"dev"
 #                    openjre flavor (Identity); this base already has a shell.
-#   wget           - only used by the Identity healthcheck.
-#   netcat-openbsd - only used by wait-for-it.sh in Optimize.
-#   tzdata         - required, and already present in this base.
-# No camunda service defines a container healthcheck, and the shipped scripts
-# shell out to nothing beyond the seven commands listed above.
+#   netcat-openbsd - only used by wait-for-it.sh in Optimize, which builds from
+#                    optimize.Dockerfile, not this one.
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Base Public Application Image ###
 # hadolint ignore=DL3006

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -3,8 +3,16 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
-ARG BASE_DIGEST="sha256:fb962d5ea0de9f2044d01607d1f29235670031fef2f2fe973d1e902f70c49203"
+# Echo equivalent of Minimus openjre-base:25-dev. Echo's floating tags (:25)
+# are the maintained ones and are rebuilt continuously; the dated tags are
+# immutable snapshots that go stale. Pin the digest of a floating tag and bump
+# it deliberately, rather than pinning a dated tag.
+ARG BASE_IMAGE="reg.echohq.com/eclipse-temurin-jre:25"
+ARG BASE_DIGEST="sha256:6d8ba575867b286c5c06065605ac408c659a45f71af238ece341e5407abfd36a"
+ARG JDK_IMAGE="reg.echohq.com/eclipse-temurin:25.0.4-20260819"
+ARG JDK_DIGEST="sha256:a8cc4cb7276f43bd438e921646b9f4c656f87caa7a82928f02a99fe3d33ee2c3"
+ARG CURL_IMAGE="reg.echohq.com/curl:8.22.0-20260907"
+ARG CURL_DIGEST="sha256:1ea8abbf714a807c32b9ee808bab2fba58d4f016883c3c819ab9d5f462d79fdb"
 ARG JATTACH_VERSION="v2.2"
 ARG JATTACH_CHECKSUM_AMD64="acd9e17f15749306be843df392063893e97bfecc5260eef73ee98f06e5cfe02f"
 ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e33710bdcaab51"
@@ -14,12 +22,35 @@ ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e3
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
 ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.4_7-jre-noble"
 ARG BASE_DIGEST_PUBLIC="sha256:1e80201efc21b839ebc9b448b1f9b16aa5f036dd2885148282fe5dae38684fe1"
+# The jattach and distball stages run on every build, including fork PRs that
+# cannot authenticate to Echo, so they need public counterparts selected by the
+# same BASE switch. curlimages/curl matches Echo's curl image closely enough
+# that one RUN body works on both: curl is preinstalled and the default user is
+# unprivileged.
+ARG JDK_IMAGE_PUBLIC="eclipse-temurin:25-jdk-noble"
+ARG JDK_DIGEST_PUBLIC="sha256:264fafc3390db78c93dc51da0109a0d66ad1fb59f7a893f12b7e3df1f15e52da"
+ARG CURL_IMAGE_PUBLIC="curlimages/curl:8.18.0"
+ARG CURL_DIGEST_PUBLIC="sha256:d94d07ba9e7d6de898b6d96c1a072f6f8266c687af78a74f380087a0addf5d17"
 ARG BASE="hardened"
 
 # set to "build" to build camunda from scratch instead of using a distball
 ARG DIST="distball"
 
 ### Base Application Image ###
+# No packages are added on top. Echo's Temurin JRE image already supplies the
+# JRE, tzdata and ca-certificates, plus a shell and coreutils - which covers
+# everything the appassembler entrypoint calls (sh, env, dirname, expr, ls,
+# uname, which; see dist/src/main/scripts/unixBinTemplate).
+#
+# The four extras Minimus's openjre-base bundled are deliberately NOT carried
+# over, because none of them apply to this image:
+#   busybox        - only needed for start/health checks on the non-"dev"
+#                    openjre flavor (Identity); this base already has a shell.
+#   wget           - only used by the Identity healthcheck.
+#   netcat-openbsd - only used by wait-for-it.sh in Optimize.
+#   tzdata         - required, and already present in this base.
+# No camunda service defines a container healthcheck, and the shipped scripts
+# shell out to nothing beyond the seven commands listed above.
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
 
@@ -42,7 +73,12 @@ RUN --mount=type=cache,target=/root/.m2,rw \
 
 ### jattach download stage ###
 # hadolint ignore=DL3006,DL3007
-FROM alpine AS jattach
+# hadolint ignore=DL3006
+FROM ${CURL_IMAGE}@${CURL_DIGEST} AS jattach-hardened
+# hadolint ignore=DL3006
+FROM ${CURL_IMAGE_PUBLIC}@${CURL_DIGEST_PUBLIC} AS jattach-public
+# hadolint ignore=DL3006
+FROM jattach-${BASE} AS jattach
 ARG TARGETARCH
 ARG JATTACH_VERSION
 ARG JATTACH_CHECKSUM_AMD64
@@ -52,9 +88,12 @@ ARG JATTACH_CHECKSUM_ARM64
 # connection to github.com. On its own --retry covers a timeout and the HTTP
 # 408, 429, 500, 502, 503 and 504 responses, none of which an SSL connect error
 # (exit 35) is, so without it the download fails on the first attempt.
-# hadolint ignore=DL4006,DL3018
-RUN apk add -q --no-cache curl && \
-    if [ "${TARGETARCH}" = "amd64" ]; then \
+# Echo's curl image defaults to the unprivileged `curl_user`; this stage writes
+# to / so it needs root. Only the jattach binary reaches the final image.
+# hadolint ignore=DL3002
+USER root
+# hadolint ignore=DL4006
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
       BINARY="linux-x64"; \
       CHECKSUM="${JATTACH_CHECKSUM_AMD64}"; \
     else  \
@@ -73,7 +112,12 @@ RUN apk add -q --no-cache curl && \
 # Use eclipse-temurin JDK (not JRE) so `jar` is available for repacking JARs,
 # avoiding a runtime dependency on external package servers for (un)zip.
 # hadolint ignore=DL3006,DL3007
-FROM eclipse-temurin:25-jdk-noble AS distball
+# hadolint ignore=DL3006
+FROM ${JDK_IMAGE}@${JDK_DIGEST} AS distball-hardened
+# hadolint ignore=DL3006
+FROM ${JDK_IMAGE_PUBLIC}@${JDK_DIGEST_PUBLIC} AS distball-public
+# hadolint ignore=DL3006
+FROM distball-${BASE} AS distball
 
 # hadolint ignore=DL3002
 USER root
@@ -164,14 +208,19 @@ ENV PATH="${CAMUNDA_HOME}/bin:${PATH}"
 # Disable RocksDB runtime check for musl, which launches `ldd` as a shell process
 # We know there's no need to check for musl on this image
 ENV ROCKSDB_MUSL_LIBC=false
+# Minimus's openjre-base set this; Debian leaves it unset. OpenSSL's built-in
+# default is the same path, but non-JVM clients that read the variable
+# explicitly would otherwise see a behaviour change. The Helm chart overrides
+# it when global.tls.caBundle is configured.
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 WORKDIR ${CAMUNDA_HOME}
 EXPOSE 8080 26500 26501 26502
 
 # Switch to root to allow setting up our own user
 USER root
-RUN addgroup --gid 1001 camunda && \
-    adduser -S -G camunda -u 1001 -h ${CAMUNDA_HOME} camunda && \
+RUN groupadd -g 1001 camunda && \
+    useradd -g camunda -u 1001 -d ${CAMUNDA_HOME} -s /usr/sbin/nologin camunda && \
     chmod g=u /etc/passwd && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.


### PR DESCRIPTION
Evaluates Echo (`reg.echohq.com`) as a replacement for the Minimus hardened base images, starting with `camunda.Dockerfile`.

## What changes

`eclipse-temurin-jre:25` replaces `openjre-base:25-dev` as the runtime base, with **no packages installed on top**. Echo's image already ships the JRE, tzdata, ca-certificates, a shell and coreutils.

The four extras `openjre-base` bundled are deliberately not carried over, because none apply to this image:

| Package | Documented reason | Applies here? |
|---|---|---|
| `wget` | health checks on the non-"dev" flavor (Identity) | **Yes — reinstalled.** The camunda service in `optimize/client/docker-compose.yml` health-checks itself with `wget -O - -q http://localhost:9600/actuator/health/readiness`, so the documented scoping was incomplete |
| `tzdata` | timezone info for SSL | Yes — already present |
| `busybox` | start & health checks on the non-"dev" openjre flavor (Identity) | No — this base has bash/dash/sh |
| `netcat-openbsd` | `wait-for-it.sh` in Optimize | No — only in `optimize.Dockerfile` |

A YAML-level sweep of every compose file finds three healthchecks on services running the camunda image: the two in `optimize/client/docker-compose.yml` (which need `wget`) and the smoke-test stack's, which uses `timeout` plus `bash` `/dev/tcp` and needs nothing extra. The Helm chart's probes are all `httpGet` (kubelet-executed), and the shipped appassembler scripts shell out to nothing beyond `sh, env, dirname, expr, ls, uname, which`.

Two changes follow from Echo being Debian rather than Alpine-derived: Debian's busybox omits the `addgroup`/`adduser` applets so user setup moves to `groupadd`/`useradd`, and `SSL_CERT_FILE` is now set explicitly because Minimus set it and Debian does not.

The `jattach` and `distball` stages gain public counterparts selected by the existing `BASE` switch — they build on every run including fork PRs, which cannot authenticate to Echo.

CI gains Echo login from the `REGISTRY_ECHO_USR` / `REGISTRY_ECHO_PSW` Vault entries, via a new `echo` input on `setup-build` plus direct `docker/login-action` steps in the release workflow.

Every job that builds `camunda.Dockerfile` against a private base opts in explicitly — fifteen of them, found by auditing every job that calls `setup-build` and references a Dockerfile. Jobs building only `optimize.Dockerfile` keep `minimus`; jobs building both keep both until Optimize also moves. `ci-zeebe` `smoke-tests` reuses its Linux-only matrix expression rather than hardcoding `true`, and `c8-orchestration-cluster-e2e-api-test-branch-on-demand` builds with `BASE=public` so it gets neither.

## Measurements vs `camunda/camunda:SNAPSHOT`

| | Minimus base | Echo base |
|---|---|---|
| size | 374 MB | 313 MB |
| packages | 82 | 112 |
| CVEs (trivy, all severities) | 0 | 1 MEDIUM (libexpat1) |
| setuid binaries | 0 | 9 |

Compatibility checked: both bases are **glibc** (this is not a musl migration), so `ROCKSDB_MUSL_LIBC=false` and the extracted `librocksdbjni-linux64.so` stay correct. glibc goes 2.44 → 2.41, a downgrade, but every x86_64 native lib in the dist requires at most `GLIBC_2.16` (aarch64 `2.17`). `jattach` is statically linked. `nsswitch.conf` resolution order is identical. All shipped scripts pass `sh -n` under both busybox ash and dash. Nothing hardcodes `/usr/lib/jvm`; the chart resolves `$JAVA_HOME` dynamically.

## Validation

- Booted the image and ran the exact failing healthcheck: `{"status":"UP","components":{"brokerReady":{"status":"UP"},...}}`
- `hadolint camunda.Dockerfile` — clean (matches the pre-change baseline)
- `actionlint` — 67 findings before, 67 after; no new findings
- `conftest` — 4199 tests, 0 failures
- `./mvnw license:format spotless:apply` — applied
- Built green: `base-hardened`, `jattach` (real download + checksum), and the same two stages with `--build-arg BASE=public` to exercise the fork path
- Verified in-image: uid 1001 created, Temurin 25.0.4 runs as that user, all seven entrypoint commands present, `keytool` + `$JAVA_HOME/lib/security/cacerts` present for the chart's `ca-bundle-truststore-init`, tzdata and ca-certs resolve, UTF-8

## Not yet validated

- **Boot verified, but against the published distribution.** Camunda starts cleanly on the Echo base (0 errors, RocksDB loads) and the readiness healthcheck passes — confirmed by an A/B against `camunda/camunda:SNAPSHOT` with the same Elasticsearch, where both images become ready in about the same time. That test layered the *published* dist onto the Echo base rather than one built from this branch, so CI's own image build remains the authoritative check.
- **`git`, `wget`, `nc` and `apk` are gone** from the runtime image. Nothing in this repo or the Helm chart uses them, but anyone shelling into a pod to debug loses them — worth telling support before this ships.
- The 9 setuid binaries come from Debian's shadow packages; a `chmod -s` sweep would remove them, as nothing in Camunda uses them. Deliberately left out of this PR.
- Only `camunda.Dockerfile` migrates. `optimize.Dockerfile` stays on Minimus, so both subscriptions are needed until it follows.

## Related issues

- [ ] This PR does not need a linked issue

Related to https://github.com/camunda/team-eng-ops/issues/319

🤖 Generated with [Claude Code](https://claude.com/claude-code)


