### PR TITLE
fix: reuse gateway authentication in test cluster clients

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.response.BrokerInfo;
 import io.camunda.configuration.Zone;
@@ -266,21 +265,17 @@ public final class TestCluster implements CloseableSilently {
   }
 
   /**
-   * Builds a new client builder by picking a random gateway started gateway for it and disabling
-   * transport security.
+   * Builds a new client builder by picking a random started gateway for it.
    *
-   * <p>NOTE: this will properly automatically configure the security level, but will not configure
-   * authentication.
+   * <p>The gateway configures transport security and, when enabled, authentication with the default
+   * admin user.
    *
-   * @return a new client builder with the gateway and transport security pre-configured
+   * @return a new client builder with the gateway configuration
    * @throws NoSuchElementException if there are no started gateways
    */
   @SuppressWarnings("resource")
   public CamundaClientBuilder newClientBuilder() {
-    return CamundaClient.newClientBuilder()
-        .preferRestOverGrpc(false)
-        .restAddress(availableGateway().restAddress())
-        .grpcAddress(availableGateway().grpcAddress());
+    return availableGateway().newClientBuilder();
   }
 
   /**
@@ -325,6 +320,7 @@ public final class TestCluster implements CloseableSilently {
       final Duration timeout) {
     Awaitility.await("until cluster topology is complete")
         .atMost(timeout)
+        .ignoreExceptions()
         .untilAsserted(
             () ->
                 assertThat(allGateways())
@@ -343,6 +339,7 @@ public final class TestCluster implements CloseableSilently {
   public TestCluster awaitHealthyTopology(final Duration timeout) {
     Awaitility.await("until cluster topology is complete")
         .atMost(timeout)
+        .ignoreExceptions()
         .untilAsserted(
             () -> assertThat(allGateways()).allSatisfy(TestCluster::assertHealthyTopology));
     return this;


### PR DESCRIPTION
## Description

TestCluster previously created raw clients with only gateway addresses, so topology checks bypassed the gateway's default admin credentials when authentication was enabled. 
Delegate client creation to the gateway and retry topology checks while authentication state is initializing. This keeps unauthenticated clusters unchanged while allowing authenticated test clusters to use the shared client setup.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

