### PR TITLE
ci: auto-retry jobs killed by runner shutdown

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -250,14 +250,23 @@ get_jobs_after_checkresults_without_ifalways(jobInput) = jobs_after_checkresults
         }
         count(job_needs_checkresults) == 1
 
-        # check that the job declares an `if: ...` condition and it contains `always()`
+        # check that the job declares an `if: ...` condition that guards on check-results
         #
         # this is important because GHA by default skips execution of jobs that itself
         # depend on jobs (transitively) that were skipped - which happens a lot in Unified CI
         # and we want to avoid accidentally skipping deploy jobs or similar
         #
+        # `always()` keeps GHA from skipping the job once the gate fails, and requiring
+        # it to be conjoined with a `needs.check-results.result` test forces the job to
+        # state which gate outcome it runs on. Pinning the comparison to `== 'success'`
+        # as well would forbid a job that legitimately runs *because* the gate failed,
+        # such as the runner-shutdown retry, so the outcome itself is left open.
+        #
+        # This is a substring match, so the two must appear in exactly this form; an
+        # `if` that only mentions both separately (e.g. joined by `||`) still runs
+        # unconditionally and is correctly rejected.
         job_if := object.get(job, "if", "")  # get with empty default value
-        not contains(job_if, "always() && needs.check-results.result == 'success'")
+        not contains(job_if, "always() && needs.check-results.result")
     }
 }
 

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -256,18 +256,29 @@ get_jobs_after_checkresults_without_ifalways(jobInput) = jobs_after_checkresults
         # depend on jobs (transitively) that were skipped - which happens a lot in Unified CI
         # and we want to avoid accidentally skipping deploy jobs or similar
         #
-        # `always()` keeps GHA from skipping the job once the gate fails, and requiring
-        # it to be conjoined with a `needs.check-results.result` test forces the job to
-        # state which gate outcome it runs on. Pinning the comparison to `== 'success'`
-        # as well would forbid a job that legitimately runs *because* the gate failed,
-        # such as the runner-shutdown retry, so the outcome itself is left open.
+        # `always()` keeps GHA from skipping the job once the gate fails, and it has to
+        # be conjoined with a comparison against `needs.check-results.result` so the job
+        # states which gate outcome it runs on. Pinning that comparison to `== 'success'`
+        # would forbid a job that legitimately runs *because* the gate failed, such as
+        # the runner-shutdown retry, so the compared value itself is left open.
         #
-        # This is a substring match, so the two must appear in exactly this form; an
-        # `if` that only mentions both separately (e.g. joined by `||`) still runs
-        # unconditionally and is correctly rejected.
+        # The comparison operator is part of the match on purpose. `A && B` in a GHA
+        # expression evaluates to `B`, so `always() && needs.check-results.result` is a
+        # non-empty string and therefore always truthy: the job would run unconditionally
+        # while looking like it checks the gate. Requiring `==` or `!=` rejects that, as
+        # it rejects an `if` that merely mentions both parts joined by `||`.
         job_if := object.get(job, "if", "")  # get with empty default value
-        not contains(job_if, "always() && needs.check-results.result")
+        not if_compares_checkresults(job_if)
     }
+}
+
+# multiple functions with the same name act as logical OR
+if_compares_checkresults(job_if) {
+    contains(job_if, "always() && needs.check-results.result ==")
+}
+
+if_compares_checkresults(job_if) {
+    contains(job_if, "always() && needs.check-results.result !=")
 }
 
 get_jobs_with_flaky_outputs(jobInput) = jobs_with_flaky_outputs {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2859,6 +2859,72 @@ jobs:
           exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 
 
+  # Re-run jobs whose runner was terminated mid-job (spot preemption, autoscaler
+  # scale-down, node eviction) rather than by anything the change did. Those jobs
+  # fail with "The runner has received a shutdown signal" while the test step is
+  # still running, which says nothing about the code under test.
+  #
+  # The action re-runs failed jobs only, so a killed matrix leg such as
+  # `database-integration-tests (mysql)` comes back on its own while every green
+  # job is left untouched. It also reads the run logs first and does nothing unless
+  # a shutdown message is present, so a genuine failure still ends the run red.
+  # `check-results` re-runs as a dependent of the failed jobs, which re-arms this
+  # job, so run_attempt caps the whole thing at two retries.
+  #
+  # Scoped to `pull_request` deliberately. `merge_group` is excluded so the merge
+  # queue never auto-retries, since a retry there would hold the queue open longer
+  # and could let a co-occurring flake reach main. Fork PRs are excluded because
+  # they cannot reach Vault to mint the retrigger token.
+  #
+  # No `deploy-` job can be re-run by this, and neither the position of this job in
+  # the file nor its `needs` is what prevents it: every `deploy-` job requires
+  # `needs.check-results.result == 'success'` where this one requires `'failure'`, so
+  # the two are mutually exclusive within an attempt. The `pull_request` scope makes
+  # it doubly unreachable, since the deploy jobs also require a `main`/`stable/*` ref
+  # and are therefore skipped on PR runs, and a re-run of failed jobs does not revive
+  # skipped ones. Widening this job past `pull_request` would remove that second
+  # guarantee and let a green re-run release the deploys the failed attempt skipped.
+  utils-rerun-failed-jobs:
+    name: rerun jobs killed by runner shutdown
+    needs: [ check-results ]
+    if: >
+      always() && needs.check-results.result == 'failure'
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork != true
+      && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        timeout-minutes: ${{ fromJSON(env.SHALLOW_CHECKOUT_TIMEOUT_MIN) }}
+        with:
+          persist-credentials: false
+      - name: Rerun failed jobs on runner shutdown
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c # rerun-failed-run-1.1.2
+        with:
+          error-messages: |
+            The runner has received a shutdown signal
+            lost communication with the server
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+
   # Dynamically generate the concurrency group based on branch name
   utils-get-concurrency-group-for-maven-snapshot:
     needs: [ check-results ]

--- a/.github/workflows/data-layer-nightly-tests.yml
+++ b/.github/workflows/data-layer-nightly-tests.yml
@@ -238,3 +238,55 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  # Auto-retry when a nightly leg failed because its self-hosted runner was
+  # terminated mid-job (spot preemption, autoscaler scale-down, node eviction)
+  # rather than by a real test failure. In run 34428217829 the stable/8.9 leg
+  # logged "The runner has received a shutdown signal" with no BUILD FAILURE and
+  # a log a fraction the length of the main leg's, so it was cut off before it
+  # could report a verdict at all.
+  #
+  # The action reads the run logs first and does nothing unless a shutdown
+  # message is present, so on the nights this workflow fails for real it costs
+  # nothing. Note the check is per run rather than per job: once a shutdown is
+  # found, every failed job in the run is re-run, so a leg that failed for real
+  # alongside a killed one is re-run too and simply fails again. That is the
+  # accepted cost here while the main leg has a standing failure.
+  #
+  # The aurora-async-replication legs run GitHub hosted and cannot be preempted;
+  # they are in `needs` only so this job sees the whole failure surface.
+  rerun-failed-jobs:
+    name: Rerun jobs killed by runner shutdown
+    needs: [nightly-tests, aurora-async-replication, aurora-async-replication-mysql]
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Rerun failed jobs on runner shutdown
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c # rerun-failed-run-1.1.2
+        with:
+          error-messages: |
+            The runner has received a shutdown signal
+            lost communication with the server
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "rerun-failed-jobs"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
@@ -184,3 +184,56 @@ jobs:
         secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
         secret_vault_address: ${{ secrets.VAULT_ADDR }}
         secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  # Auto-retry when integration-tests failed because its self-hosted runner was
+  # terminated mid-job (spot preemption, autoscaler scale-down, node eviction)
+  # rather than by a real test failure. Those runs end with "The runner has
+  # received a shutdown signal" partway through Maven Test Build, which says
+  # nothing about the code under test.
+  #
+  # The action reads the run logs first and only retriggers when a shutdown
+  # message is present, and it re-runs failed jobs only, so genuine failures stay
+  # red and anything already green is left alone. Capped at two retries via
+  # run_attempt.
+  #
+  # send-slack-notification above still fires on the original failure, so a
+  # shutdown that the retry goes on to fix can leave one alert behind.
+  rerun-failed-jobs:
+    name: "Rerun jobs killed by runner shutdown"
+    needs: integration-tests
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        sparse-checkout: .github
+    - name: Print metadata
+      uses: ./.github/actions/print-metadata
+      with:
+        test_owner: '@camunda/core-features'
+    - name: Rerun failed jobs on runner shutdown
+      uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c # rerun-failed-run-1.1.2
+      with:
+        error-messages: |
+          The runner has received a shutdown signal
+          lost communication with the server
+        run-id: ${{ github.run_id }}
+        repository: ${{ github.repository }}
+        vault-addr: ${{ secrets.VAULT_ADDR }}
+        vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+        vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+    - name: Observe build status
+      if: always()
+      continue-on-error: true
+      uses: ./.github/actions/observe-build-status
+      with:
+        job_name: "rerun-failed-jobs"
+        build_status: ${{ job.status }}
+        secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secret_vault_address: ${{ secrets.VAULT_ADDR }}
+        secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -200,3 +200,59 @@ jobs:
       test-type-label: "Identity"
       notify-slack-on-failure: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify-slack-on-failure) }}
       use-shared-distball: true
+
+  # Auto-retry when one of the jobs above failed because its self-hosted runner was
+  # terminated mid-job (spot preemption, autoscaler scale-down, node eviction) rather
+  # than by a real test failure, as in run 34190097454 where the MySQL 8.4 shard was
+  # killed partway through its test step.
+  #
+  # The action reads the run logs first and only retriggers when a shutdown message is
+  # present, and it re-runs failed jobs only, so genuine failures stay red and shards
+  # that already passed are left alone. Capped at two retries via run_attempt.
+  #
+  # generate-matrix is deliberately not in `needs`: it runs on a GitHub-hosted runner
+  # and so is not exposed to spot preemption. build-distball is, and a shutdown there
+  # skips every shard below it, so it is covered.
+  #
+  # `github.run_id` is the caller's run when this workflow is invoked through
+  # workflow_call from zeebe-rdbms-pr-multidb-test.yaml, which is what we want: the
+  # re-run then targets the run that actually holds the failed jobs.
+  rerun-failed-jobs:
+    name: "Rerun jobs killed by runner shutdown"
+    needs: [ build-distball, rdbms-integration-tests, rdbms-history-tests, rdbms-identity-tests ]
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+        with:
+          test_owner: '@camunda/core-features'
+      - name: Rerun failed jobs on runner shutdown
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c # rerun-failed-run-1.1.2
+        with:
+          error-messages: |
+            The runner has received a shutdown signal
+            lost communication with the server
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "rerun-failed-jobs"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -172,3 +172,56 @@ jobs:
       test-type-label: "Identity"
       notify-slack-on-failure: ${{ github.event_name == 'schedule' }}
       use-shared-distball: true
+
+  # Auto-retry when one of the jobs above failed because its self-hosted runner was
+  # terminated mid-job (spot preemption, autoscaler scale-down, node eviction) rather
+  # than by a real test failure. No run here has been lost that way yet, but these
+  # shards use the same gcp-perf runner classes as the RDBMS ones that have, so the
+  # exposure is identical.
+  #
+  # The action reads the run logs first and only retriggers when a shutdown message is
+  # present, and it re-runs failed jobs only, so genuine failures stay red and shards
+  # that already passed are left alone. Capped at two retries via run_attempt.
+  #
+  # generate-matrix is deliberately not in `needs`: it runs on a GitHub-hosted runner
+  # and so is not exposed to spot preemption. build-distball is, and a shutdown there
+  # skips every shard below it, so it is covered.
+  rerun-failed-jobs:
+    name: "Rerun jobs killed by runner shutdown"
+    needs: [ build-distball, search-integration-tests, search-history-tests, search-identity-tests ]
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+        with:
+          test_owner: '@camunda/data-layer'
+      - name: Rerun failed jobs on runner shutdown
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c # rerun-failed-run-1.1.2
+        with:
+          error-messages: |
+            The runner has received a shutdown signal
+            lost communication with the server
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "rerun-failed-jobs"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## Description

Jobs on self-hosted runners are reported red when their node is terminated mid-test by spot preemption, autoscaler scale down, or node eviction. The log ends with "The runner has received a shutdown signal" while Maven is still running, so the result says nothing about the code under test and someone has to notice and re-run by hand.

Measured before changing anything:

- Unified CI: 3 of the 15 most recent failed PR runs, 4 jobs, all confirmed in logs, none with a real test failure alongside
- Aurora: 3 of the last 12 scheduled main runs (`34186245579`, `33590156751`)
- RDBMS: run `34190097454`, MySQL 8.4 shard
- Data layer nightly: run `34428217829`, stable/8.9 leg, cut off with no `BUILD FAILURE` and a log a fraction the length of the main leg's

## What this does

Adds the `rerun-failed-run` action already used by the optimize and c8-orchestration-cluster nightlies to five more workflows. It inspects the run logs and does nothing unless a shutdown message is present, and it re-runs failed jobs only, so genuine failures stay red and passing jobs are untouched. Capped at two automatic retries via `run_attempt`.

| Workflow | Scope |
|---|---|
| `ci.yml` | `pull_request` only |
| `zeebe-aws-aurora-dispatch-tests.yml` | all events |
| `zeebe-rdbms-integration-tests.yml` | all events |
| `zeebe-search-integration-tests.yml` | all events |
| `data-layer-nightly-tests.yml` | all events |

`ci.yml` is deliberately restricted to `pull_request`. `merge_group` is excluded so the merge queue never auto-retries, where a retry would hold the queue open longer and could let a co-occurring flake reach main. Fork PRs are excluded because they cannot reach Vault to mint the retrigger token. No `deploy-` job is reachable: they require `check-results.result == 'success'` where this job requires `'failure'`, and on PR runs they are skipped by their `main`/`stable/*` ref guard anyway.

## Why the policy file changes

`conftest-unified-ci-rules.rego` required any job depending on `check-results` to spell out `always() && needs.check-results.result == 'success'`, which forbids a job that runs precisely because the gate failed. The `== 'success'` tail is dropped so the outcome is open, while the conjunction is kept so every such job must still be `always()` guarded and must still test the gate result. That is what stops a deploy job from shipping off a red gate. Note the rule's own comment already described the looser intent.

Verified against five workflow shapes: the seven existing post-gate jobs pass, the new retry job passes, and all three bypass shapes are still rejected (no `always()`, `always()` without a gate check, and `always() ||` in place of `&&`).

## Alternatives considered

- A separate workflow on `workflow_run`, rejected because `workflow_run` triggers do not fire in this repository (see the note in `alwaysgreen-streak-detector.yml`, zero runs since 2026-05-28)
- A step inside `check-results` rather than its own job, rejected because it would need the branch-protection gate's `timeout-minutes` raised from 3
- Retrying unconditionally rather than on a log match, rejected because it masks real breakage and defeats `detect-new-flaky-tests`
- Moving these legs to on demand runners, which avoids the preemption entirely but needs an infra change and costs more

## Validation

- `conftest --rego-version v0 --policy .github .github/workflows/*.y*ml`: 4617 tests, 4590 passed, 27 warnings, 0 failures. Same 27 warnings as before this branch, so no new ones
- `actionlint`: unchanged from baseline on every changed file. The remaining findings are pre-existing unknown self-hosted runner labels

## Known limitation

The log check is per run, not per job. Once a shutdown is found, every failed job in that run is re-run, so a job that failed for real alongside a killed one is re-run and simply fails again. Relevant to `data-layer-nightly-tests.yml` while its main leg carries a standing failure. Documented in the workflow.

## Related issues

relates to #52892