### PR TITLE
feat: allow filtering role members by username

### DIFF
--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -159,6 +159,13 @@ FROM (
       <if test="filter.memberType != null">
         AND rm.ENTITY_TYPE = #{filter.memberType}
       </if>
+
+      <if test="filter.memberIdOperations != null and !filter.memberIdOperations.isEmpty()">
+        <foreach collection="filter.memberIdOperations" item="operation">
+          AND rm.ENTITY_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
     </where>
   </sql>
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -42,6 +42,7 @@ import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameFilter;
 import io.camunda.gateway.protocol.model.ProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.ResourceFilter;
 import io.camunda.gateway.protocol.model.RoleFilterFields;
+import io.camunda.gateway.protocol.model.RoleUserFilterRequest;
 import io.camunda.gateway.protocol.model.StringFilterProperty;
 import io.camunda.gateway.protocol.model.UserFilterFields;
 import io.camunda.gateway.protocol.model.UserTaskAuditLogFilter;
@@ -86,11 +87,13 @@ import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.ProcessInstanceFilter.Builder;
 import io.camunda.search.filter.RoleFilter;
+import io.camunda.search.filter.RoleMemberFilter;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
+import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.zeebe.util.Either;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
@@ -852,6 +855,16 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
     }
     return builder;
+  }
+
+  static RoleMemberFilter toRoleUserFilter(final @Nullable RoleUserFilterRequest filter) {
+    final var builder = FilterBuilders.roleMember().memberType(EntityType.USER);
+    if (filter != null) {
+      ofNullable(filter.getUsername())
+          .map(mapToStringOperations())
+          .ifPresent(builder::memberIdOperations);
+    }
+    return builder.build();
   }
 
   static MappingRuleFilter toMappingRuleFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -351,7 +351,7 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper.fromRoleUserSearchQuerySortRequest(request.getSort()),
             SortOptionBuilders::roleMember,
             SearchQuerySortRequestMapper::applyRoleUserSortField);
-    final var filter = FilterBuilders.roleMember().build();
+    final var filter = SearchQueryFilterMapper.toRoleUserFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::roleMemberSearchQuery);
   }
 

--- a/identity/client/src/components/entityListV2/EntityList.tsx
+++ b/identity/client/src/components/entityListV2/EntityList.tsx
@@ -23,6 +23,7 @@ import { LucideIcon, Plus } from "lucide-react";
 import { DocumentationLink } from "src/components/documentationV2";
 import useTranslate from "src/utility/localization";
 import { PageResult, SortConfig } from "src/utility/api";
+import { SearchFilterValue } from "src/utility/api/hooks/usePagination";
 import SearchBar from "./SearchBar";
 
 export type EntityData = {
@@ -63,6 +64,8 @@ type EntityListProps<D extends EntityData> = {
   documentationPath?: string;
   searchPlaceholder?: string;
   searchKey?: string;
+  /** "eq" (default) matches the typed value exactly; "like" matches it as a substring. */
+  searchOperator?: "eq" | "like";
   data: D[] | null | undefined;
   headers: DataTableHeader<D>[];
   addEntityLabel?: string | null;
@@ -90,7 +93,7 @@ type EntityListProps<D extends EntityData> = {
     | ({ pageNumber: number; pageSize: number } & Partial<PageResult>)
     | undefined;
   setSort?: (sort: SortConfig[] | undefined) => void;
-  setSearch?: (search: Record<string, string> | undefined) => void;
+  setSearch?: (search: Record<string, SearchFilterValue> | undefined) => void;
   renderExpandedRow?: (entity: D) => ReactNode;
 };
 
@@ -123,6 +126,7 @@ const EntityList = <D extends EntityData>({
   batchSelection,
   searchPlaceholder,
   searchKey,
+  searchOperator,
   maxDisplayCellLength = 50,
   setPageNumber = () => {},
   setPageSize = () => {},
@@ -283,6 +287,7 @@ const EntityList = <D extends EntityData>({
             <SearchBar
               searchKey={searchKey}
               searchPlaceholder={searchPlaceholder}
+              searchOperator={searchOperator}
               onSearch={setSearch}
             />
           )}

--- a/identity/client/src/components/entityListV2/SearchBar.tsx
+++ b/identity/client/src/components/entityListV2/SearchBar.tsx
@@ -10,19 +10,31 @@ import { SearchInput } from "@camunda/design-system";
 import { FC, useEffect, useState } from "react";
 import useDebounce from "react-debounced";
 import useTranslate from "src/utility/localization";
+import { SearchFilterValue } from "src/utility/api/hooks/usePagination";
 
 type SearchBarProps = {
   searchKey: string;
-  onSearch: (value: Record<string, string> | undefined) => void;
+  onSearch: (value: Record<string, SearchFilterValue> | undefined) => void;
   searchPlaceholder?: string;
   debounce?: number;
+  /** "eq" (default) matches the typed value exactly; "like" matches it as a substring. */
+  searchOperator?: "eq" | "like";
 };
+
+/** Escapes the backend's LIKE wildcard characters (`*`, `?`) and their escape prefix (`\`) so a typed value matches literally. */
+function escapeWildcards(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\*/g, "\\*")
+    .replace(/\?/g, "\\?");
+}
 
 export default function SearchBar({
   searchPlaceholder,
   searchKey,
   onSearch,
   debounce = 300,
+  searchOperator = "eq",
 }: SearchBarProps): ReturnType<FC> {
   const { t } = useTranslate("components");
   const [search, setSearchState] = useState<string>("");
@@ -38,8 +50,12 @@ export default function SearchBar({
       return;
     }
 
-    debounceFn(() => onSearch({ [searchKey]: search }));
-  }, [debounceFn, onSearch, search, searchKey]);
+    const value: SearchFilterValue =
+      searchOperator === "like"
+        ? { $like: `*${escapeWildcards(search)}*` }
+        : search;
+    debounceFn(() => onSearch({ [searchKey]: value }));
+  }, [debounceFn, onSearch, search, searchKey, searchOperator]);
 
   return (
     <SearchInput

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -70,7 +70,12 @@ export const useMcpProcessTools = () => {
   const { pageParams, page, ...paginationRest } = usePagination();
 
   const searchTermsFilter = useMemo(() => {
-    const term = pageParams.filter?.toolName?.trim();
+    const rawToolName = pageParams.filter?.toolName;
+    if (typeof rawToolName !== "string") {
+      // Already a structured filter (e.g. `{ $like }`) — pass it through as-is.
+      return rawToolName ? { toolName: rawToolName } : undefined;
+    }
+    const term = rawToolName.trim();
     if (!term) return undefined;
     return { toolName: { $like: `*${term}*` } };
   }, [pageParams.filter]);

--- a/identity/client/src/pages/roles/detailV2/members/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/index.tsx
@@ -111,6 +111,8 @@ const Members: FC<MembersProps> = ({ roleId, isOIDC }) => {
         addEntityLabel={t("assignUser")}
         onAddEntity={openAssignModal}
         searchPlaceholder={t("searchByUsername")}
+        searchKey="username"
+        searchOperator="like"
         menuItems={[
           {
             label: t("remove"),

--- a/identity/client/src/utility/api/hooks/usePagination.ts
+++ b/identity/client/src/utility/api/hooks/usePagination.ts
@@ -32,9 +32,12 @@ export type SortConfig = {
   order: "ASC" | "DESC";
 };
 
+/** A search term, either matched exactly or, wrapped as `{ $like }`, as a substring. */
+export type SearchFilterValue = string | { $like: string };
+
 export type PaginationRequestParams = PageSearchParams & {
   sort?: SortConfig[];
-  filter?: Record<string, string>;
+  filter?: Record<string, SearchFilterValue>;
 };
 
 export type UsePaginationResult = {
@@ -43,23 +46,23 @@ export type UsePaginationResult = {
   setPageNumber: (newPage: number) => void;
   setPageSize: (newPageSize: number) => void;
   setSort: (sort: SortConfig[] | undefined) => void;
-  setSearch: (search: Record<string, string> | undefined) => void;
-  search?: Record<string, string>;
+  setSearch: (search: Record<string, SearchFilterValue> | undefined) => void;
+  search?: Record<string, SearchFilterValue>;
   resetPagination: () => void;
 };
 
 const useSearch = (
   reset = () => {},
 ): [
-  Record<string, string> | undefined,
-  (newSearch: Record<string, string> | undefined) => void,
+  Record<string, SearchFilterValue> | undefined,
+  (newSearch: Record<string, SearchFilterValue> | undefined) => void,
 ] => {
-  const [search, setSearch] = useState<Record<string, string> | undefined>(
-    undefined,
-  );
+  const [search, setSearch] = useState<
+    Record<string, SearchFilterValue> | undefined
+  >(undefined);
 
   const handleSearchChange = useCallback(
-    (newSearch: Record<string, string> | undefined) => {
+    (newSearch: Record<string, SearchFilterValue> | undefined) => {
       setSearch(newSearch);
       reset();
     },

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleMemberIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleMemberIT.java
@@ -17,6 +17,7 @@ import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.RoleMemberEntity;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.RoleMemberFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.RoleMemberQuery;
@@ -24,6 +25,7 @@ import io.camunda.search.sort.RoleMemberSort;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +63,39 @@ public class RoleMemberIT {
     assertThat(searchResult.items()).hasSize(2);
     assertThat(searchResult.items().stream().map(RoleMemberEntity::id))
         .contains("user-1", "user-2");
+  }
+
+  @TestTemplate
+  public void shouldFindRoleMemberByMemberIdLike(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final RoleMemberDbReader reader = rdbmsService.getRoleMemberReader();
+
+    // given
+    final var role = RoleFixtures.createAndSaveRole(rdbmsWriters, b -> b);
+    addUserToRole(rdbmsWriters, role.roleId(), "jonny");
+    addUserToRole(rdbmsWriters, role.roleId(), "mrjonas");
+    addUserToRole(rdbmsWriters, role.roleId(), "jane");
+    addUserToRole(rdbmsWriters, role.roleId(), "mark");
+
+    // when
+    final var searchResult =
+        reader.search(
+            new RoleMemberQuery(
+                RoleMemberFilter.of(
+                    b ->
+                        b.memberType(EntityType.USER)
+                            .roleId(role.roleId())
+                            .memberIdOperations(List.of(Operation.like("*jo*")))),
+                RoleMemberSort.of(b -> b),
+                SearchQueryPage.of(b -> b)),
+            ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(2);
+    assertThat(searchResult.items().stream().map(RoleMemberEntity::id))
+        .containsExactlyInAnyOrder("jonny", "mrjonas");
   }
 
   private void addUserToRole(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleMemberFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleMemberFilterTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasParentQuery;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
@@ -18,6 +19,7 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
+import java.util.Arrays;
 
 public class RoleMemberFilterTransformer extends IndexFilterTransformer<RoleMemberFilter> {
   public RoleMemberFilterTransformer(final IndexDescriptor indexDescriptor) {
@@ -27,14 +29,16 @@ public class RoleMemberFilterTransformer extends IndexFilterTransformer<RoleMemb
   @Override
   public SearchQuery toSearchQuery(final RoleMemberFilter filter) {
     return and(
-        filter.memberType() == null
-            ? null
-            : term(RoleIndex.MEMBER_TYPE, filter.memberType().name()),
-        filter.roleId() == null
-            ? term(RoleIndex.JOIN, IdentityJoinRelationshipType.ROLE.getType())
-            : hasParentQuery(
-                IdentityJoinRelationshipType.ROLE.getType(),
-                term(RoleIndex.ROLE_ID, filter.roleId())));
+        Arrays.asList(
+            filter.memberType() == null
+                ? null
+                : term(RoleIndex.MEMBER_TYPE, filter.memberType().name()),
+            filter.roleId() == null
+                ? term(RoleIndex.JOIN, IdentityJoinRelationshipType.ROLE.getType())
+                : hasParentQuery(
+                    IdentityJoinRelationshipType.ROLE.getType(),
+                    term(RoleIndex.ROLE_ID, filter.roleId()))),
+        stringOperations(RoleIndex.MEMBER_ID, filter.memberIdOperations()));
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleMemberFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleMemberFilter.java
@@ -7,11 +7,18 @@
  */
 package io.camunda.search.filter;
 
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
 import io.camunda.security.api.model.authz.EntityType;
+import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
+import java.util.List;
 import java.util.function.Function;
 
-public record RoleMemberFilter(String roleId, EntityType memberType) implements FilterBase {
+public record RoleMemberFilter(
+    String roleId, EntityType memberType, List<Operation<String>> memberIdOperations)
+    implements FilterBase {
 
   public static RoleMemberFilter of(
       final Function<RoleMemberFilter.Builder, RoleMemberFilter.Builder> builderFunction) {
@@ -19,12 +26,16 @@ public record RoleMemberFilter(String roleId, EntityType memberType) implements 
   }
 
   public Builder toBuilder() {
-    return new Builder().roleId(roleId).memberType(memberType);
+    return new Builder()
+        .roleId(roleId)
+        .memberType(memberType)
+        .memberIdOperations(memberIdOperations);
   }
 
   public static final class Builder implements ObjectBuilder<RoleMemberFilter> {
     private String roleId;
     private EntityType memberType;
+    private List<Operation<String>> memberIdOperations;
 
     public Builder roleId(final String value) {
       roleId = value;
@@ -36,9 +47,30 @@ public record RoleMemberFilter(String roleId, EntityType memberType) implements 
       return this;
     }
 
+    public Builder memberIdOperations(final List<Operation<String>> operations) {
+      if (operations != null) {
+        memberIdOperations = addValuesToList(memberIdOperations, operations);
+      }
+      return this;
+    }
+
+    public Builder memberId(final String value, final String... values) {
+      final var vals = FilterUtil.mapDefaultToOperation(value, values);
+      if (vals != null) {
+        return memberIdOperations(vals);
+      }
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder memberIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return memberIdOperations(collectValues(operation, operations));
+    }
+
     @Override
     public RoleMemberFilter build() {
-      return new RoleMemberFilter(roleId, memberType);
+      return new RoleMemberFilter(roleId, memberType, memberIdOperations);
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -1104,11 +1104,27 @@ components:
         - $ref: 'search-models.yaml#/components/schemas/SearchQueryRequest'
       type: object
       properties:
+        filter:
+          description: The user filter criteria.
+          allOf:
+            - $ref: '#/components/schemas/RoleUserFilterRequest'
         sort:
           description: Sort field criteria.
           type: array
           items:
             $ref: '#/components/schemas/RoleUserSearchQuerySortRequest'
+      x-properties-added-in-version:
+        - propertyName: "filter"
+          addedInVersion: "8.10"
+
+    RoleUserFilterRequest:
+      description: Role user filter request
+      type: object
+      properties:
+        username:
+          description: The username search filters.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
 
     RoleUserSearchQuerySortRequest:
       type: object


### PR DESCRIPTION
## Description

Admins managing a role with many members (e.g. "Tasklist users" with hundreds of assignees) had no way to check whether a specific user is assigned without scrolling through the entire member list — the Admin UI's role detail view had no search/filter capability.

This adds a `username` filter to the role-user search, wired end-to-end:

- `RoleMemberFilter` (search-domain): new `memberIdOperations`.
- `RoleMemberFilterTransformer` (ES/OS): translates it into a query on `RoleIndex.MEMBER_ID`.
- `RoleMapper.xml` (RDBMS): matching `memberIdOperations` clause on `ENTITY_ID`.
- `roles.yaml`: new `RoleUserFilterRequest{username}` wired into `RoleUserSearchQueryRequest.filter`, supporting `$like` for substring search.
- `SearchQueryFilterMapper`/`SearchQueryRequestMapper`: map the REST filter through instead of discarding it.
- `identity/client`: wired a search box into the role detail view's Users tab, reusing the existing entity-list search bar with a new opt-in `searchOperator="like"` mode (default behavior for every other list is unchanged).

Scoped to the Users tab only, matching the linked issue's design (Groups/Clients tabs are unchanged).

## Test plan

- [x] `RoleMemberIT.shouldFindRoleMemberByMemberIdLike` — new RDBMS integration test, passing on all 6 supported dialects (H2, Postgres, MySQL, MariaDB, Oracle, MSSQL).
- [x] Manually verified in a running instance (RDBMS/H2 + identity/client dev server): assigned 4 users to a test role, typed a partial username in the new search box, confirmed the list narrowed to matching users and cleared back to the full list.
- [x] `identity/client`: `tsc --noEmit` and `eslint` clean across the whole app (the widened search-filter type is used by every list in the app).
- [x] Full-repo `mvn install -Dquickly` green.

## Related issues

closes #59820