### PR TITLE
docs: key STATE.md session-continuity files by session id

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -50,6 +50,7 @@ When a skill exists for a recurring operation, use it rather than improvising st
 | `frontend-unit-test`           | Write or debug Vitest browser-mode unit tests in the orchestration cluster webapp                              |
 | `operate-engineering-loop`     | Drive a tracked Operate change (OC webapp `src/operate/`) through implementation, gated validation, independent review, a draft PR, and Copilot review |
 | `operate-frontend`             | Operate frontend conventions for both codebases — the OC webapp `src/operate/` pod and legacy `operate/client/` |
+| `session-state`                | Persist and resume Claude Code session progress across restarts, `--resume`/`--continue`, and compaction        |
 | `tasklist-frontend`            | Build or change Tasklist pod features in the OC webapp at `src/tasklist/`                                      |
 
 ## Adding a new skill

--- a/.claude/skills/session-state/SKILL.md
+++ b/.claude/skills/session-state/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: session-state
+description: Persist and resume Claude Code session progress across restarts, --resume/--continue, and context compaction. Use when asked to persist/save/output session state, or when starting a session and checking for prior progress to resume from.
+---
+
+# Session State
+
+Session-continuity files let a session survive context loss (a fresh terminal, `--resume`,
+`--continue`, or compaction losing detail) by writing progress to disk, keyed by session id so
+concurrent sessions in the same working directory never clobber each other's state.
+
+## Persisting
+
+If the user prompts you to persist/save/output session state:
+
+- Write to `.agent-sessions/STATE.<session-id>.md` at repo root, creating the `.agent-sessions/`
+  directory first if it doesn't exist. Key the filename by a stable per-session identifier (e.g.
+  `$CLAUDE_CODE_SESSION_ID`, falling back to a random suffix generated once and reused for every
+  write in the session if no such identifier is available).
+- Start the file with a `_Last updated: <ISO 8601 timestamp>_` line, refreshed on every write, then
+  record discoveries and remaining work under
+  `## Goal / Instructions / Discoveries / Accomplished / Not Yet Done / Relevant Files` — keep it
+  useful to a fresh session.
+
+## Resuming
+
+At session start:
+
+- Check `.agent-sessions/STATE*.md` files: delete any whose `Last updated` timestamp is older than
+  14 days, since that file's session is abandoned.
+- Resume only from `.agent-sessions/STATE.<session-id>.md` matching the current session's own
+  identifier, if it exists (that file persists across `--resume`/`--continue` and context
+  compaction). A genuinely new session id has no matching file and starts fresh — this is not a
+  mechanism for a new, unrelated session to discover another session's prior work.
+
+## Cleanup
+
+Delete the session's own `.agent-sessions/STATE.<session-id>.md` once its goal is fully done,
+rather than waiting for it to age out.

--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,5 @@ load-tests/setup/c8-*
 **/__pycache__/**
 
 # Used by agents to persist session state
-STATE.md
+/.agent-sessions/
+/STATE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,6 @@ https://raw.githubusercontent.com/camunda/.github/refs/heads/main/AGENTS.md
 Treat the central file's contents as if they were written directly in this file.
 Instructions below extend those guidelines and take precedence if there is any conflict.
 
-## Quick start
-
-If the user prompts you to persist/save/output session state do the following:
-- Read `STATE.md` at repo root if it exists (session continuity file, gitignored). Record discoveries and remaining work there as you go, under `## Goal / Instructions / Discoveries / Accomplished / Not Yet Done / Relevant Files` — keep it useful to a fresh session.
-
 ## Repo-specific instructions
 
 ### Role & boundary


### PR DESCRIPTION
## Description

STATE.md session persistence (#62478) shares one fixed filename per directory. Two Claude sessions running in the same working directory at once, most commonly the main checkout since git worktrees each get their own working tree and therefore their own `STATE.md`, read-modify-write that same file and can silently overwrite each other's progress, with no git history to recover it since the file is gitignored.

This keys the filename by a stable per-session identifier (`.agent-sessions/STATE.<session-id>.md`) instead of a single shared root file, so concurrent sessions in the same directory no longer collide. A resuming session (`--resume`/`--continue`, or after context compaction) keeps the same session id, so it looks for its own exact file; a genuinely new session id has no matching file and starts fresh. This is scoped to a session's own continuity, not a mechanism for an unrelated session to discover another one's prior work. Files older than 14 days are treated as abandoned and deleted. The old shared root `STATE.md` stays gitignored as a permanent safety net in case an older agent still writes it.

The whole convention now lives in a `session-state` skill instead of inline in `AGENTS.md`, since `AGENTS.md` is read on every session in the monorepo regardless of whether that session uses it, while a skill only loads when actually invoked.

Follow-up to a discussion with @entangled90 in [this Slack thread](https://camunda.slack.com/archives/C08F5RD5X8B/p1788953358647419).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

- [X] This PR does not need a linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
