### PR TITLE
fix: prevent cross-test data leakage in Elasticsearch IT rule provider

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
@@ -112,10 +112,8 @@ public class ElasticsearchTestRuleProvider implements SearchTestRuleProvider {
 
   @Override
   public void finished(final Description description) {
-    if (!failed) {
-      final String indexPrefix = searchEngineConfiguration.connect().getIndexPrefix();
-      TestUtil.removeAllIndices(esClient, indexPrefix);
-    }
+    final String currentIndexPrefix = searchEngineConfiguration.connect().getIndexPrefix();
+    TestUtil.removeAllIndices(esClient, currentIndexPrefix);
     operateProperties.getElasticsearch().setIndexPrefix(DEFAULT_INDEX_PREFIX);
     searchEngineConfiguration.connect().setIndexPrefix(DEFAULT_INDEX_PREFIX);
     assertMaxOpenScrollContexts(15);


### PR DESCRIPTION
IncidentStatisticsIT and DecisionListQueryIT assert exact counts/ids against shared Elasticsearch indices. ElasticsearchTestRuleProvider only removed those indices in finished() when the preceding test had passed, so a failing test left its data behind. The next test (or a Failsafe rerun of the same test) then persisted new data on top of that leftover data, snowballing the mismatch across attempts instead of resolving it.

OpensearchTestRuleProvider has no such guard and always tears down its indices, which is why the equivalent Opensearch ITs job stayed green while the Elasticsearch one kept failing with growing counts.

Always remove the indices in finished(), matching the Opensearch provider and the repo's testing convention of tearing down test resources even on failure.

relates [#inc-7879-unsuccessful-job-operate-integration-tests-integration-tests-on-st](https://camunda.slack.com/archives/C0BUR2MELK1)

