### PR TITLE
fix: ensure recently added changes to identity search endpoints are backwards compatible

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -346,11 +346,13 @@
             <typeMapping>ElementInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>FormKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>JobKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>MappingRuleIdFilterProperty=StringFilterProperty</typeMapping>
             <typeMapping>MessageSubscriptionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>ProcessDefinitionIdFilterProperty=StringFilterProperty</typeMapping>
             <typeMapping>ProcessDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>ProcessInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>ResourceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>RoleIdFilterProperty=StringFilterProperty</typeMapping>
             <typeMapping>ScopeKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>VariableKeyFilterProperty=BasicStringFilterProperty</typeMapping>
           </typeMappings>

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -204,11 +204,13 @@
                 <typeMapping>FormKeyFilterProperty=String</typeMapping>
                 <typeMapping>IntegerFilterProperty=Integer</typeMapping>
                 <typeMapping>JobKeyFilterProperty=String</typeMapping>
+                <typeMapping>MappingRuleIdFilterProperty=String</typeMapping>
                 <typeMapping>MessageSubscriptionKeyFilterProperty=String</typeMapping>
                 <typeMapping>ProcessDefinitionIdFilterProperty=String</typeMapping>
                 <typeMapping>ProcessDefinitionKeyFilterProperty=String</typeMapping>
                 <typeMapping>ProcessInstanceKeyFilterProperty=String</typeMapping>
                 <typeMapping>ResourceKeyFilterProperty=String</typeMapping>
+                <typeMapping>RoleIdFilterProperty=String</typeMapping>
                 <typeMapping>ScopeKeyFilterProperty=String</typeMapping>
                 <typeMapping>StringFilterProperty=String</typeMapping>
                 <typeMapping>VariableKeyFilterProperty=String</typeMapping>

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -957,6 +957,7 @@ components:
                 <br>
                 <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
               type: array
+              nullable: true
               items:
                 $ref: '#/components/schemas/GroupFilterFields'
           x-properties-added-in-version:

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -302,6 +302,58 @@ components:
         - propertyName: "$like"
           addedInVersion: "8.10"
 
+    MappingRuleIdFilterProperty:
+      description: MappingRuleId property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/MappingRuleId'
+        - $ref: '#/components/schemas/AdvancedMappingRuleIdFilter'
+
+    AdvancedMappingRuleIdFilter:
+      title: Advanced filter
+      description: Advanced MappingRuleId filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/MappingRuleId'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/MappingRuleId'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/MappingRuleId'
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/MappingRuleId'
+        $like:
+          $ref: 'filters.yaml#/components/schemas/LikeFilter'
+      x-properties-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.10"
+        - propertyName: "$neq"
+          addedInVersion: "8.10"
+        - propertyName: "$exists"
+          addedInVersion: "8.10"
+        - propertyName: "$in"
+          addedInVersion: "8.10"
+        - propertyName: "$notIn"
+          addedInVersion: "8.10"
+        - propertyName: "$like"
+          addedInVersion: "8.10"
+
     ProcessDefinitionIdFilterProperty:
       description: ProcessDefinitionId property with full advanced search capabilities.
       oneOf:
@@ -338,6 +390,58 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProcessDefinitionId'
+        $like:
+          $ref: 'filters.yaml#/components/schemas/LikeFilter'
+      x-properties-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.10"
+        - propertyName: "$neq"
+          addedInVersion: "8.10"
+        - propertyName: "$exists"
+          addedInVersion: "8.10"
+        - propertyName: "$in"
+          addedInVersion: "8.10"
+        - propertyName: "$notIn"
+          addedInVersion: "8.10"
+        - propertyName: "$like"
+          addedInVersion: "8.10"
+
+    RoleIdFilterProperty:
+      description: RoleId property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/RoleId'
+        - $ref: '#/components/schemas/AdvancedRoleIdFilter'
+
+    AdvancedRoleIdFilter:
+      title: Advanced filter
+      description: Advanced RoleId filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/RoleId'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/RoleId'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleId'
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleId'
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
       x-properties-added-in-version:

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -421,6 +421,7 @@ components:
                 <br>
                 <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
               type: array
+              nullable: true
               items:
                 $ref: '#/components/schemas/MappingRuleFilterFields'
           x-properties-added-in-version:

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -393,7 +393,7 @@ components:
         mappingRuleId:
           description: The ID of the mapping rule.
           allOf:
-            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+            - $ref: 'identifiers.yaml#/components/schemas/MappingRuleIdFilterProperty'
 
     MappingRuleFilter:
       description: Mapping rule search filter.

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -1058,6 +1058,7 @@ components:
                 <br>
                 <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
               type: array
+              nullable: true
               items:
                 $ref: '#/components/schemas/RoleFilterFields'
           x-properties-added-in-version:

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -1015,7 +1015,7 @@ components:
         roleId:
           description: The role ID search filters.
           allOf:
-            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+            - $ref: 'identifiers.yaml#/components/schemas/RoleIdFilterProperty'
         name:
           description: The role name search filters.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -426,6 +426,7 @@ components:
                 <br>
                 <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
               type: array
+              nullable: true
               items:
                 $ref: '#/components/schemas/UserFilterFields'
           x-properties-added-in-version:


### PR DESCRIPTION
so we ensure the API and clients will be backwards compatible

New fields were added in https://github.com/camunda/camunda/pull/61116 but were missing `nullable`

In addition the `Role.roleId` and `MappingRule.mappingRuleId` had changed type, so extra work was needed to handle that gracefully.

## Related issues

Refs: #56453

