### PR TITLE
fix: keep Optimize smoke healthcheck working on fork-PR camunda images

### DIFF
--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -163,9 +163,16 @@ services:
       - "9600:9600"
       - "8080:8080"
     healthcheck:
-      test: ['CMD-SHELL', "wget -O - -q 'http://localhost:9600/actuator/health/readiness'"]
+      test:
+        - CMD
+        - bash
+        - -c
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/9600 &&
+          printf 'GET /actuator/health/readiness HTTP/1.0\r\n\r\n' >&3 &&
+          grep -q '"status":"UP"' <&3
       interval: 30s
-      timeout: 1s
+      timeout: 5s
       retries: 5
       start_period: 30s
     depends_on:
@@ -202,9 +209,16 @@ services:
       - "9600:9600"
       - "8080:8080"
     healthcheck:
-      test: ['CMD-SHELL', "wget -O - -q 'http://localhost:9600/actuator/health/readiness'"]
+      test:
+        - CMD
+        - bash
+        - -c
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/9600 &&
+          printf 'GET /actuator/health/readiness HTTP/1.0\r\n\r\n' >&3 &&
+          grep -q '"status":"UP"' <&3
       interval: 30s
-      timeout: 1s
+      timeout: 5s
       retries: 5
       start_period: 30s
     depends_on:

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -170,7 +170,7 @@ services:
         - >-
           exec 3<>/dev/tcp/127.0.0.1/9600 &&
           printf 'GET /actuator/health/readiness HTTP/1.0\r\n\r\n' >&3 &&
-          grep -q '"status":"UP"' <&3
+          grep -q '"status":"UP","components"' <&3
       interval: 30s
       timeout: 5s
       retries: 5
@@ -216,7 +216,7 @@ services:
         - >-
           exec 3<>/dev/tcp/127.0.0.1/9600 &&
           printf 'GET /actuator/health/readiness HTTP/1.0\r\n\r\n' >&3 &&
-          grep -q '"status":"UP"' <&3
+          grep -q '"status":"UP","components"' <&3
       interval: 30s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Description

The Optimize `Self-Managed (Smoke)` E2E job never reached its "Start services" gate for pull requests opened from **forks**: the `camunda` and `camunda-opensearch` services stayed `starting` until the 300s compose timeout, so the job failed before a single test ran.

The root cause is the container **base image**, not the compose stack. For fork PRs, `build-platform-docker` builds `camunda` with `BASE=public`, which uses the public `eclipse-temurin` base. That base ships **neither `wget` nor `curl`**, so the healthcheck `wget ... /actuator/health/readiness` exits `127` (`wget: not found`) on every attempt and the container is never marked healthy — even though the readiness endpoint returns `200 UP`. Internal branches use the hardened Minimus base (busybox `wget`), so the check passes there and the gap only surfaces on forks.

**Fix:** probe over bash's `/dev/tcp` instead. `bash` is present in **both** the hardened and public bases (verified locally), so the check no longer depends on a tool that only one base ships. The `keycloak` service in this same compose file already probes this way. The probe still reads the response body and matches `"status":"UP"`, so a broker whose port is open but not yet ready is reported unhealthy rather than merely port-reachable. The `1s` timeout was too tight for a body read, so it is raised to `5s`. Applied to both the `camunda` and `camunda-opensearch` services.

### Validation

- `bash` + `/dev/tcp` confirmed working in both the hardened `current-test` image and `eclipse-temurin:25.0.4_7-jre-noble`; `wget`/`curl` confirmed absent on the Temurin base.
- `docker compose config` parses; live `docker compose up --wait` brings `camunda` to `healthy` in ~26s. The earliest probe attempt correctly reports `ExitCode 1` (connection refused) before readiness, confirming the check is not a blind port-open pass.

## Related issues

closes #62726