### PR TITLE
deps: bump camunda-security-library to 1.0.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>1.0.0</version.camunda-security-library>
+    <version.camunda-security-library>1.0.1</version.camunda-security-library>
     <version.checkstyle>14.1.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
Closes #62775

## Summary
- Bump `version.camunda-security-library` from `1.0.0` to `1.0.1` in `parent/pom.xml`, the single dependency-management property that all consumers (including `webapp/server` — the unified Operate/Tasklist/Admin webapp — and the legacy `operate/webapp` chain) inherit their CSL version from.
- Picks up [camunda-security-library#628](https://github.com/camunda/camunda-security-library/pull/628): a new `camunda.security.authentication.oidc.post-logout-redirect-enabled` property (default `true`) that lets a deployment suppress `post_logout_redirect_uri` on RP-initiated logout for an IdP that cannot register the resulting per-cluster/per-tenant URL (Auth0 rejects the entire end-session request otherwise, so the user isn't logged out at all). SaaS needs to set this to `false`; it fixes Optimize's `/`-rooted post-logout route the same way.
- No API removed or changed between 1.0.0 and 1.0.1 that this repo uses, so this is a plain version bump with no follow-up code changes.

## Test plan
- [x] `webapp/server`, `operate/webapp` resolve `camunda-security-library-{api,core,spring-boot-starter}` at `1.0.1` (`mvn dependency:tree`)
- [x] `operate/common`, `operate/data-generator`, `security/security-services`, `authentication` resolve `camunda-security-library-{api,core,validation}` at `1.0.1`
- [x] All of the above compile cleanly against `1.0.1` (`mvn compile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
