### PR TITLE
feat: type lease token by request in generated SDKs via x-present-when

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2543,6 +2543,13 @@ jobs:
           --ruleset zeebe/gateway-protocol/.spectral.yaml
           --fail-severity error
         shell: bash
+      - name: Run Spectral custom-rule unit tests
+        # Exercises each custom Spectral function and shape rule against its
+        # fixtures (lints a fixture spec with the production ruleset and asserts
+        # on the emitted violations). The Spectral CLI installed above is
+        # required at runtime by spectral-tests/helpers.js.
+        run: node --test zeebe/gateway-protocol/spectral-tests/*.test.js
+        shell: bash
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1455,11 +1455,11 @@ property of `R`. Project the property three ways on the compile-time value of
 `F`, and propagate the projection outward through every enclosing type (e.g.
 `JobActivationResult.jobs[] → ActivatedJobResult.leaseToken`):
 
-|                            `F` at the call site                             |                                               Projection of the annotated property                                                |
-|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| the literal `V`                                                             | **present** — required, non-null                                                                                                  |
+|                                                               `F` at the call site                                                                |                                                                                              Projection of the annotated property                                                                                               |
+|---------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| the literal `V`                                                                                                                                   | **present** — required, non-null                                                                                                                                                                                                |
 | any other compile-time literal ≠ `V` — `false` / `null` / omitted, or a non-matching string/number (e.g. `mode: "summary"` when `equals: "full"`) | **absent** — omitted for nominal languages (Go, Rust, C#); typed `?: never` for JS/TS; for Python (no `?: never` equivalent) modelled via an overload whose return type omits the property (e.g. a `TypedDict` without the key) |
-| not a compile-time literal (dynamic value of `F`'s type, variable)          | base schema unchanged — property stays nullable (preserves backward compatibility)                                                |
+| not a compile-time literal (dynamic value of `F`'s type, variable)                                                                                | base schema unchanged — property stays nullable (preserves backward compatibility)                                                                                                                                              |
 
 Method surface derived from the marker (stated generally in terms of the
 request field `F` and its match literal `V`; the `withLease: true` / boolean

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1455,18 +1455,23 @@ property of `R`. Project the property three ways on the compile-time value of
 `F`, and propagate the projection outward through every enclosing type (e.g.
 `JobActivationResult.jobs[] → ActivatedJobResult.leaseToken`):
 
-|                   `F` at the call site                   |                           Projection of the annotated property                            |
-|----------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| equals `V` (literal)                                     | **present** — required, non-null                                                          |
-| `false` / `null` / omitted (literal)                     | **absent** — omitted for nominal languages (Go, Rust, C#); typed `?: never` for JS/Python |
-| not a compile-time literal (dynamic `boolean`, variable) | base schema unchanged — property stays nullable (preserves backward compatibility)        |
+|                            `F` at the call site                             |                                               Projection of the annotated property                                                |
+|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| the literal `V`                                                             | **present** — required, non-null                                                                                                  |
+| any other compile-time literal ≠ `V` — `false` / `null` / omitted, or a non-matching string/number (e.g. `mode: "summary"` when `equals: "full"`) | **absent** — omitted for nominal languages (Go, Rust, C#); typed `?: never` for JS/TS; for Python (no `?: never` equivalent) modelled via an overload whose return type omits the property (e.g. a `TypedDict` without the key) |
+| not a compile-time literal (dynamic value of `F`'s type, variable)          | base schema unchanged — property stays nullable (preserves backward compatibility)                                                |
 
-Method surface derived from the marker:
+Method surface derived from the marker (stated generally in terms of the
+request field `F` and its match literal `V`; the `withLease: true` / boolean
+case is the current production instance):
 
 - **Overload languages (JS/TS, Python, C#):** emit overloads keyed on the `F`
-  literal — `withLease: true` returns the present projection, `withLease?:
-  false | null | undefined` returns the absent projection, and the general
-  `boolean` overload returns the dynamic (base, nullable) projection.
+  literal — `F` set to `V` returns the present projection, `F` set to any other
+  compile-time literal returns the absent projection, and a non-literal `F`
+  (dynamic value of `F`'s declared type) returns the base, nullable projection.
+  For `activateJobs` this is: `withLease: true` returns the present projection,
+  `withLease?: false | null | undefined` returns the absent projection, and the
+  general `boolean` overload returns the dynamic (base, nullable) projection.
 - **Two-method languages (Go, Rust):** emit the base method for the absent
   projection (`activateJobs`, no token field) and a second method named
   `<baseMethod> + PascalCase(F)` — `activateJobsWithLease` — for the present

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1399,6 +1399,100 @@ cross-check the value against the `@ClusterScoped` annotation in Java directly
 
 ---
 
+### 2.21 Conditional-presence annotation (`x-present-when`)
+
+Some response properties are only meaningful for certain request shapes. The
+canonical case is `activateJobs`: `ActivatedJobResult.leaseToken` is populated
+only when the request was made with `withLease: true`; when `withLease` is
+`false` or omitted, the server returns no lease token. OpenAPI 3.x binds exactly
+one response schema per operation/status, so it cannot express that a response
+field's presence depends on a request field. Left unannotated, every generated
+SDK types `leaseToken` as always-nullable, and a user who reads it after an
+unleased activation writes code that compiles but fails at runtime.
+
+`x-present-when` encodes that request→response dependency as ground truth on the
+response property. It is the single source of truth from which each SDK's
+facade/post-generation layer derives dependent typing; the SDKs must not
+hardcode the relationship.
+
+#### Shape
+
+Place the marker on the response property whose presence is conditional:
+
+```yaml
+ActivatedJobResult:
+  required:
+    - ...
+    - leaseToken        # stays required + nullable on the wire (see below)
+  properties:
+    leaseToken:
+      description: The lease token; `null` when activated without a lease.
+      nullable: true
+      x-present-when:
+        request: withLease   # a TOP-LEVEL property of the operation's request body
+        equals: true         # a scalar literal (boolean / string / number)
+      allOf:
+        - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
+```
+
+- **`request`** — the name of a top-level property on the operation's request
+  body. Nested paths are not supported (decision: top-level only).
+- **`equals`** — a single scalar literal (`boolean`, `string`, or `number`).
+  Composite/array matchers are not supported (decision: scalar only).
+
+The `present-when-shape` Spectral rule validates this structure (see §3). The
+marker is **inert on the wire**: the property keeps its declared `nullable`
+shape and stays in `required`, so the server contract and any consumer that does
+not derive from the marker are completely unaffected. Adding or removing the
+marker is not a wire-breaking change.
+
+#### Derivation contract (what every SDK implements)
+
+For an operation with request body `R` and 200-response schema `S`, walk `S`
+transitively (including through arrays and nested objects) for any property
+annotated `x-present-when: { request: F, equals: V }`, where `F` is a top-level
+property of `R`. Project the property three ways on the compile-time value of
+`F`, and propagate the projection outward through every enclosing type (e.g.
+`JobActivationResult.jobs[] → ActivatedJobResult.leaseToken`):
+
+|                   `F` at the call site                   |                           Projection of the annotated property                            |
+|----------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| equals `V` (literal)                                     | **present** — required, non-null                                                          |
+| `false` / `null` / omitted (literal)                     | **absent** — omitted for nominal languages (Go, Rust, C#); typed `?: never` for JS/Python |
+| not a compile-time literal (dynamic `boolean`, variable) | base schema unchanged — property stays nullable (preserves backward compatibility)        |
+
+Method surface derived from the marker:
+
+- **Overload languages (JS/TS, Python, C#):** emit overloads keyed on the `F`
+  literal — `withLease: true` returns the present projection, `withLease?:
+  false | null | undefined` returns the absent projection, and the general
+  `boolean` overload returns the dynamic (base, nullable) projection.
+- **Two-method languages (Go, Rust):** emit the base method for the absent
+  projection (`activateJobs`, no token field) and a second method named
+  `<baseMethod> + PascalCase(F)` — `activateJobsWithLease` — for the present
+  projection (token required non-null). These are technical preview, so the
+  surface change is acceptable.
+
+The present-variant method must additionally assert at runtime that the property
+is populated and fail fast if it is absent. This covers the later-client →
+earlier-server case: a newer SDK that requested a lease against an older server
+that ignores `withLease` gets a clear failure rather than a silent null.
+
+Because the lease token is optional on every wire (REST `nullable`, gRPC proto3
+`optional`), none of this changes the wire; it is a pure client-typing
+refinement.
+
+#### When to add a new `x-present-when`
+
+Only when a response property's presence genuinely depends on a scalar
+top-level request field. This is rare — as of writing, `activateJobs` is the
+only production case. Do not use it for data-provenance or response-state
+conditioning (those use different mechanisms). If a new case needs nested
+request paths or non-scalar matchers, extend this section and the
+`present-when-shape` rule together rather than overloading the existing shape.
+
+---
+
 ## 3. Spectral linting & custom rules
 
 ### 3.1 What is Spectral?

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1465,18 +1465,29 @@ Method surface derived from the marker (stated generally in terms of the
 request field `F` and its match literal `V`; the `withLease: true` / boolean
 case is the current production instance):
 
-- **Overload languages (JS/TS, Python, C#):** emit overloads keyed on the `F`
-  literal — `F` set to `V` returns the present projection, `F` set to any other
-  compile-time literal returns the absent projection, and a non-literal `F`
-  (dynamic value of `F`'s declared type) returns the base, nullable projection.
-  For `activateJobs` this is: `withLease: true` returns the present projection,
-  `withLease?: false | null | undefined` returns the absent projection, and the
-  general `boolean` overload returns the dynamic (base, nullable) projection.
-- **Two-method languages (Go, Rust):** emit the base method for the absent
-  projection (`activateJobs`, no token field) and a second method named
-  `<baseMethod> + PascalCase(F)` — `activateJobsWithLease` — for the present
-  projection (token required non-null). These are technical preview, so the
-  surface change is acceptable.
+- **Literal-overload languages (JS/TS, Python):** emit overloads keyed on the
+  `F` literal — `F` set to `V` returns the present projection, `F` set to any
+  other compile-time literal returns the absent projection, and a non-literal
+  `F` returns the base, nullable projection. The dynamic overload must accept
+  `F`'s **full declared type including `null`** (for `withLease`, which is
+  `nullable: true`, that is `boolean | null`) so a runtime `boolean | null`
+  value resolves to the base projection rather than falling between the literal
+  overloads. These languages model this with TS function overloads on literal
+  types / Python `@overload` on `Literal[...]`. For `activateJobs` this is:
+  `withLease: true` returns the present projection, `withLease?: false | null |
+  undefined` returns the absent projection, and the general
+  `withLease: boolean | null` overload returns the dynamic (base, nullable)
+  projection.
+- **Distinct-surface languages (Go, Rust, C#):** these cannot select a return
+  type from a literal argument value — Go and Rust have no overloading, and C#
+  overload resolution distinguishes neither a `true` from a `false` argument nor
+  the return type. Emit two distinct methods instead: a base method
+  (`activateJobs` / `ActivateJobs`) that returns the **base nullable projection**
+  (token present but nullable) — this is the safe surface for both the absent
+  case and a runtime dynamic `F`, since the caller reads the nullable token — and
+  a second method named `<baseMethod> + PascalCase(F)` (`activateJobsWithLease` /
+  `ActivateJobsWithLease`) for the present projection (token required non-null).
+  These are technical preview, so the surface change is acceptable.
 
 The present-variant method must additionally assert at runtime that the property
 is populated and fail fast if it is absent. This covers the later-client →

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -193,6 +193,16 @@ rules:
   # from (e.g. ActivatedJobResult.leaseToken vs JobActivationRequest.withLease).
   # The marker is inert on the wire: the property keeps its declared nullable
   # shape for any consumer that does not derive from it.
+  #
+  # Scope: like the other `*-shape` rules here, this validates only the marker's
+  # local JSON shape — it does NOT cross-reference that `request` names a real
+  # top-level property on the operation's request body, so a typo'd binding
+  # (`request: withLeese`) passes this rule. That cross-reference is deliberately
+  # out of scope while `x-present-when` has a single production instance
+  # (activateJobs); the one live binding is pinned by the Spectral custom-rule
+  # unit tests. Add a semantic resolver (a custom JS function, as
+  # verify-semantic-kinds-registered does for x-semantic-*) here if the marker
+  # sees broader adoption.
   present-when-shape:
     description: "Each `x-present-when` marker must declare a request field and a scalar `equals` value."
     severity: error

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -14,6 +14,7 @@ functions:
   - verifyAddedInVersion
   - verifyScope
   - verifySemanticKindsRegistered
+  - verifyPresentWhenRequestResolves
   - verifyNoAmbiguousIdentifierProperty
   - verifySecurityDeclared
   - verifyRequiredPermissions
@@ -195,18 +196,10 @@ rules:
   # shape for any consumer that does not derive from it.
   #
   # Scope: like the other `*-shape` rules here, this validates only the marker's
-  # local JSON shape — it does NOT cross-reference that `request` names a real
-  # top-level property on the operation's request body, so a typo'd binding
-  # (`request: withLeese`) passes this rule. That cross-reference is deliberately
-  # out of scope while `x-present-when` has a single production instance
-  # (activateJobs). NOTE: the Spectral custom-rule unit tests
-  # (`spectral-tests/presentWhenShape.test.js`) lint only a synthetic fixture
-  # that carries no `requestBody`/`withLease` operation, so they verify the
-  # marker's *shape* only — neither they nor this rule pin the production
-  # `jobs.yaml` binding, so a typo'd `request` (e.g. `withLeese`) would go
-  # uncaught. Add a semantic resolver (a custom JS function, as
-  # verify-semantic-kinds-registered does for x-semantic-*) that checks the
-  # binding against the real spec here if the marker sees broader adoption.
+  # local JSON shape. It does NOT cross-reference that `request` names a real
+  # top-level property on the operation's request body — that referential-
+  # integrity check lives in the `present-when-request-resolves` rule below,
+  # which resolves each operation against the real spec.
   present-when-shape:
     description: "Each `x-present-when` marker must declare a request field and a scalar `equals` value."
     severity: error
@@ -227,6 +220,23 @@ rules:
             equals:
               type: [boolean, string, number]
               description: Scalar literal the request field must equal for the property to be present (required, non-null).
+
+  # Referential integrity for `x-present-when` (complements `present-when-shape`).
+  # The shape rule cannot see that `request` names a real field, because the
+  # marker sits on a shared component schema with no back-reference to the
+  # operation whose request body it constrains. This rule resolves each
+  # operation, finds every marker reachable from its 2xx responses, and asserts
+  # `request` is a top-level property of that operation's request body (and that
+  # the annotated property stays nullable + required — inert on the wire). A
+  # dangling binding (`request: withLeese`) would otherwise silently degrade the
+  # dependent typing every SDK generator derives from the marker.
+  present-when-request-resolves:
+    description: "Each `x-present-when.request` must name a top-level property of its operation's request body, and the annotated response property must stay nullable and required."
+    severity: error
+    given: "$.paths[*]"
+    message: "{{error}}"
+    then:
+      function: verifyPresentWhenRequestResolves
 
   # ── x-required-permissions (camunda/camunda#54727) ──
   # Canonical endpoint -> required-permission(s) binding. Two rules:

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -185,6 +185,35 @@ rules:
     then:
       function: verifyScope
 
+  # ── x-present-when ──
+  # Response-property marker declaring conditional presence: the annotated
+  # response property is present (required, non-null) iff the named top-level
+  # request-body field equals the given scalar; otherwise it is absent. This is
+  # the ground-truth SDK generators derive request→response dependent typing
+  # from (e.g. ActivatedJobResult.leaseToken vs JobActivationRequest.withLease).
+  # The marker is inert on the wire: the property keeps its declared nullable
+  # shape for any consumer that does not derive from it.
+  present-when-shape:
+    description: "Each `x-present-when` marker must declare a request field and a scalar `equals` value."
+    severity: error
+    given: $..x-present-when
+    message: "{{error}}"
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          additionalProperties: false
+          required: [request, equals]
+          properties:
+            request:
+              type: string
+              minLength: 1
+              description: Top-level request-body property whose value governs presence of this response property.
+            equals:
+              type: [boolean, string, number]
+              description: Scalar literal the request field must equal for the property to be present (required, non-null).
+
   # ── x-required-permissions (camunda/camunda#54727) ──
   # Canonical endpoint -> required-permission(s) binding. Two rules:
   #   1. Schema-shape lint for each entry (built-in `schema` function).

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -199,10 +199,14 @@ rules:
   # top-level property on the operation's request body, so a typo'd binding
   # (`request: withLeese`) passes this rule. That cross-reference is deliberately
   # out of scope while `x-present-when` has a single production instance
-  # (activateJobs); the one live binding is pinned by the Spectral custom-rule
-  # unit tests. Add a semantic resolver (a custom JS function, as
-  # verify-semantic-kinds-registered does for x-semantic-*) here if the marker
-  # sees broader adoption.
+  # (activateJobs). NOTE: the Spectral custom-rule unit tests
+  # (`spectral-tests/presentWhenShape.test.js`) lint only a synthetic fixture
+  # that carries no `requestBody`/`withLease` operation, so they verify the
+  # marker's *shape* only — neither they nor this rule pin the production
+  # `jobs.yaml` binding, so a typo'd `request` (e.g. `withLeese`) would go
+  # uncaught. Add a semantic resolver (a custom JS function, as
+  # verify-semantic-kinds-registered does for x-semantic-*) that checks the
+  # binding against the real spec here if the marker sees broader adoption.
   present-when-shape:
     description: "Each `x-present-when` marker must declare a request field and a scalar `equals` value."
     severity: error

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -244,11 +244,15 @@ ActivatedJobResult:
         - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
 ```
 
-Semantics SDK generators derive from the marker: when the request field equals
-the literal, the property is **present** (required, non-null); when it is
-`false`/`null`/omitted, the property is **absent** (omitted for nominal
-languages, typed `?: never` for JS/Python); when the request field is not a
-compile-time literal, the base nullable shape is preserved. The marker is inert
+Semantics SDK generators derive from the marker: when the request field is the
+compile-time literal `equals` value (`V`), the property is **present** (required,
+non-null); when it is any other compile-time literal — `false`/`null`/omitted, or
+a non-matching string/number such as `mode: "compact"` when `equals: "full"` —
+the property is **absent** (omitted for nominal languages; typed `?: never` for
+JS/TS; for Python, which has no `?: never` equivalent, modelled via an overload
+whose return type omits the property, e.g. a `TypedDict` without the key); when
+the request field is not a compile-time literal, the base nullable shape is
+preserved. The marker is inert
 on the wire — the property keeps its declared `nullable` shape and stays in
 `required`, so any consumer that does not derive from it is unaffected. See §2.21
 of [`docs/rest-api-endpoint-guidelines.md`](../../docs/rest-api-endpoint-guidelines.md)

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -218,6 +218,42 @@ paths:
 
 See §2.20 of [`docs/rest-api-endpoint-guidelines.md`](../../docs/rest-api-endpoint-guidelines.md) for the full convention, including how this maps to the `@ClusterScoped` controller annotation.
 
+### Conditional-presence annotations (`x-present-when`)
+
+A response property may be present only for certain request shapes. OpenAPI 3.x
+cannot express that a response field's presence depends on a request field, so
+generated SDKs default to typing such fields as always-nullable — which lets
+users write code that fails at runtime but compiles cleanly. `x-present-when`
+encodes that dependency as ground truth on the response property so SDK
+generators can derive request→response dependent typing.
+
+The `present-when-shape` rule validates the marker's structure: it must be an
+object with a `request` field (a top-level request-body property name) and a
+scalar `equals` literal (`boolean`, `string`, or `number`).
+
+```yaml
+ActivatedJobResult:
+  properties:
+    leaseToken:
+      description: The lease token; `null` when activated without a lease.
+      nullable: true
+      x-present-when:
+        request: withLease   # top-level field on the operation's request body
+        equals: true         # property is present (required, non-null) iff withLease === true
+      allOf:
+        - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
+```
+
+Semantics SDK generators derive from the marker: when the request field equals
+the literal, the property is **present** (required, non-null); when it is
+`false`/`null`/omitted, the property is **absent** (omitted for nominal
+languages, typed `?: never` for JS/Python); when the request field is not a
+compile-time literal, the base nullable shape is preserved. The marker is inert
+on the wire — the property keeps its declared `nullable` shape and stays in
+`required`, so any consumer that does not derive from it is unaffected. See §2.21
+of [`docs/rest-api-endpoint-guidelines.md`](../../docs/rest-api-endpoint-guidelines.md)
+for the full derivation contract each SDK implements.
+
 ### Semantic graph annotations (`x-semantic-establishes`, `x-semantic-requires`)
 
 Three rules validate the producer/consumer dependency annotations consumed by the API test generator:

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -244,7 +244,7 @@ ActivatedJobResult:
         - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
 ```
 
-Semantics SDK generators derive from the marker: when the request field is the
+Semantics: SDK generators derive from the marker: when the request field is the
 compile-time literal `equals` value (`V`), the property is **present** (required,
 non-null); when it is any other compile-time literal — `false`/`null`/omitted, or
 a non-matching string/number such as `mode: "compact"` when `equals: "full"` —

--- a/zeebe/gateway-protocol/spectral-functions/verifyPresentWhenRequestResolves.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyPresentWhenRequestResolves.js
@@ -1,0 +1,183 @@
+// Spectral custom function enforcing the referential integrity of every
+// `x-present-when` marker against the operation it actually belongs to.
+//
+// The `present-when-shape` rule only validates a marker's *local* shape (a
+// `request` string and a scalar `equals`). It cannot tell whether `request`
+// names a real field, because the marker lives on a shared component schema
+// (e.g. `ActivatedJobResult.leaseToken`) with no back-reference to the
+// operation whose request body it constrains. A typo — `request: withLeese` —
+// therefore passes the shape rule, and every SDK generator that derives
+// dependent typing from the marker silently falls back to base typing: no
+// error, no failing build, the compile-time safety just evaporates across all
+// SDKs at once.
+//
+// This function closes that gap. Applied via `$.paths[*]` in the resolved
+// traversal pass (rest-api.yaml), so $refs are inlined, it walks from each
+// operation into its 2xx response schemas, finds every reachable
+// `x-present-when` marker, and asserts:
+//
+//   1. `request` names a *top-level* property of that operation's request body
+//      (SDK generators can only project onto a top-level request field), and
+//   2. the annotated response property stays `nullable: true` and `required`,
+//      so it remains inert on the wire for consumers that do not derive from
+//      the marker.
+//
+// Error paths are anchored at the operation node under `paths` (staying on the
+// `paths` side of any $ref boundary) with a synthetic suffix so each violation
+// remains distinct.
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+const MARKER = 'x-present-when';
+
+module.exports = (input, _opts, context) => {
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+
+  const errors = [];
+
+  // input is a path item; iterate over HTTP methods.
+  for (const method of HTTP_METHODS) {
+    const operation = input[method];
+    if (!operation || typeof operation !== 'object') {
+      continue;
+    }
+
+    // Collect every marker reachable from success (2xx) response schemas.
+    const markers = [];
+    if (operation.responses && typeof operation.responses === 'object') {
+      for (const [code, response] of Object.entries(operation.responses)) {
+        if (!/^2\d\d$/.test(code)) continue;
+        if (!response || !response.content) continue;
+        for (const mediaObj of Object.values(response.content)) {
+          if (!mediaObj || !mediaObj.schema) continue;
+          collectMarkers(mediaObj.schema, new Set(), markers);
+        }
+      }
+    }
+
+    if (markers.length === 0) {
+      continue;
+    }
+
+    const operationPath = [...context.path, method];
+    const opId =
+      operation.operationId ||
+      `${context.path[context.path.length - 1]} ${method}`;
+
+    // Top-level property names of the operation's request body.
+    const requestProps = new Set();
+    if (operation.requestBody && operation.requestBody.content) {
+      for (const mediaObj of Object.values(operation.requestBody.content)) {
+        if (mediaObj && mediaObj.schema) {
+          collectTopLevelProperties(mediaObj.schema, requestProps, new Set());
+        }
+      }
+    }
+
+    for (const marked of markers) {
+      const request = marked.marker && marked.marker.request;
+      // A missing/mistyped `request` is the `present-when-shape` rule's job.
+      if (typeof request !== 'string' || request.length === 0) {
+        continue;
+      }
+
+      if (!requestProps.has(request)) {
+        errors.push({
+          message: `\`x-present-when.request: ${request}\` on response property \`${marked.name}\` does not resolve to a top-level property of the request body of operation \`${opId}\`.`,
+          path: [...operationPath, `${MARKER}/${marked.name}/request`],
+        });
+      }
+
+      // Inert-on-the-wire: the marked property must keep its declared
+      // nullable + required shape so non-deriving consumers are unaffected.
+      if (marked.propSchema.nullable !== true) {
+        errors.push({
+          message: `Response property \`${marked.name}\` carries \`${MARKER}\` and must be \`nullable: true\` (inert on the wire) in operation \`${opId}\`.`,
+          path: [...operationPath, `${MARKER}/${marked.name}/nullable`],
+        });
+      }
+      if (!marked.required) {
+        errors.push({
+          message: `Response property \`${marked.name}\` carries \`${MARKER}\` and must be listed in \`required\` (inert on the wire) in operation \`${opId}\`.`,
+          path: [...operationPath, `${MARKER}/${marked.name}/required`],
+        });
+      }
+    }
+  }
+
+  return errors;
+};
+
+// Aggregate the `required` entries and `properties` of a schema and its
+// allOf members into a single view for the current schema level.
+function aggregate(schema, requiredSet, propertyEntries) {
+  if (!schema || typeof schema !== 'object') return;
+
+  if (Array.isArray(schema.required)) {
+    schema.required.forEach((name) => requiredSet.add(name));
+  }
+
+  if (schema.properties && typeof schema.properties === 'object') {
+    for (const [name, prop] of Object.entries(schema.properties)) {
+      propertyEntries.push({ name, schema: prop });
+    }
+  }
+
+  if (Array.isArray(schema.allOf)) {
+    schema.allOf.forEach((sub) => aggregate(sub, requiredSet, propertyEntries));
+  }
+}
+
+// Collect the top-level property names of a (possibly allOf-composed) schema.
+// Intentionally does not recurse into nested objects: `x-present-when.request`
+// must name a *top-level* request-body field.
+function collectTopLevelProperties(schema, out, visited) {
+  if (!schema || typeof schema !== 'object' || visited.has(schema)) return;
+  visited.add(schema);
+
+  const requiredSet = new Set();
+  const entries = [];
+  aggregate(schema, requiredSet, entries);
+  for (const { name } of entries) {
+    out.add(name);
+  }
+}
+
+// Recursively find every property carrying an `x-present-when` marker, along
+// with whether its enclosing schema lists it in `required`.
+function collectMarkers(schema, visited, found) {
+  if (!schema || typeof schema !== 'object' || visited.has(schema)) return;
+  visited.add(schema);
+
+  const requiredSet = new Set();
+  const entries = [];
+  aggregate(schema, requiredSet, entries);
+
+  for (const { name, schema: propSchema } of entries) {
+    if (!propSchema || typeof propSchema !== 'object') continue;
+
+    if (propSchema[MARKER] && typeof propSchema[MARKER] === 'object') {
+      found.push({
+        name,
+        propSchema,
+        marker: propSchema[MARKER],
+        required: requiredSet.has(name),
+      });
+    }
+
+    // Recurse into nested objects and allOf compositions.
+    if (propSchema.properties || propSchema.allOf) {
+      collectMarkers(propSchema, visited, found);
+    }
+
+    // Recurse into array items.
+    if (
+      propSchema.type === 'array' &&
+      propSchema.items &&
+      typeof propSchema.items === 'object'
+    ) {
+      collectMarkers(propSchema.items, visited, found);
+    }
+  }
+}

--- a/zeebe/gateway-protocol/spectral-tests/README.md
+++ b/zeebe/gateway-protocol/spectral-tests/README.md
@@ -11,6 +11,10 @@ node --test spectral-tests/*.test.js
 
 Requires [Spectral CLI](https://docs.stoplight.io/docs/spectral/b8391e051b7d8-installation) (globally installed or via `npx`).
 
+CI runs the same suite in the `Lint / C8 REST OpenAPI` job (see
+`.github/workflows/ci.yml`), gated on the `openapi-change` path filter, so a
+broken rule or fixture fails the build.
+
 ## Structure
 
 ```

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/present-when-referential/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/present-when-referential/rest-api.yaml
@@ -1,0 +1,186 @@
+# Entry point for the `present-when-request-resolves` rule tests.
+#
+# The rule resolves each operation, finds `x-present-when` markers reachable
+# from its 2xx response schemas, and asserts that `request` names a top-level
+# property of the operation's request body, and that the annotated property is
+# nullable + required. Each operation below isolates one scenario; the tests
+# filter violations by the operation's path segment. Only the
+# `present-when-request-resolves` code is asserted on, so noise from other
+# rules is irrelevant.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — present-when-request-resolves
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid: request resolves; marker nested under an array; nullable+required.
+  /valid:
+    post:
+      operationId: activateValid
+      x-scope: physical-tenant
+      tags: [Test]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LeaseRequest'
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaseResultList'
+
+  # ── Invalid: `request` names no request-body property (typo).
+  /typo:
+    post:
+      operationId: activateTypo
+      x-scope: physical-tenant
+      tags: [Test]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LeaseRequest'
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypoResult'
+
+  # ── Invalid: operation has no request body at all.
+  /no-request-body:
+    get:
+      operationId: activateNoRequestBody
+      x-scope: physical-tenant
+      tags: [Test]
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaseResult'
+
+  # ── Invalid: marked property is not nullable.
+  /not-nullable:
+    post:
+      operationId: activateNotNullable
+      x-scope: physical-tenant
+      tags: [Test]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LeaseRequest'
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotNullableResult'
+
+  # ── Invalid: marked property is not listed in `required`.
+  /not-required:
+    post:
+      operationId: activateNotRequired
+      x-scope: physical-tenant
+      tags: [Test]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LeaseRequest'
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotRequiredResult'
+
+components:
+  schemas:
+    LeaseRequest:
+      type: object
+      required:
+        - maxJobs
+      properties:
+        maxJobs:
+          description: Maximum jobs to activate.
+          type: integer
+        withLease:
+          description: Whether to activate with a lease.
+          type: boolean
+          nullable: true
+
+    # Nested array shape, mirroring JobActivationResult -> jobs[] -> item.
+    LeaseResultList:
+      type: object
+      required:
+        - jobs
+      properties:
+        jobs:
+          description: The activated jobs.
+          type: array
+          items:
+            $ref: '#/components/schemas/LeaseResult'
+
+    LeaseResult:
+      type: object
+      required:
+        - leaseToken
+      properties:
+        leaseToken:
+          description: Present only when withLease is true.
+          type: string
+          nullable: true
+          x-present-when:
+            request: withLease
+            equals: true
+
+    TypoResult:
+      type: object
+      required:
+        - leaseToken
+      properties:
+        leaseToken:
+          description: Marker bound to a non-existent request field.
+          type: string
+          nullable: true
+          x-present-when:
+            request: withLeese
+            equals: true
+
+    NotNullableResult:
+      type: object
+      required:
+        - leaseToken
+      properties:
+        leaseToken:
+          description: Marked property missing nullable.
+          type: string
+          x-present-when:
+            request: withLease
+            equals: true
+
+    NotRequiredResult:
+      type: object
+      properties:
+        leaseToken:
+          description: Marked property missing from required.
+          type: string
+          nullable: true
+          x-present-when:
+            request: withLease
+            equals: true

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/present-when/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/present-when/rest-api.yaml
@@ -1,0 +1,139 @@
+# Entry point for the `present-when-shape` rule tests.
+# The rule targets every `x-present-when` marker in the document
+# (`given: $..x-present-when`) and validates its shape with the built-in
+# `schema` function: an object with a `request` string and a scalar `equals`
+# literal, and no additional properties. Schemas below inline both valid and
+# invalid markers so a single-file lint exercises the rule end to end. Only the
+# `present-when-shape` code is asserted on, so noise from other rules
+# (descriptions, unused components, etc.) is irrelevant.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — present-when
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  /things:
+    post:
+      operationId: activateThings
+      x-scope: physical-tenant
+      tags: [Test]
+      responses:
+        '200':
+          description: OK.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidBooleanTrueResult'
+
+components:
+  schemas:
+    # ── Valid: boolean equals ─────────────────────────────────────
+    ValidBooleanTrueResult:
+      type: object
+      properties:
+        leaseToken:
+          description: Present only when withLease is true.
+          type: string
+          nullable: true
+          x-present-when:
+            request: withLease
+            equals: true
+
+    # ── Valid: string equals ──────────────────────────────────────
+    ValidStringEqualsResult:
+      type: object
+      properties:
+        detail:
+          description: Present only for the full view mode.
+          type: string
+          nullable: true
+          x-present-when:
+            request: mode
+            equals: full
+
+    # ── Valid: number equals ──────────────────────────────────────
+    ValidNumberEqualsResult:
+      type: object
+      properties:
+        trace:
+          description: Present only at verbosity level 2.
+          type: string
+          nullable: true
+          x-present-when:
+            request: verbosity
+            equals: 2
+
+    # ── Invalid: missing `equals` ─────────────────────────────────
+    InvalidMissingEqualsResult:
+      type: object
+      properties:
+        leaseToken:
+          description: Marker without an equals literal.
+          type: string
+          nullable: true
+          x-present-when:
+            request: withLease
+
+    # ── Invalid: missing `request` ────────────────────────────────
+    InvalidMissingRequestResult:
+      type: object
+      properties:
+        leaseToken:
+          description: Marker without a request field.
+          type: string
+          nullable: true
+          x-present-when:
+            equals: true
+
+    # ── Invalid: empty `request` string ───────────────────────────
+    InvalidEmptyRequestResult:
+      type: object
+      properties:
+        leaseToken:
+          description: Marker with an empty request field.
+          type: string
+          nullable: true
+          x-present-when:
+            request: ""
+            equals: true
+
+    # ── Invalid: unknown extra property ───────────────────────────
+    InvalidExtraPropertyResult:
+      type: object
+      properties:
+        leaseToken:
+          description: Marker with an unrecognised extra key.
+          type: string
+          nullable: true
+          x-present-when:
+            request: withLease
+            equals: true
+            bogus: true
+
+    # ── Invalid: non-scalar `equals` (array) ──────────────────────
+    InvalidArrayEqualsResult:
+      type: object
+      properties:
+        leaseToken:
+          description: Marker with an array equals value.
+          type: string
+          nullable: true
+          x-present-when:
+            request: withLease
+            equals:
+              - true
+
+    # ── Invalid: non-scalar `equals` (object) ─────────────────────
+    InvalidObjectEqualsResult:
+      type: object
+      properties:
+        leaseToken:
+          description: Marker with an object equals value.
+          type: string
+          nullable: true
+          x-present-when:
+            request: withLease
+            equals:
+              nested: true

--- a/zeebe/gateway-protocol/spectral-tests/presentWhenReferentialIntegrity.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/presentWhenReferentialIntegrity.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule, filterByPathSegment } = require('./helpers');
+
+const FIXTURE = 'present-when-referential';
+const RULE = 'present-when-request-resolves';
+
+describe('present-when-request-resolves', () => {
+  let violations;
+
+  before(() => {
+    // Unlike `present-when-shape`, this rule resolves each operation and
+    // cross-references the marker's `request` against the operation's request
+    // body, so the fixture carries full operations (requestBody + 2xx
+    // responses). Each operation isolates one scenario; we filter by its path.
+    violations = filterByRule(lintFixture(FIXTURE), RULE);
+  });
+
+  const forPath = (segment) => filterByPathSegment(violations, segment);
+
+  // ── Valid: request resolves, marker nested under an array, nullable+required.
+
+  it('accepts a marker whose request resolves to a top-level request field', () => {
+    assert.equal(forPath('/valid').length, 0);
+  });
+
+  // ── Invalid scenarios (each isolated on its own operation) ───────
+
+  it('flags a marker whose request names no request-body property', () => {
+    const v = forPath('/typo');
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /withLeese/);
+    assert.match(v[0].message, /does not resolve to a top-level property/);
+  });
+
+  it('flags a marker on an operation with no request body', () => {
+    const v = forPath('/no-request-body');
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /does not resolve to a top-level property/);
+  });
+
+  it('flags a marked response property that is not nullable', () => {
+    const v = forPath('/not-nullable');
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /nullable/);
+  });
+
+  it('flags a marked response property missing from `required`', () => {
+    const v = forPath('/not-required');
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /required/);
+  });
+});

--- a/zeebe/gateway-protocol/spectral-tests/presentWhenShape.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/presentWhenShape.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule, filterByPathSegment } = require('./helpers');
+
+const FIXTURE = 'present-when';
+const SHAPE_RULE = 'present-when-shape';
+
+describe('present-when-shape', () => {
+  let shape;
+
+  before(() => {
+    const allResults = lintFixture(FIXTURE);
+    shape = filterByRule(allResults, SHAPE_RULE);
+  });
+
+  const shapeFor = (schemaName) => filterByPathSegment(shape, schemaName);
+
+  // ── Valid markers (no shape violations) ──────────────────────────
+
+  describe('valid markers', () => {
+    it('accepts a boolean equals literal', () => {
+      assert.equal(shapeFor('ValidBooleanTrueResult').length, 0);
+    });
+
+    it('accepts a string equals literal', () => {
+      assert.equal(shapeFor('ValidStringEqualsResult').length, 0);
+    });
+
+    it('accepts a number equals literal', () => {
+      assert.equal(shapeFor('ValidNumberEqualsResult').length, 0);
+    });
+  });
+
+  // ── Invalid markers (exactly one shape violation each) ───────────
+
+  describe('invalid markers', () => {
+    it('flags a marker missing the equals literal', () => {
+      const v = shapeFor('InvalidMissingEqualsResult');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /equals/);
+    });
+
+    it('flags a marker missing the request field', () => {
+      const v = shapeFor('InvalidMissingRequestResult');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /request/);
+    });
+
+    it('flags an empty request field', () => {
+      assert.equal(shapeFor('InvalidEmptyRequestResult').length, 1);
+    });
+
+    it('flags an unknown extra property', () => {
+      assert.equal(shapeFor('InvalidExtraPropertyResult').length, 1);
+    });
+
+    it('flags a non-scalar (array) equals value', () => {
+      assert.equal(shapeFor('InvalidArrayEqualsResult').length, 1);
+    });
+
+    it('flags a non-scalar (object) equals value', () => {
+      assert.equal(shapeFor('InvalidObjectEqualsResult').length, 1);
+    });
+  });
+});

--- a/zeebe/gateway-protocol/spectral-tests/presentWhenShape.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/presentWhenShape.test.js
@@ -11,6 +11,11 @@ describe('present-when-shape', () => {
   let shape;
 
   before(() => {
+    // Scope: this suite lints only the synthetic `present-when` fixture, so it
+    // verifies the marker's shape — not the production `jobs.yaml` binding. A
+    // typo'd `request` (e.g. `withLeese`) in the live spec would still pass; add
+    // a production-spec / semantic-resolver check if x-present-when sees broader
+    // adoption (see the matching note in `.spectral.yaml`).
     const allResults = lintFixture(FIXTURE);
     shape = filterByRule(allResults, SHAPE_RULE);
   });

--- a/zeebe/gateway-protocol/spectral-tests/presentWhenShape.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/presentWhenShape.test.js
@@ -12,10 +12,11 @@ describe('present-when-shape', () => {
 
   before(() => {
     // Scope: this suite lints only the synthetic `present-when` fixture, so it
-    // verifies the marker's shape — not the production `jobs.yaml` binding. A
-    // typo'd `request` (e.g. `withLeese`) in the live spec would still pass; add
-    // a production-spec / semantic-resolver check if x-present-when sees broader
-    // adoption (see the matching note in `.spectral.yaml`).
+    // verifies the marker's shape — not that `request` names a real request-body
+    // field. That referential-integrity check lives in the
+    // `present-when-request-resolves` rule and its suite
+    // (`presentWhenReferentialIntegrity.test.js`), which resolves each operation
+    // against the real spec and catches a typo'd `request` (e.g. `withLeese`).
     const allResults = lintFixture(FIXTURE);
     shape = filterByRule(allResults, SHAPE_RULE);
   });

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -571,6 +571,9 @@ components:
             The lease token identifying this activation. This is `null` when the job was
             activated without a lease.
           nullable: true
+          x-present-when:
+            request: withLease
+            equals: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/JobLeaseToken'
       x-properties-added-in-version:


### PR DESCRIPTION
## Description

An `ActivatedJob`'s `leaseToken` is populated only when the job was activated with `withLease: true`; when `withLease` is `false` or omitted, the server returns no token. OpenAPI 3.x binds one response schema per operation/status, so it cannot express that a response field's presence depends on a request field. Every generated SDK therefore types `leaseToken` as always-nullable, and a user who reads it after an unleased activation writes code that **compiles cleanly but fails at runtime**.

This PR encodes the dependency as ground truth in the spec so each SDK's facade/post-generation layer can *derive* request-to-response dependent typing rather than hardcoding the relationship.

### What changes

- **New field-level vendor extension `x-present-when`** — `{ request: <field>, equals: <scalar> }` marks a response property as present (required, non-null) iff the named top-level request field equals the given scalar literal, and absent otherwise. Applied to `ActivatedJobResult.leaseToken` (`request: withLease, equals: true`) — the first and currently only case.
- **Inert on the wire** — the property keeps its declared `nullable` shape and stays in `required`, so the server contract and any consumer that does not derive from the marker are unaffected. Valid because the lease token is already optional on every wire (REST `nullable`, gRPC proto3 `optional`). This is purely a client-typing refinement; no wire/behavioural change.
- **`present-when-shape` Spectral rule** validates the marker structure (request string, scalar `equals`, no extra keys), with a fixture + unit test mirroring the existing `required-permissions-shape` coverage.
- **Docs** — the full per-SDK derivation contract (present/absent/dynamic projections, nested-projection propagation, derived method surface, and the runtime guard covering a newer client hitting an older server) is documented in §2.21 of the REST API endpoint guidelines and summarised in `OPENAPI_VALIDATION.md`.
- **CI** — the `spectral-tests` harness previously ran nowhere in CI (local-only). Added a `node --test` step to the existing `Lint / C8 REST OpenAPI` job so the whole harness, including the new rule, is now gated.

The SDK-side derivations (JS hook, Go facadegen, then Python/Rust/C#) are follow-up work in the individual SDK repos; this PR lands the spec ground truth they derive from.

## Related issues

- [x] This PR does not need a linked issue

## Notes

- The marker is additive and inert; no existing type contract or wire behaviour changes.
- Spectral lints clean on the real spec; `present-when-shape` fires on malformed markers (unit-tested).
