### PR TITLE
fix: prevent test-artifact upload failing the job on transient GitHub errors

### DIFF
--- a/.github/actions/collect-test-artifacts/action.yml
+++ b/.github/actions/collect-test-artifacts/action.yml
@@ -23,11 +23,52 @@ inputs:
 
 runs:
   using: composite
+  # GitHub Actions has no retry primitive for a `uses:` step, so each attempt is
+  # a literal copy of the step gated on the previous attempt's outcome (same
+  # pattern as setup-java-with-retry, adopted after INC-7417 showed that
+  # wrapping a `uses:` step in a third-party retry action can break it).
+  # Editing one attempt means editing all of them -- keep the `with:` blocks
+  # identical.
   steps:
-  - name: Archive Test Results
+  - name: Archive Test Results (attempt 1 of 3)
+    id: attempt-1
+    continue-on-error: true
     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: Test results for ${{ inputs.name  }}
       path: ${{ inputs.path }}
       retention-days: ${{ inputs.retention-days }}
       if-no-files-found: ignore
+      overwrite: true
+
+  - name: Wait before attempt 2
+    if: always() && steps.attempt-1.outcome == 'failure'
+    shell: bash
+    run: sleep 10
+
+  - name: Archive Test Results (attempt 2 of 3)
+    id: attempt-2
+    if: always() && steps.attempt-1.outcome == 'failure'
+    continue-on-error: true
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    with:
+      name: Test results for ${{ inputs.name  }}
+      path: ${{ inputs.path }}
+      retention-days: ${{ inputs.retention-days }}
+      if-no-files-found: ignore
+      overwrite: true
+
+  - name: Wait before attempt 3
+    if: always() && steps.attempt-2.outcome == 'failure'
+    shell: bash
+    run: sleep 10
+
+  - name: Archive Test Results (attempt 3 of 3)
+    if: always() && steps.attempt-2.outcome == 'failure'
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    with:
+      name: Test results for ${{ inputs.name  }}
+      path: ${{ inputs.path }}
+      retention-days: ${{ inputs.retention-days }}
+      if-no-files-found: ignore
+      overwrite: true


### PR DESCRIPTION
## Summary

Three Optimize `ccsm-test` matrix legs failed on a `stable/8.10` push run
(https://github.com/camunda/camunda/actions/runs/34559648494), each opening its own CI
incident (INC-7981, INC-7982, INC-7983), even though every actual test step in those jobs
passed. The only failing step in each was `Archive Test Results` (uploads test reports via
`.github/actions/collect-test-artifacts`), with the annotation:

```
Failed to FinalizeArtifact: Received non-retryable error: Failed request: (403) Forbidden:
Error from intermediary with HTTP status code 403 "Forbidden"
```

That's a transient GitHub artifact-storage error, not a test/product regression, but it fails
the whole job because the upload step has no retry.

## Why this approach

`nick-fields/retry` only retries a shell `command:`, not a `uses:` step, so it can't wrap
`actions/upload-artifact`. `Wandalen/wretry.action` can wrap a `uses:` step, but this repo has
already been burned by it twice — see References below — and moved off it entirely in favor of
a literal 3-attempt copy of the step gated on the previous attempt's `outcome` (the pattern
`setup-java-with-retry` already uses). This PR applies that same established pattern to
`Archive Test Results` in `.github/actions/collect-test-artifacts/action.yml` instead of
reintroducing the wrapper this repo deliberately removed.

Scope is limited to this one composite action; no workflow-level changes.

## References

- **INC-7417** (2026-08-25, 11 incidents) — introduced wrapping `setup-java` / GCS WIF auth in
  `Wandalen/wretry.action` to fix a different missing-retry gap. Caught mid-PR: wretry blanks
  `INPUT_SERVICE_ACCOUNT` / `INPUT_WORKLOAD_IDENTITY_PROVIDER` before `google-github-actions/auth`
  reads them, dropping SA impersonation and 403'ing every downstream `gcloud storage` call —
  discussion and fix: https://github.com/camunda/camunda/pull/61190
- **INC-7723** (2026-09-03, 33 incidents) — root cause of the incident above traced further:
  `Wandalen/wretry.action` fetches the wrapped action via an anonymous runtime `git clone`,
  which GitHub rate-limits per source IP; ~40 shared-runner jobs behind one NAT egress exhausted
  it in minutes. Fix removed the wrapper entirely and introduced the literal-repeat composite
  pattern this PR reuses (`setup-java-with-retry`, `setup-buildx-with-retry`,
  `docker-build-with-retry`) — incident: https://app.incident.io/camunda/incidents/7723,
  PR: https://github.com/camunda/camunda/pull/62493
- **INC-7981**: https://camunda.slack.com/archives/C0C147RUV4J
- **INC-7982**: https://camunda.slack.com/archives/C0C0Y2DG30T
- **INC-7983**: https://camunda.slack.com/archives/C0C17UT090U

## Related issues

closes #62789

## Test plan

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/actions/collect-test-artifacts/action.yml'))"` — YAML parses, step ids unique (done locally, see PR)
- [ ] actionlint / conftest were not available in the sandbox this was authored in — CI's own `Java checks` / workflow-lint job will validate on push
- [ ] Merge and watch the next `ci-optimize.yml` run for `collect-test-artifacts` — confirm the job still succeeds when attempt 1 succeeds, and would retry cleanly if attempt 1 failed
