### PR TITLE
fix: run the .github checkout before writing metrics files in aggregate-metrics

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -143,6 +143,14 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # Runs first, before any step below writes metrics-*.json/variants.json into
+      # $GITHUB_WORKSPACE: checkout wipes the entire workspace contents whenever it finds no
+      # existing .git directory there (regardless of the `clean` input), which would otherwise
+      # delete those files before the GCS upload step gets to read them.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
       - name: Download variant metrics artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true # a variant whose collect-metrics never ran just yields fewer entries below
@@ -193,14 +201,6 @@ jobs:
             variants.json
           retention-days: 90
           if-no-files-found: ignore
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
-          # clean: false -- checkout defaults to `git clean -ffdx`, which would delete the
-          # metrics-*.json/variants.json files the steps above just wrote into $GITHUB_WORKSPACE
-          # before the GCS upload step below gets to read them.
-          clean: false
       - name: Download flamegraph artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true # profiling is best-effort; a run with no flamegraphs still persists its metrics


### PR DESCRIPTION
## Description

Since [#62542](https://github.com/camunda/camunda/pull/62542) merged, every daily load test run's "Upload results to GCS" step has silently failed, and `gs://camunda-benchmark-load-test-results-prod` has stayed empty. The failure is masked because that step has `continue-on-error: true`, so the job and PR checks show green.

Root cause: the `aggregate-metrics` job writes `metrics-*.json`/`variants.json` into `$GITHUB_WORKSPACE`, then checks out `.github` (sparse) to pull in the local `gcs-build-cache-auth` action, before uploading those files to GCS. That checkout is the *first* one in the job, so the workspace has no `.git` yet. `actions/checkout`'s `prepareExistingDirectory()` treats a workspace with no existing `.git` as needing a full wipe and deletes every file in it, before it even looks at the `clean` input - so the workflow's `clean: false` (added by a previous fix attempt in the same PR) never had any effect, since that input only guards a later `git clean -ffdx` call that this code path never reaches.

Confirmed against the actual failure: `gcloud storage cp` reported `variants.json` as "matched no objects or files" (`metrics-*.json` silently disappeared too, elided by `nullglob` since it's a glob pattern with no match, while `variants.json` is a literal name that stays in the copy list and surfaces the error).

Fix: move the checkout to the first step of the job, before anything writes to the workspace, so the wipe lands on an empty directory instead of the generated metrics files. Drops the now-inert `clean: false` and its comment.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

Not backported: `camunda-daily-load-tests.yml` only runs against `main`, it has no stable-branch wrapper.

## Related issues

- [x] This PR does not need a linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)