### PR TITLE
TEMP - do not merge - verify GCS checkout-order fix

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -143,6 +143,14 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # Runs first, before any step below writes metrics-*.json/variants.json into
+      # $GITHUB_WORKSPACE: checkout wipes the entire workspace contents whenever it finds no
+      # existing .git directory there (regardless of the `clean` input), which would otherwise
+      # delete those files before the GCS upload step gets to read them.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
       - name: Download variant metrics artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true # a variant whose collect-metrics never ran just yields fewer entries below
@@ -193,14 +201,6 @@ jobs:
             variants.json
           retention-days: 90
           if-no-files-found: ignore
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
-          # clean: false -- checkout defaults to `git clean -ffdx`, which would delete the
-          # metrics-*.json/variants.json files the steps above just wrote into $GITHUB_WORKSPACE
-          # before the GCS upload step below gets to read them.
-          clean: false
       - name: Download flamegraph artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true # profiling is best-effort; a run with no flamegraphs still persists its metrics

--- a/.github/workflows/test-gcs-checkout-fix.yml
+++ b/.github/workflows/test-gcs-checkout-fix.yml
@@ -1,0 +1,78 @@
+name: TEMP - verify GCS checkout-order fix
+
+# Throwaway workflow to empirically verify the fix in the aggregate-metrics job of
+# camunda-daily-load-tests.yml (checkout wipes an untracked workspace regardless of `clean`).
+# Never meant to merge to main - delete before closing the throwaway PR that triggers this.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test-gcs-checkout-fix.yml
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  old-order:
+    name: OLD order (write files, then checkout) - expect failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Write dummy metrics files
+        run: |
+          echo '[{"key":"grpc"}]' > variants.json
+          echo '{"foo":1}' > metrics-grpc.json
+          ls -la
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Show workspace after checkout
+        run: ls -la
+      - name: Authenticate to GCS load-test-results
+        continue-on-error: true
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          secret-path: secret/data/products/camunda/ci/load-test-results/load-test-results-sa
+      - name: Upload to GCS test prefix (expected to fail)
+        continue-on-error: true
+        run: |
+          shopt -s nullglob
+          files=(metrics-*.json variants.json)
+          echo "Files to copy: ${files[*]:-<none>}"
+          gcloud storage cp "${files[@]}" "gs://camunda-benchmark-load-test-results-prod/automated/_test/checkout-fix/${{ github.run_id }}/old-order/"
+
+  new-order:
+    name: NEW order (checkout, then write files) - expect success
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Show workspace after checkout
+        run: ls -la
+      - name: Write dummy metrics files
+        run: |
+          echo '[{"key":"grpc"}]' > variants.json
+          echo '{"foo":1}' > metrics-grpc.json
+          ls -la
+      - name: Authenticate to GCS load-test-results
+        continue-on-error: true
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          secret-path: secret/data/products/camunda/ci/load-test-results/load-test-results-sa
+      - name: Upload to GCS test prefix (expected to succeed)
+        run: |
+          shopt -s nullglob
+          files=(metrics-*.json variants.json)
+          echo "Files to copy: ${files[*]:-<none>}"
+          gcloud storage cp "${files[@]}" "gs://camunda-benchmark-load-test-results-prod/automated/_test/checkout-fix/${{ github.run_id }}/new-order/"


### PR DESCRIPTION
Throwaway PR to trigger `.github/workflows/test-gcs-checkout-fix.yml` and empirically verify the root cause / fix in [#62792](https://github.com/camunda/camunda/pull/62792). Runs `old-order` (reproduces the bug: write files, then checkout) and `new-order` (the fix: checkout, then write files) side by side, uploading to a throwaway `automated/_test/checkout-fix/<run_id>/` prefix in the real bucket. Will be closed and deleted once verified - never merges.