### PR TITLE
fix: feed liquibase runner with table prefix as context

### DIFF
--- a/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/RdbmsChangelogContextTest.java
+++ b/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/RdbmsChangelogContextTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import liquibase.Liquibase;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.DatabaseFactory;
+import liquibase.resource.DirectoryResourceAccessor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the per-table-prefix Liquibase fast-check workaround in {@code LiquibaseSchemaManager}.
+ *
+ * <p>Liquibase's fast-check cache key omits the changelog table name, so the runner configures a
+ * unique context for every non-blank table prefix. Contextless changesets remain eligible for every
+ * tenant, but a context-filtered changeset would be skipped because it cannot match that synthetic
+ * context. Adding one must therefore revisit the cache workaround rather than silently changing the
+ * migration set.
+ */
+class RdbmsChangelogContextTest {
+
+  private static final Path MAIN_RESOURCES_DIRECTORY = Path.of("src", "main", "resources");
+  private static final Path CHANGELOG_DIRECTORY =
+      MAIN_RESOURCES_DIRECTORY.resolve("db/changelog/rdbms-exporter");
+
+  @Test
+  void shouldNotFilterRdbmsChangelogsByContext() throws Exception {
+    // given every production changelog, including the master, seed, and included changesets
+    final List<Path> changelogFiles = changelogFiles();
+    assertThat(changelogFiles).isNotEmpty();
+    for (final var changelog : changelogFiles) {
+      final var changeSets = loadChangeSets(changelog);
+
+      // then the synthetic per-prefix context cannot exclude any changeset
+      assertThat(changeSets)
+          .isNotEmpty()
+          .filteredOn(RdbmsChangelogContextTest::hasContextFilter)
+          .as(
+              "%s has context-filtered changesets. The per-table-prefix Liquibase fast-check "
+                  + "workaround would skip them because its synthetic context cannot match.",
+              changelog)
+          .isEmpty();
+    }
+  }
+
+  private static List<Path> changelogFiles() throws IOException {
+    try (final var paths = Files.walk(CHANGELOG_DIRECTORY)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith(".xml"))
+          .toList();
+    }
+  }
+
+  private static boolean hasContextFilter(final ChangeSet changeSet) {
+    final var contextFilter = changeSet.getContextFilter();
+    return contextFilter != null && !contextFilter.isEmpty();
+  }
+
+  private static List<ChangeSet> loadChangeSets(final Path changelog) throws Exception {
+    final var database = DatabaseFactory.getInstance().getDatabase("h2");
+    final var changelogPath =
+        MAIN_RESOURCES_DIRECTORY
+            .relativize(changelog)
+            .toString()
+            .replace(changelog.getFileSystem().getSeparator(), "/");
+    final var liquibase =
+        new Liquibase(
+            changelogPath, new DirectoryResourceAccessor(MAIN_RESOURCES_DIRECTORY), database);
+    liquibase.setChangeLogParameter("prefix", "");
+    liquibase.setChangeLogParameter("userCharColumnSize", 4000);
+    liquibase.setChangeLogParameter("errorMessageSize", 4000);
+    liquibase.setChangeLogParameter("treePathSize", 4000);
+    return liquibase.getDatabaseChangeLog().getChangeSets();
+  }
+}

--- a/db/rdbms/pom.xml
+++ b/db/rdbms/pom.xml
@@ -160,6 +160,11 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
@@ -244,6 +244,13 @@ public class LiquibaseSchemaManager implements RdbmsSchemaManager {
             "userCharColumnSize", Integer.toString(vendorDatabaseProperties.userCharColumnSize()),
             "errorMessageSize", Integer.toString(vendorDatabaseProperties.errorMessageSize()),
             "treePathSize", Integer.toString(vendorDatabaseProperties.treePathSize())));
+    /**
+     * to avoid that Liquibase's JVM-wide fast-check mistakes one prefixed physical tenant's schema
+     * for another's {@link liquibase.changelog.FastCheckService#isUpToDateFastCheck}
+     */
+    if (StringUtils.isNotBlank(prefix)) {
+      runner.setContexts(prefix + "CONTEXT");
+    }
     return runner;
   }
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerFastCheckH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerFastCheckH2Test.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.util.UUID;
+import liquibase.Scope;
+import liquibase.changelog.ChangeLogHistoryServiceFactory;
+import liquibase.changelog.FastCheckService;
+import liquibase.integration.spring.SpringLiquibase;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that Liquibase's JVM-wide fast-check cache cannot mistake one prefixed physical tenant's
+ * schema for another's.
+ *
+ * <p>The cache key does not contain Liquibase's changelog table name. This test uses a deliberately
+ * minimal master changelog because the production changelog contains a changeset that requires an
+ * update-command run even after the schema is otherwise current. The real seed changelog is still
+ * used so the skipped master migration is reported as initialized, matching #62802.
+ */
+class LiquibaseSchemaManagerFastCheckH2Test {
+
+  private static final String TENANT_A_PREFIX = "TENANT_A_";
+  private static final String TENANT_B_PREFIX = "TENANT_B_";
+  private static final String FAST_CHECK_CHANGELOG =
+      "db/changelog/rdbms-fast-check/changelog-master.xml";
+
+  private JdbcDataSource dataSource;
+  private VendorDatabaseProperties h2Properties;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    h2Properties = VendorDatabasePropertiesLoader.load("h2");
+    dataSource = new JdbcDataSource();
+    dataSource.setURL(
+        "jdbc:h2:mem:fast-check-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
+    dataSource.setUser("sa");
+    dataSource.setPassword("");
+  }
+
+  @Test
+  @RegressionTest("https://github.com/camunda/camunda/issues/62802")
+  void shouldMigratePrefixedTenantWhenAnotherTenantIsCachedAsUpToDate() throws Exception {
+    // given a second tenant seeded by a peer, and a first tenant fully migrated by that peer
+    final var tenantA = schemaManagerFor(TENANT_A_PREFIX);
+    final var tenantB = schemaManagerFor(TENANT_B_PREFIX);
+    tenantB.seedSchemaVersion();
+    tenantA.initialize();
+    resetLiquibaseServicesAfterPeerMigration();
+
+    // when this node sees tenant A is current before it initializes tenant B
+    tenantA.initialize();
+    tenantB.initialize();
+
+    // then tenant B's master changelog was not skipped because of tenant A's cached result
+    assertThat(tableExists(TENANT_B_PREFIX + "FAST_CHECK_PROBE")).isTrue();
+  }
+
+  private LiquibaseSchemaManager schemaManagerFor(final String prefix) throws Exception {
+    return new LiquibaseSchemaManager(
+        new PerTenantSchemaConfig(dataSource, h2Properties, prefix, true, null), "8.10.0") {
+      @Override
+      protected SpringLiquibase buildRunner() {
+        final var runner = super.buildRunner();
+        runner.setChangeLog(FAST_CHECK_CHANGELOG);
+        return runner;
+      }
+    };
+  }
+
+  private static void resetLiquibaseServicesAfterPeerMigration() {
+    final var scope = Scope.getCurrentScope();
+    scope.getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
+    scope.getSingleton(FastCheckService.class).clearCache();
+  }
+
+  private boolean tableExists(final String tableName) throws Exception {
+    try (final var connection = dataSource.getConnection()) {
+      final var metadata = connection.getMetaData();
+      try (final var tables =
+          metadata.getTables(null, null, tableName.toUpperCase(), new String[] {"TABLE"})) {
+        return tables.next();
+      }
+    }
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
@@ -61,6 +61,30 @@ class LiquibaseSchemaManagerTest {
     verify(versionStore).recordCurrentVersion();
   }
 
+  @Test
+  void shouldUseTablePrefixAsLiquibaseContext() {
+    // given
+    final var schemaManager = new LiquibaseSchemaManager(autoDdlConfig("TENANT_"), "8.10.0");
+
+    // when
+    final var runner = schemaManager.buildRunner();
+
+    // then
+    assertThat(runner.getContexts()).isEqualTo("TENANT_CONTEXT");
+  }
+
+  @Test
+  void shouldNotSetLiquibaseContextWithoutTablePrefix() {
+    // given
+    final var schemaManager = new LiquibaseSchemaManager(autoDdlConfig(), "8.10.0");
+
+    // when
+    final var runner = schemaManager.buildRunner();
+
+    // then
+    assertThat(runner.getContexts()).isNull();
+  }
+
   // ---- stale lock (mock-based) ----
 
   @Test
@@ -205,7 +229,11 @@ class LiquibaseSchemaManagerTest {
   // ---- helpers ----
 
   private static PerTenantSchemaConfig autoDdlConfig() {
-    return new PerTenantSchemaConfig(mock(DataSource.class), h2Properties(), "", true, null);
+    return autoDdlConfig("");
+  }
+
+  private static PerTenantSchemaConfig autoDdlConfig(final String prefix) {
+    return new PerTenantSchemaConfig(mock(DataSource.class), h2Properties(), prefix, true, null);
   }
 
   private static VendorDatabaseProperties h2Properties() {

--- a/db/rdbms/src/test/resources/db/changelog/rdbms-fast-check/changelog-master.xml
+++ b/db/rdbms/src/test/resources/db/changelog/rdbms-fast-check/changelog-master.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="create-fast-check-probe" author="camunda">
+    <createTable tableName="${prefix}FAST_CHECK_PROBE">
+      <column name="ID" type="BIGINT">
+        <constraints nullable="false" primaryKey="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Description

Prevents Liquibase's JVM-wide fast-check cache from treating one physical tenant's prefixed changelog tables as another's. A unique Liquibase context is configured for each non-blank table prefix, while the no-prefix path is unchanged.

Regression tests cover the cached migration sequence and ensure the production RDBMS changelogs remain context-free.

## Checklist

- [ ] Enable backports when necessary
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow before requesting review.

## Related issues

closes #62802

- [ ] This PR does not need a linked issue