### PR TITLE
test: cover centralized secret resolution end to end

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -133,6 +133,12 @@ services:
       - CAMUNDA_DATA_AUDITLOG_CLIENT_CATEGORIES_2=USER_TASKS
       - CAMUNDA_DATA_AUDITLOG_USER_EXCLUDES_0=VARIABLE # [AUTHORIZATION, BATCH, DECISION, GROUP, INCIDENT, MAPPING_RULE, PROCESS_INSTANCE, ROLE, TENANT, USER, USER_TASK, RESOURCE, VARIABLE]
       - CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED=true
+      # Centralized secret resolution. Without a store the broker registers a
+      # NoopSecretStore, so every reference resolves to NOT_FOUND. The store id
+      # must be `default` - any other id is rejected at startup. A 1m cache TTL
+      # (the minimum) keeps rotation testable; the product default is 20m.
+      - CAMUNDA_SECRETS_STORES_FILE_DEFAULT_PATH=/etc/camunda/secrets
+      - CAMUNDA_SECRETS_CACHE_TTL=1m
     ports:
       - 26500:26500
       - 9600:9600
@@ -141,6 +147,8 @@ services:
       - ${DATABASE}
     networks:
       - zeebe_network
+    volumes:
+      - ./secrets:/etc/camunda/secrets:ro
     env_file:
       - envs/.env.database.${DATABASE}
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/secrets/MY_SECRET
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/secrets/MY_SECRET
@@ -1,0 +1,1 @@
+dummy-value-for-e2e-not-a-real-secret

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/secretResolutionProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/secretResolutionProcess.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_secretResolution" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="secretResolutionProcess" name="Secret Resolution Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_toTask</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_toTask" sourceRef="StartEvent_1" targetRef="consumeSecret" />
+    <bpmn:serviceTask id="consumeSecret" name="Consume secret">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="secretConsumerTask" />
+        <!-- The source must be an unquoted FEEL expression. A quoted literal
+             such as ="camunda.secrets.MY_SECRET" is rejected at deploy time by
+             SecretReferenceLiteralValidator. -->
+        <zeebe:ioMapping>
+          <zeebe:input source="=camunda.secrets.MY_SECRET" target="token" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_toTask</bpmn:incoming>
+      <bpmn:outgoing>Flow_toEnd</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_toEnd" sourceRef="consumeSecret" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_toEnd</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="secretResolutionProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="consumeSecret_di" bpmnElement="consumeSecret">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="412" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_toTask_di" bpmnElement="Flow_toTask">
+        <di:waypoint x="208" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_toEnd_di" bpmnElement="Flow_toEnd">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="412" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/secretResolution.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/secretResolution.spec.ts
@@ -8,7 +8,13 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
+import {randomUUID} from 'crypto';
+import {
+  cancelProcessInstance,
+  createSingleInstance,
+  createWorker,
+  deployWithSubstitutions,
+} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToAppHome} from '@pages/UtilitiesPage';
 
@@ -17,26 +23,38 @@ import {navigateToAppHome} from '@pages/UtilitiesPage';
 const SECRET_VALUE = 'dummy-value-for-e2e-not-a-real-secret';
 const PLACEHOLDER = 'camunda.secrets.MY_SECRET';
 
-type ProcessInstance = {processInstanceKey: string};
+// The process id and job type are per-run so that several Playwright projects
+// sharing one cluster cannot activate each other's jobs. The secret reference
+// stays fixed - the mounted store is read-only and shared by design.
+const suffix = randomUUID().slice(0, 8);
+const processId = `secretResolutionProcess-${suffix}`;
+const jobType = `secretConsumerTask-${suffix}`;
 
-let processInstance: ProcessInstance;
+let processInstanceKey: string;
 let workerVariables: Record<string, unknown> | undefined;
+const workers: Array<{close: () => Promise<unknown> | unknown}> = [];
 
 test.beforeAll(async () => {
-  await deploy(['./resources/secretResolutionProcess.bpmn']);
+  await deployWithSubstitutions('./resources/secretResolutionProcess.bpmn', {
+    secretResolutionProcess: processId,
+    secretConsumerTask: jobType,
+  });
 
-  const worker = createWorker(
-    'secretConsumerTask',
-    false,
-    {},
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (job: any) => {
-      workerVariables = job.variables;
-      return job.complete();
-    },
+  workers.push(
+    createWorker(
+      jobType,
+      false,
+      {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (job: any) => {
+        workerVariables = job.variables;
+        return job.complete();
+      },
+    ),
   );
 
-  processInstance = await createSingleInstance('secretResolutionProcess', 1);
+  const instance = await createSingleInstance(processId, 1);
+  processInstanceKey = String(instance.processInstanceKey);
 
   // Secret resolution is requested from the job activation path rather than at
   // job creation, so the first poll registers the request and a later poll
@@ -45,8 +63,22 @@ test.beforeAll(async () => {
   await expect(async () => {
     expect(workerVariables).toBeDefined();
   }).toPass({timeout: 30000});
+});
 
-  await worker.close();
+test.afterAll(async () => {
+  // Runs even when the wait above throws, so a regression in secret resolution
+  // fails this spec only instead of leaving a worker polling for the rest of
+  // the suite.
+  if (processInstanceKey) {
+    await cancelProcessInstance(processInstanceKey);
+  }
+  for (const w of workers) {
+    try {
+      await w.close();
+    } catch {
+      // best-effort cleanup
+    }
+  }
 });
 
 test.describe('Secret resolution', () => {
@@ -70,7 +102,7 @@ test.describe('Secret resolution', () => {
     await test.step('open the instance and select the service task', async () => {
       await expect(async () => {
         await operateProcessInstancePage.gotoProcessInstancePage({
-          id: processInstance.processInstanceKey,
+          id: processInstanceKey,
         });
         await expect(operateProcessInstancePage.instanceHeader).toBeVisible({
           timeout: 15000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/secretResolution.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/secretResolution.spec.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
+
+// Matches config/secrets/MY_SECRET, mounted into the broker at
+// /etc/camunda/secrets by config/docker-compose.yml.
+const SECRET_VALUE = 'dummy-value-for-e2e-not-a-real-secret';
+const PLACEHOLDER = 'camunda.secrets.MY_SECRET';
+
+type ProcessInstance = {processInstanceKey: string};
+
+let processInstance: ProcessInstance;
+let workerVariables: Record<string, unknown> | undefined;
+
+test.beforeAll(async () => {
+  await deploy(['./resources/secretResolutionProcess.bpmn']);
+
+  const worker = createWorker(
+    'secretConsumerTask',
+    false,
+    {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (job: any) => {
+      workerVariables = job.variables;
+      return job.complete();
+    },
+  );
+
+  processInstance = await createSingleInstance('secretResolutionProcess', 1);
+
+  // Secret resolution is requested from the job activation path rather than at
+  // job creation, so the first poll registers the request and a later poll
+  // collects the job. The engine's idle scheduler interval is 5s, so this wait
+  // needs to stay generous - do not tighten it.
+  await expect(async () => {
+    expect(workerVariables).toBeDefined();
+  }).toPass({timeout: 30000});
+
+  await worker.close();
+});
+
+test.describe('Secret resolution', () => {
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('worker gets the value, Operate shows the placeholder', async ({
+    operateProcessInstancePage,
+  }) => {
+    await test.step('worker received the resolved secret', async () => {
+      expect(workerVariables?.token).toBe(SECRET_VALUE);
+    });
+
+    await test.step('open the instance and select the service task', async () => {
+      await expect(async () => {
+        await operateProcessInstancePage.gotoProcessInstancePage({
+          id: processInstance.processInstanceKey,
+        });
+        await expect(operateProcessInstancePage.instanceHeader).toBeVisible({
+          timeout: 15000,
+        });
+      }).toPass({timeout: 90000});
+
+      // The input mapping creates a variable local to the element instance, so
+      // it is not listed at root process scope. Selecting the task is required.
+      await operateProcessInstancePage.clickTreeItem(/consume secret/i);
+      await operateProcessInstancePage.variablesTabButton.click();
+      await expect(operateProcessInstancePage.variablesList).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('stored variable holds the placeholder', async () => {
+      const variable =
+        operateProcessInstancePage.existingVariableByName('token');
+
+      // Both assertions are needed. On its own the first still passes if
+      // resolution stops entirely and the placeholder is handed straight to the
+      // worker; the second still passes if resolved values start being
+      // persisted alongside it.
+      await expect(variable.value).toHaveText(`"${PLACEHOLDER}"`);
+      await expect(variable.value).not.toContainText(SECRET_VALUE);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds the first automated end-to-end test for Centralized Secret Resolution.

There was no functional secret-resolution test in any Playwright suite, so a regression in the feature would not have been caught by anything. The only secret-related automation was the authorization-grant UI in `tests/identity/authorizations.spec.ts` and auto-generated 400-validation specs for `/v2/secrets/*` — neither touches resolution.

**What the test asserts.** The feature's contract is a pair: the worker receives the resolved value, and the engine stores only the placeholder. Either assertion alone passes while the feature is broken — the worker check survives values leaking into variable state, and the Operate check survives resolution stopping entirely with the placeholder handed straight through. The spec asserts both, plus the explicit negative that the value is absent from the UI.

**Changes**

| File | |
| --- | --- |
| `config/docker-compose.yml` | Enables the file secret store and a 1m cache TTL on the `camunda` service |
| `config/secrets/MY_SECRET` | Dummy fixture value |
| `resources/secretResolutionProcess.bpmn` | Service task with a secret input mapping |
| `tests/operate/secretResolution.spec.ts` | The spec |

**On the shared-config change.** The e2e cluster already had secret resolution active but no store behind it, so every reference resolved to `NOT_FOUND` via the `NoopSecretStore`. Enabling the file store is additive — no other spec references secrets. Agreed with the automation team beforehand, including the dummy value wording and the 1m cache TTL, which is the minimum the product allows and is set now so cache-expiry and rotation tests do not need a second change to shared config later.

**Two details reviewers may want to know**, both carrying comments in the code:

- Selecting the service task before reading variables is required. An input mapping creates a variable **local to the element instance**; at root process scope it is not listed at all.
- The 30s wait for the worker is not padding. Secret resolution is requested from the **job activation path** rather than at job creation, so the first poll registers the request and a later poll collects the job, against a 5s idle scheduler interval.

**Verification**

- `npm run lint` — 0 errors; TestRail id check passes (111 bytes of 250). The 205 warnings are pre-existing suite-wide; the new file lints clean on its own.
- `npx tsc --noEmit` — clean.
- Store binds: startup logs `Registered file secret store 'default' for physical tenant 'default'`.
- Spec passes against a real SM cluster (`--project=operate-e2e`).
- **Confirmed the test can fail:** removed the secret file, restarted to clear the cache, and it failed at the worker wait rather than passing. Restored and re-confirmed green.

**Scope.** Happy path only. The negative paths — missing secret, incident, retry — are cheap to add now that the store is configured, but are deliberately out of scope here. Defects found during the manual pass are tracked separately in #62711, #62719, #62727 and #62736.

## Checklist

- [x] Enable backports when necessary — `backport stable/8.10` applied, since this covers an 8.10 feature.
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

> **On-demand workflow run: [34588011870](https://github.com/camunda/camunda/actions/runs/34588011870).** The new spec passes in both cluster modes — `tests/operate/secretResolution.spec.ts › worker gets the value, Operate shows the placeholder`, 5.7s (all-in-one) and 4.7s (profiles).
>
> **The E2E suite is currently broadly red on `main` itself, independently of this PR.** To establish that, the same workflow was dispatched against `main` ([34597186786](https://github.com/camunda/camunda/actions/runs/34597186786)): it fails with **58 failed / 197 passed**, in the same specs — `tasklist/task-details` (28), `operate/processInstanceModifications` (18), `tasklist/processes-page` (16), `tasklist/variables` (12), `common-flows/hto-user-flows` (10) and others.
>
> Comparing the failing test sets directly, **this branch introduces no new failures**: 58 unique failing tests here against 59 on `main`, and every one of them also fails on `main`. This branch passes 199 where `main` passes 197 — the delta being the test this PR adds. No failing test anywhere in the run involves secrets.
>
> Two tests were flaky here and passed on retry: `operate/multiInstanceSelection.spec.ts` (a known flake, tracked in #23694) and `operate/batchOperations.spec.ts:215`.

## Related issues

closes #62784

