### PR TITLE
fix: Stop excluding `CamundaAutoConfiguration` from the Spring Boot 3 starter's shaded jar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -865,7 +865,7 @@ jobs:
             {
               "group": "qa-camunda-process-test",
               "name": "Camunda Process",
-              "maven-modules": "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example",
+              "maven-modules": "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example,testing/camunda-process-test-spring-boot-3",
               "maven-build-threads": 1,
               "maven-test-fork-count": 3,
               "runs-on": "gcp-perf-core-8-default",

--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -208,14 +208,12 @@
                     <!-- Exclude classes that we override with Spring Boot 3 versions -->
                     <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.class</exclude>
-                    <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/properties/CamundaClientPropertiesPostProcessor.class</exclude>
                     <!-- The same overrides in the shaded sources jar (createSourcesJar). Filters
                          match by literal path, so the .class excludes above don't cover .java. -->
                     <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java</exclude>
-                    <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.java</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.java</exclude>
                     <exclude>io/camunda/client/spring/properties/CamundaClientPropertiesPostProcessor.java</exclude>
                     <!-- Exclude META-INF services that we override -->


### PR DESCRIPTION
## Description

`camunda-spring-boot-3-starter` shades `camunda-spring-boot-starter` and filters out classes it overrides with its own Spring Boot 3–specific versions. `CamundaAutoConfiguration` was in that exclude list because SB3 used to carry its own override of it. #57826 unified the starters onto a single `CamundaAutoConfiguration` and deleted SB3's override, but left the now-stale shade-filter exclusion in place — silently dropping the class from the shaded jar with no replacement, and breaking `camunda-process-test-spring-boot-3` with `ClassNotFoundException: io.camunda.client.spring.configuration.CamundaAutoConfiguration`.

We didn't discover the issue before because the CI doesn't run the integration tests of `camunda-process-test-spring-boot-3`. Add the module to the CPT CI QA job for verify the fix.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #62717
closes #62721

- [ ] This PR does not need a linked issue

