### PR TITLE
docs: document the GCS historical results archive for load tests

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -176,6 +176,28 @@ More details about observability can be read [here](../docs/observability.md).
 
 For a full list of Prometheus metrics, SLO targets, and PromQL queries used to evaluate load tests, see [docs/metrics.md](docs/metrics.md).
 
+### Historical results archive (GCS)
+
+The daily stress-test workflow (`camunda-daily-load-tests.yml`) persists each run's aggregated
+metrics, variant manifest, and flamegraphs to
+`gs://camunda-benchmark-load-test-results-prod/automated/daily/stress/<benchmark>/`, outliving both
+the 90-day GH Actions artifact retention and the Prometheus retention window.
+
+To list available runs and then download one for local analysis:
+
+```bash
+gcloud storage ls gs://camunda-benchmark-load-test-results-prod/automated/daily/stress/
+gcloud storage cp -r gs://camunda-benchmark-load-test-results-prod/automated/daily/stress/<benchmark>/ ./<local-dir>/
+```
+
+For more details:
+
+See `camunda/infra-core`'s
+[`docs/benchmark/load-test-results-storage.md`](https://github.com/camunda/infra-core/blob/stage/docs/benchmark/load-test-results-storage.md)
+for bucket setup, and `camunda/team-reliability-testing`'s
+[`knowledge/load-tests/workflows.md`](https://github.com/camunda/team-reliability-testing/blob/main/knowledge/load-tests/workflows.md)
+for how to backfill a run if that failed.
+
 ### Accessing metrics via Claude Code (Grafana MCP)
 
 If you are using Claude Code and have kubectl access to the benchmark cluster, you can query

--- a/load-tests/skills/load-test-ops/references/analyze-metrics.md
+++ b/load-tests/skills/load-test-ops/references/analyze-metrics.md
@@ -50,6 +50,12 @@ cd load-tests/docs/scripts
 
 Args: `<namespace> [duration_seconds] [endpoint] [extra_curl_opts]`.
 
+## Via GCS archive (namespace/Prometheus retention already expired)
+
+The only option once both have expired, no kubectl or Grafana access needed. See
+`load-tests/README.md` → **Historical results archive (GCS)** for the listing/download commands
+and how to check and backfill a run whose upload failed.
+
 ## Additional metrics via Prometheus (kubectl required)
 
 When the headline metrics aren't enough, query the full set from


### PR DESCRIPTION
## Description

The daily stress-test workflow ([#62542](https://github.com/camunda/camunda/pull/62542)) persists metrics/variants/flamegraphs to `gs://camunda-benchmark-load-test-results-prod`, outliving both the 90-day GH Actions artifact retention and the Prometheus retention window, but neither `load-tests/README.md` nor the `load-test-ops` skill mentioned it. Adds a short pointer in each, plus a GCS-archive fallback in the skill's `analyze-metrics` reference for when a namespace and its Prometheus data have already expired.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

Not backported: describes a `main`-only workflow and bucket that doesn't exist on stable branches.

## Related issues

- [x] This PR does not need a linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)