### PR TITLE
docs: remove alpha markers from secret resolution endpoints and client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -3750,11 +3750,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   /**
    * Command to resolve a batch of secret references in a single round-trip.
    *
-   * <p><strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
    * <p>Each reference is authorized and resolved independently, so a reference that cannot be
    * resolved never fails the others. Such a failure is returned as data on the response, not as an
    * exception: the resolved references are available on {@link
@@ -3771,17 +3766,11 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/56661")
   ResolveSecretsCommandStep1 newResolveSecretsCommand();
 
   /**
    * Command to list the secret reference names the caller is authorized to see. It never returns
    * secret values, only the reference names.
-   *
-   * <p><strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
    *
    * <pre>
    *   camundaClient
@@ -3791,6 +3780,5 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/56661")
   ListSecretsCommandStep1 newListSecretsCommand();
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -13,7 +13,7 @@ paths:
       security:
         - bearerAuth: []
         - basicAuth: []
-      summary: Resolve secrets (alpha)
+      summary: Resolve secrets
       description: |
         Resolve a deduplicated batch of `camunda.secrets.*` references for the caller's
         physical tenant in a single round-trip.
@@ -28,8 +28,6 @@ paths:
         References are resolved against the secret stores configured for the caller's physical
         tenant, served from the gateway's secret cache when the value is already cached and read
         from the store otherwise.
-
-        This endpoint is an alpha feature and may be subject to change in future releases.
       requestBody:
         required: true
         content:
@@ -68,7 +66,7 @@ paths:
       security:
         - bearerAuth: []
         - basicAuth: []
-      summary: List secrets (alpha)
+      summary: List secrets
       description: |
         List the `camunda.secrets.*` references known for the caller's physical tenant.
 
@@ -84,8 +82,6 @@ paths:
         however, a name that is not a bare identifier has to be backtick-escaped, since FEEL reads
         a bare dash as the minus operator: a listed `camunda.secrets.db-password` is written
         `` =camunda.secrets.`db-password` `` in a BPMN input mapping.
-
-        This endpoint is an alpha feature and may be subject to change in future releases.
       requestBody:
         required: false
         content:
@@ -207,9 +203,8 @@ components:
       description: |
         The secret references the caller is authorized to see.
 
-        Unbounded for now: the response carries the configured stores' full enumeration for the
-        physical tenant. Pagination is expected to land here before GA. This is an alpha endpoint,
-        so that is not yet a breaking-contract concern.
+        Unbounded: the response carries the configured stores' full enumeration for the physical
+        tenant.
       properties:
         references:
           type: array


### PR DESCRIPTION
## Description

The `/secrets/resolve` and `/secrets/list` REST endpoints, and the Java client's
`newResolveSecretsCommand()` / `newListSecretsCommand()`, are becoming generally available in
8.10 but still carry their alpha markers:

- OpenAPI spec: `(alpha)` suffix on both endpoint summaries, the alpha sentinel description
  paragraph on both endpoints, and an alpha caveat in `SecretListResult`'s description.
- Java client: `@ExperimentalApi` annotations and an "Experimental: this method is under
  development" javadoc paragraph on both commands.

The alpha designation on `docs.camunda.io` is not removed by anything automatic — the
`camunda-docs` generation pipeline only decorates whatever alpha sentinel text it finds in the
spec, it never strips it. This PR removes the markers by hand from the spec and the client.

`revapi` already whitelists removal of `@ExperimentalApi` as non-breaking, so no compatibility
exception was needed; `clients/java` tests (2150) and the `zeebe-gateway-rest` `Secret*Test`
suite (16) pass, and spectral lint is clean.

## Related issues

closes #62807
