### PR TITLE
fix: fail the workflow when the GCS results upload actually fails

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -259,14 +259,8 @@ jobs:
           timeout_minutes: 2
           shell: bash
           command: |
-            set -euo pipefail
-            shopt -s nullglob
-            prefix="gs://${GCS_LOAD_TEST_RESULTS_BUCKET}/automated/daily/stress/${BENCHMARK}"
-            metrics_files=(data/metrics-*.json data/variants.json)
-            gcloud storage cp "${metrics_files[@]}" "${prefix}/"
-            if [ -d data/flamegraphs ] && [ -n "$(ls -A data/flamegraphs)" ]; then
-              gcloud storage cp -r data/flamegraphs/* "${prefix}/flamegraphs/"
-            fi
+            target="gs://${GCS_LOAD_TEST_RESULTS_BUCKET}/automated/daily/stress/${BENCHMARK}/"
+            gcloud storage cp -r data/* "${target}"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -387,7 +381,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: *${{ needs.upload-results-to-gcs.result == 'failure' && 'Daily load test result upload failed' || 'Daily load test execution failed' }}:*"
+                    "text": ":warning: *Daily load test creation failed:*"
                   }
                 },
                 {

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -135,13 +135,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ benchmark-data, run-variant ]
     if: always()
-    # 20 minutes covers the pre-existing fast artifact/merge steps plus the GCS auth
-    # (3-minute timeout) and upload (retried up to 5x at a 2-minute timeout each) steps below.
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
-      id-token: write
     steps:
       # Runs first, before any step below writes metrics-*.json/variants.json into
       # $GITHUB_WORKSPACE: checkout wipes the entire workspace contents whenever it finds no
@@ -201,6 +198,39 @@ jobs:
             variants.json
           retention-days: 90
           if-no-files-found: ignore
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  # Persists metrics, variant manifest, and flamegraphs to the long-term GCS archive. Runs as its
+  # own job, separate from aggregate-metrics, so a real GCS failure fails this job for real (red in
+  # the Actions UI, surfaced through the `notify` job's Slack alert below) instead of being
+  # swallowed, while still not blocking notify-results, which only depends on aggregate-metrics.
+  upload-results-to-gcs:
+    name: Upload results to GCS
+    runs-on: ubuntu-latest
+    needs: [ benchmark-data, aggregate-metrics ]
+    if: needs.aggregate-metrics.result == 'success'
+    timeout-minutes: 10 # covers the 3-minute auth timeout plus upload retried up to 5x at 2 minutes each
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Download metrics and variant manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: daily-load-test-metrics-${{ needs.benchmark-data.outputs.benchmark }}
       - name: Download flamegraph artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true # profiling is best-effort; a run with no flamegraphs still persists its metrics
@@ -212,10 +242,6 @@ jobs:
           # overwriting another's.
       - name: Authenticate to GCS load-test-results
         timeout-minutes: 3 # fail fast on a Vault/WIF hang instead of consuming the job's whole timeout
-        # Best-effort: GCS persistence is a long-term archive on top of the GH artifact uploaded
-        # above, so a Vault/GCS hiccup here must not fail this job and block the Slack summary
-        # notify-results depends on (needs.aggregate-metrics.result == 'success').
-        continue-on-error: true
         uses: ./.github/actions/gcs-build-cache-auth
         with:
           vault-addr: ${{ secrets.VAULT_ADDR }}
@@ -223,7 +249,6 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           secret-path: secret/data/products/camunda/ci/load-test-results/load-test-results-sa
       - name: Upload results to GCS
-        continue-on-error: true # see the auth step above
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           BENCHMARK: ${{ needs.benchmark-data.outputs.benchmark }}
@@ -332,7 +357,7 @@ jobs:
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ run-variant, aggregate-metrics, notify-results ]
+    needs: [ run-variant, aggregate-metrics, upload-results-to-gcs, notify-results ]
     if: failure()
     timeout-minutes: 5
     permissions: { }

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -231,12 +231,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: daily-load-test-metrics-${{ needs.benchmark-data.outputs.benchmark }}
+          path: data
       - name: Download flamegraph artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true # profiling is best-effort; a run with no flamegraphs still persists its metrics
         with:
           pattern: flamegraph-*
-          path: flamegraphs
+          path: data/flamegraphs
           # No merge-multiple: every artifact contains identically-named files (flamegraph-cpu.html
           # etc.), so each needs its own per-artifact-name folder to avoid one pod's report
           # overwriting another's.
@@ -258,16 +259,8 @@ jobs:
           timeout_minutes: 2
           shell: bash
           command: |
-            set -euo pipefail
-            shopt -s nullglob
-            prefix="gs://${GCS_LOAD_TEST_RESULTS_BUCKET}/automated/daily/stress/${BENCHMARK}"
-            # metrics-*.json only exists per-variant when that variant's collect-metrics ran;
-            # variants.json is always written by the merge step above, even when empty.
-            metrics_files=(metrics-*.json variants.json)
-            gcloud storage cp "${metrics_files[@]}" "${prefix}/"
-            if [ -d flamegraphs ] && [ -n "$(ls -A flamegraphs)" ]; then
-              gcloud storage cp -r flamegraphs/* "${prefix}/flamegraphs/"
-            fi
+            target="gs://${GCS_LOAD_TEST_RESULTS_BUCKET}/automated/daily/stress/${BENCHMARK}/"
+            gcloud storage cp "data" "${target}"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -217,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ benchmark-data, aggregate-metrics ]
     if: needs.aggregate-metrics.result == 'success'
-    timeout-minutes: 10 # covers the 3-minute auth timeout plus upload retried up to 5x at 2 minutes each
+    timeout-minutes: 15 # covers auth, artifact downloads, and the full retry budget for the GCS upload
     permissions:
       actions: read
       contents: read
@@ -259,8 +259,14 @@ jobs:
           timeout_minutes: 2
           shell: bash
           command: |
-            target="gs://${GCS_LOAD_TEST_RESULTS_BUCKET}/automated/daily/stress/${BENCHMARK}/"
-            gcloud storage cp "data" "${target}"
+            set -euo pipefail
+            shopt -s nullglob
+            prefix="gs://${GCS_LOAD_TEST_RESULTS_BUCKET}/automated/daily/stress/${BENCHMARK}"
+            metrics_files=(data/metrics-*.json data/variants.json)
+            gcloud storage cp "${metrics_files[@]}" "${prefix}/"
+            if [ -d data/flamegraphs ] && [ -n "$(ls -A data/flamegraphs)" ]; then
+              gcloud storage cp -r data/flamegraphs/* "${prefix}/flamegraphs/"
+            fi
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -381,7 +387,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: *Daily load test creation failed:*"
+                    "text": ":warning: *${{ needs.upload-results-to-gcs.result == 'failure' && 'Daily load test result upload failed' || 'Daily load test execution failed' }}:*"
                   }
                 },
                 {


### PR DESCRIPTION
Builds on [#62792](https://github.com/camunda/camunda/pull/62792) (base branch), which fixes the checkout-order bug that caused one real silent upload failure. This PR addresses the underlying visibility problem: the GCS auth/upload steps run with `continue-on-error: true` so a Vault/GCS hiccup doesn't fail `aggregate-metrics` and block the Slack summary `notify-results` depends on, but that also means a genuine upload failure stays completely invisible. The job, the workflow run, and the PR checks all stay green while the run's data is silently dropped from the long-term GCS archive.

This moves the GCS auth/upload steps into their own `upload-results-to-gcs` job, downloading its inputs from the `daily-load-test-metrics-<benchmark>` artifact instead of reading files off `aggregate-metrics`' workspace. The new job runs without `continue-on-error`, so a real failure fails it for real, and it's added to the existing `notify` job's `needs` so the failure surfaces through the Slack alert already wired up for `run-variant`/`aggregate-metrics` failures. `notify-results` still only depends on `aggregate-metrics`, so the results summary keeps posting regardless of whether the GCS upload succeeds.

Validated with `actionlint` and a YAML parse check; no local `act` run since GCS auth (Vault/WIF) is external orchestration this repo's `act-testing` skill would classify as Tier 3.

## Related issues

- [ ] This PR does not need a linked issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)