### PR TITLE
test: stop cancelProcessInstance from hiding a vacuous drain assertion on 8.9

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-draining-state.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-draining-state.spec.ts
@@ -85,7 +85,9 @@ test.describe('Process Definition Draining State', () => {
       [],
     );
 
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
 
     await expectDefinitionKeysForState(
       request,
@@ -136,7 +138,9 @@ test.describe('Process Definition Draining State', () => {
       expect(items[0]!.state).toBe('DRAINING');
     }).toPass(defaultAssertionOptions);
 
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
     await expectProcessDefinitionDeleted(request, v2.processDefinitionKey);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-draining-api.spec.ts
@@ -178,7 +178,9 @@ test.describe('Process Definition Draining Deletion API', () => {
     await findUserTask(request, instance.processInstanceKey, 'CREATED');
     await drainProcessDefinition(request, processDefinitionKey);
 
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
 
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
   });
@@ -203,7 +205,9 @@ test.describe('Process Definition Draining Deletion API', () => {
     await drainProcessDefinition(request, processDefinitionKey);
 
     for (let ended = 1; ended < instances.length; ended++) {
-      await cancelProcessInstance(instances[ended - 1]!.processInstanceKey);
+      await cancelProcessInstance(instances[ended - 1]!.processInstanceKey, {
+        ignoreNotFound: false,
+      });
       await expectProcessInstanceCount(
         request,
         {processDefinitionId, state: 'ACTIVE'},
@@ -218,6 +222,9 @@ test.describe('Process Definition Draining Deletion API', () => {
 
     await cancelProcessInstance(
       instances[instances.length - 1]!.processInstanceKey,
+      {
+        ignoreNotFound: false,
+      },
     );
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
   });
@@ -261,7 +268,9 @@ test.describe('Process Definition Draining Deletion API', () => {
     await drainProcessDefinition(request, childKey);
     await expectProcessDefinitionState(request, parentKey, 'ACTIVE');
 
-    await cancelProcessInstance(parentInstance.processInstanceKey);
+    await cancelProcessInstance(parentInstance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
 
     await expectProcessDefinitionDeleted(request, childKey);
   });
@@ -546,7 +555,9 @@ test.describe('Process Definition Draining Deletion API', () => {
 
     // Cancelling keeps the test off the user-task index, the slowest propagation
     // path.
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
 
     await expectProcessInstanceCount(request, {processDefinitionId}, 1);
@@ -577,7 +588,9 @@ test.describe('Process Definition Draining Deletion API', () => {
     // History is retained for as long as the definition is draining.
     await expectProcessInstanceCount(request, {processDefinitionId}, 1);
 
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
 
     // The purge takes the definition record with it, so there is nothing left to
     // read back.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processDefinitionDraining.spec.ts
@@ -296,7 +296,9 @@ test.describe('Operate Process Definition Draining — lifecycle and incidents',
 
     // The dashboard panel counts running instances, so the whole row goes, not
     // just the marker.
-    await cancelProcessInstance(instance.processInstanceKey);
+    await cancelProcessInstance(instance.processInstanceKey, {
+      ignoreNotFound: false,
+    });
     await expectProcessDefinitionDeleted(request, processDefinitionKey);
 
     await waitForAssertion({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -80,16 +80,18 @@ const createSingleInstance = async (
   });
 };
 
-const cancelProcessInstance = async (processInstanceKey: string) => {
+// Default true for teardown; pass false when the cancel itself drives the
+// assertion, so a 404 there is not silently absorbed.
+const cancelProcessInstance = async (
+  processInstanceKey: string,
+  {ignoreNotFound = true}: {ignoreNotFound?: boolean} = {},
+) => {
   return zeebe.cancelProcessInstance({processInstanceKey}).catch((e) => {
-    // The SDK wraps HTTPError and exposes the response status as `statusCode`;
-    // older code paths used `status`. Accept either so 404s from already-
-    // completed instances are silently swallowed (common cleanup scenario).
+    // SDK reports the status as statusCode or status depending on the path.
     const status = e?.statusCode ?? e?.status;
-    if (status === 404) {
+    if (ignoreNotFound && status === 404) {
       return;
     }
-    // Something else happened. Throw the error to surface the problem.
     throw e;
   });
 };


### PR DESCRIPTION
## Description

`cancelProcessInstance` on this branch still swallows `404` unconditionally, with no way to opt out. `main` and the `stable/8.8` backport already fixed this (#62697): the six -- now nine, after further review -- cancellations that finalize a drain are immediately followed by a `DRAINING`/`DELETED` assertion, and swallowing a 404 there would let that assertion pass even if the instance was never where the test thought it was.

This branch missed that fix because the 8.9 backport of #62408 (#62570) ported `main`'s original unconditional-swallow helper verbatim during conflict resolution, and the review on that PR caught a different, unrelated issue (history batch-operation attribution -- already fixed there and since ported to `main`), not this one.

Same shape as #62697 and the 8.8 backport: `ignoreNotFound` defaults to `true`, so the 39 other callers on this branch keep their current behavior; the nine drain-finalizing cancellations pass `{ignoreNotFound: false}`.

No test count or coverage change.

## Related issues

relates to #55930

🤖 Generated with [Claude Code](https://claude.com/claude-code)
