### PR TITLE
fix: extract partial partition case in a standalone test

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -35,8 +35,6 @@ import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -96,7 +94,6 @@ class BackupMultiPartitionTest {
   private ZeebeResourcesHelper resourcesHelper;
   private BackupRequestHandler backupRequestHandler;
   private BackupActuator backupActuator;
-  private int lastSeenDistributionRecordCount = -1;
 
   @TestZeebe
   private final TestCluster cluster =
@@ -358,44 +355,6 @@ class BackupMultiPartitionTest {
     assertThat(backupStates.get(1).checkpointPosition()).isGreaterThan(0);
   }
 
-  @Test
-  @Timeout(value = 120)
-  void canRetrieveCheckpointStateFromPartialPartitions()
-      throws ExecutionException, InterruptedException, TimeoutException {
-    // given
-    awaitCommandDistributionsDrained();
-    final long processKey = resourcesHelper.deployProcess(PROCESS_WITH_MESSAGE_EVENT);
-    createProcessInstanceOnPartitionOne(processKey);
-
-    final long backupId = 3;
-    // trigger backup only on partition 2
-    takeBackupOnPartition(backupId, 2);
-
-    // then
-    waitUntilBackupCompletedOnPartition(backupId, 2);
-
-    final var state = getCheckpointState();
-    assertThat(state).isNotNull();
-    assertThat(state.getCheckpointStates()).hasSize(1);
-    assertThat(state.getBackupStates()).hasSize(1);
-
-    final var checkpointStates =
-        state.getCheckpointStates().stream()
-            .sorted(Comparator.comparingInt(PartitionCheckpointState::partitionId))
-            .toList();
-
-    final var backupStates =
-        state.getBackupStates().stream()
-            .sorted(Comparator.comparingInt(PartitionCheckpointState::partitionId))
-            .toList();
-
-    assertThat(checkpointStates.stream().filter(f -> f.partitionId() == 2)).isNotEmpty();
-    assertThat(backupStates.stream().filter(f -> f.partitionId() == 2)).isNotEmpty();
-
-    assertThat(checkpointStates.stream().filter(f -> f.partitionId() == 1)).isEmpty();
-    assertThat(backupStates.stream().filter(f -> f.partitionId() == 1)).isEmpty();
-  }
-
   private Set<Long> createJobsOnAllPartitions() {
     final Set<Integer> partitions = new HashSet<>();
     final Set<Long> jobKeys = new HashSet<>();
@@ -485,40 +444,6 @@ class BackupMultiPartitionTest {
                 .limit(1)
                 .findFirst())
         .isPresent();
-  }
-
-  private void awaitCommandDistributionsDrained() {
-    lastSeenDistributionRecordCount = -1;
-    Awaitility.await("no command distribution is in flight")
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofMillis(100))
-        .during(Duration.ofSeconds(5))
-        .until(this::commandDistributionsDrained);
-  }
-
-  private boolean commandDistributionsDrained() {
-    final var distributionRecords =
-        RecordingExporter.getRecords().stream()
-            .filter(record -> record.getValueType() == ValueType.COMMAND_DISTRIBUTION)
-            .toList();
-
-    final var unchanged = distributionRecords.size() == lastSeenDistributionRecordCount;
-    lastSeenDistributionRecordCount = distributionRecords.size();
-    if (!unchanged) {
-      return false;
-    }
-
-    final Set<Long> pending = new HashSet<>();
-    final Set<Long> finished = new HashSet<>();
-    for (final var record : distributionRecords) {
-      if (record.getIntent() == CommandDistributionIntent.STARTED) {
-        pending.add(record.getKey());
-      } else if (record.getIntent() == CommandDistributionIntent.FINISHED) {
-        finished.add(record.getKey());
-      }
-    }
-    pending.removeAll(finished);
-    return pending.isEmpty();
   }
 
   private void createProcessInstanceOnPartitionOne(final long processKey) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupPartialPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupPartialPartitionTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.client.api.BackupRequestHandler;
+import io.camunda.zeebe.backup.client.api.BackupStatusRequest;
+import io.camunda.zeebe.backup.client.api.BrokerBackupRequest;
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.MinioContainer;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+class BackupPartialPartitionTest {
+  @Container private static final MinioContainer S3 = new MinioContainer();
+  private static final String CORRELATION_KEY = "key";
+  private static final String MESSAGE_NAME = "message";
+  private static final String CORRELATION_KEY_VALUE_FOR_PARTITION_2 = "item-1";
+  private static final BpmnModelInstance PROCESS_WITH_MESSAGE_EVENT =
+      Bpmn.createExecutableProcess("message-process")
+          .startEvent()
+          .intermediateCatchEvent("receive-message")
+          .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKeyExpression(CORRELATION_KEY))
+          .endEvent()
+          .done();
+  private BackupStore backupStore;
+  private S3BackupConfig clientConfig;
+  private String bucketName;
+  @AutoClose private CamundaClient client;
+  private ZeebeResourcesHelper resourcesHelper;
+  private BackupRequestHandler backupRequestHandler;
+  private int lastSeenDistributionRecordCount = -1;
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(2)
+          .withPartitionsCount(2)
+          .withReplicationFactor(1)
+          .withBrokerConfig(
+              broker ->
+                  broker.withUnifiedConfig(
+                      config -> {
+                        configureBackupStore(config);
+                        config
+                            .getProcessing()
+                            .getEngine()
+                            .getDistribution()
+                            .setPauseCommandDistribution(true);
+                      }))
+          .build();
+
+  @BeforeEach
+  void setup() {
+    client = cluster.newClientBuilder().build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+    backupRequestHandler = new BackupRequestHandler(cluster.anyGateway().bean(BrokerClient.class));
+    createBackupStore();
+    awaitCommandDistributionsDrained();
+  }
+
+  @AfterEach
+  void close() {
+    if (backupStore != null) {
+      backupStore.closeAsync().join();
+    }
+    bucketName = null;
+  }
+
+  @Test
+  @Timeout(value = 120)
+  void canRetrieveCheckpointStateFromPartialPartitions() {
+    final long processKey = deployProcess();
+    createProcessInstanceOnPartitionOne(processKey);
+
+    final long backupId = 3;
+    takeBackupOnPartition(backupId, 2);
+    waitUntilBackupCompletedOnPartition(backupId, 2);
+
+    Awaitility.await("partial checkpoint state must be visible")
+        .timeout(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var state = getCheckpointState();
+              assertThat(state.getCheckpointStates()).hasSize(1);
+              assertThat(state.getBackupStates()).hasSize(1);
+              assertThat(state.getCheckpointStates())
+                  .first()
+                  .returns(2, PartitionCheckpointState::partitionId)
+                  .returns(backupId, PartitionCheckpointState::checkpointId);
+              assertThat(state.getBackupStates())
+                  .first()
+                  .returns(2, PartitionCheckpointState::partitionId)
+                  .returns(backupId, PartitionCheckpointState::checkpointId);
+            });
+  }
+
+  private void configureBackupStore(final Camunda config) {
+    final var backupConfig = config.getData().getPrimaryStorage().getBackup();
+    backupConfig.setStore(BackupStoreType.S3);
+    final var s3Config = backupConfig.getS3();
+    if (bucketName == null) {
+      bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    }
+    s3Config.setBucketName(bucketName);
+    s3Config.setEndpoint(S3.externalEndpoint());
+    s3Config.setRegion(S3.region());
+    s3Config.setAccessKey(S3.accessKey());
+    s3Config.setSecretKey(S3.secretKey());
+    s3Config.setForcePathStyleAccess(true);
+  }
+
+  private void createBackupStore() {
+    clientConfig =
+        new Builder()
+            .withBucketName(bucketName)
+            .withEndpoint(S3.externalEndpoint())
+            .withRegion(S3.region())
+            .withCredentials(S3.accessKey(), S3.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(15))
+            .forcePathStyleAccess(true)
+            .build();
+    backupStore = S3BackupStore.of(clientConfig);
+    try (final var s3Client = S3BackupStore.buildClient(clientConfig)) {
+      s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();
+    }
+  }
+
+  private long deployProcess() {
+    final var deployment =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(PROCESS_WITH_MESSAGE_EVENT, "process.bpmn")
+            .send()
+            .join();
+    resourcesHelper.waitUntilDeploymentIsDone(deployment.getKey());
+    return deployment.getProcesses().getFirst().getProcessDefinitionKey();
+  }
+
+  private void createProcessInstanceOnPartitionOne(final long processKey) {
+    Awaitility.await()
+        .until(
+            () -> {
+              final var result =
+                  client
+                      .newCreateInstanceCommand()
+                      .processDefinitionKey(processKey)
+                      .variables(Map.of(CORRELATION_KEY, CORRELATION_KEY_VALUE_FOR_PARTITION_2))
+                      .send()
+                      .join();
+              return 1 == Protocol.decodePartitionId(result.getProcessInstanceKey());
+            });
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withPartitionId(2)
+                .limit(1)
+                .findFirst())
+        .isPresent();
+  }
+
+  private void takeBackupOnPartition(final long backupId, final int partitionId) {
+    final var request = new BrokerBackupRequest();
+    request.setBackupId(backupId);
+    request.setPartitionId(partitionId);
+    request.setCheckpointType(CheckpointType.MANUAL_BACKUP);
+    request.setPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
+    cluster.anyGateway().bean(BrokerClient.class).sendRequest(request).join();
+  }
+
+  private void waitUntilBackupCompletedOnPartition(final long backupId, final int partitionId) {
+    final var request = new BackupStatusRequest();
+    request.setPartitionId(partitionId);
+    request.setBackupId(backupId);
+    request.setPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
+    final var brokerClient = cluster.anyGateway().bean(BrokerClient.class);
+    Awaitility.await()
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(brokerClient.sendRequest(request).join())
+                    .matches(
+                        response ->
+                            response.getResponse().getStatus() == BackupStatusCode.COMPLETED));
+  }
+
+  private CheckpointStateResponse getCheckpointState()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return backupRequestHandler
+        .getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID)
+        .toCompletableFuture()
+        .get(30, TimeUnit.SECONDS);
+  }
+
+  private void awaitCommandDistributionsDrained() {
+    Awaitility.await("initial command distributions must finish")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(100))
+        .during(Duration.ofSeconds(5))
+        .until(
+            () -> {
+              final var records =
+                  RecordingExporter.getRecords().stream()
+                      .filter(record -> record.getValueType() == ValueType.COMMAND_DISTRIBUTION)
+                      .toList();
+              final var started = new HashSet<Long>();
+              final var finished = new HashSet<Long>();
+              records.forEach(
+                  record -> {
+                    if (record.getIntent() == CommandDistributionIntent.STARTED) {
+                      started.add(record.getKey());
+                    } else if (record.getIntent() == CommandDistributionIntent.FINISHED) {
+                      finished.add(record.getKey());
+                    }
+                  });
+              started.removeAll(finished);
+              final var unchanged = records.size() == lastSeenDistributionRecordCount;
+              lastSeenDistributionRecordCount = records.size();
+              return unchanged && started.isEmpty();
+            });
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Move partial partition querying to a distinct test class in order to disable command redistribution on the cluster.

The flake should be removed now as the backup instruction is not propagated to other partitions via the inter partition command distribution.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

