### PR TITLE
fix: bound the size of the incident update task's bulk ES requests

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -272,6 +272,11 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
       return CompletableFuture.completedFuture(List.of());
     }
 
+    return sendBulkRequest(updates, refresh);
+  }
+
+  private CompletableFuture<List<String>> sendBulkRequest(
+      final List<BulkOperation> updates, final Refresh refresh) {
     final var request =
         new BulkRequest.Builder()
             .operations(updates)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -24,6 +24,8 @@ import co.elastic.clients.elasticsearch.core.search.SourceFilter;
 import co.elastic.clients.elasticsearch.indices.AnalyzeRequest;
 import co.elastic.clients.elasticsearch.indices.RefreshResponse;
 import co.elastic.clients.elasticsearch.indices.analyze.AnalyzeToken;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -36,6 +38,7 @@ import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
 import io.camunda.zeebe.exporter.api.ExporterException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -53,6 +56,16 @@ import org.slf4j.Logger;
 public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRepository
     implements IncidentUpdateRepository {
   private static final int RETRY_COUNT = 3;
+
+  /**
+   * Caps how many update operations go into a single bulk request. The number of documents a cycle
+   * touches is driven by the incidents' tree paths, not by the configured incident batch size, so
+   * without this cap a few incidents spanning a deep or wide call hierarchy can build a request
+   * large enough to trip the cluster's request circuit breaker. Mirrors the record exporter's own
+   * bulk size.
+   */
+  @VisibleForTesting static final int BULK_CHUNK_SIZE = 5_000;
+
   private static final List<FieldValue> DELETED_OPERATION_STATES =
       List.of(
           FieldValue.of(OperationState.SENT.name()),
@@ -272,7 +285,22 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
       return CompletableFuture.completedFuture(List.of());
     }
 
-    return sendBulkRequest(updates, refresh);
+    final var chunks = Lists.partition(updates, BULK_CHUNK_SIZE);
+    final var updatedIds = new ArrayList<String>();
+    var result = CompletableFuture.<Void>completedFuture(null);
+    for (int i = 0; i < chunks.size(); i++) {
+      final var chunk = chunks.get(i);
+      // Only the final chunk carries the caller's refresh mode. A refresh is index-wide, so
+      // waiting on the last one also makes the preceding chunks visible, whereas waiting per
+      // chunk would add a full refresh interval of latency for every chunk.
+      final var chunkRefresh = i == chunks.size() - 1 ? refresh : Refresh.False;
+      result =
+          result.thenComposeAsync(
+              ignored -> sendBulkRequest(chunk, chunkRefresh).thenAccept(updatedIds::addAll),
+              executor);
+    }
+
+    return result.thenApply(ignored -> List.copyOf(updatedIds));
   }
 
   private CompletableFuture<List<String>> sendBulkRequest(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
@@ -11,17 +11,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
 import co.elastic.clients.elasticsearch.core.ClearScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesAsyncClient;
 import co.elastic.clients.elasticsearch.indices.RefreshResponse;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
+import io.camunda.webapps.schema.entities.incident.IncidentState;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
@@ -31,6 +36,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -128,6 +134,67 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
     // "[es/bulk] failed: [parse_exception] request body is required"
     assertThat(result).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(List.of());
     verify(client, Mockito.never()).bulk(Mockito.any(BulkRequest.class));
+  }
+
+  @Test
+  void shouldChunkBulkUpdateExceedingTheChunkSize() {
+    // given - one more update than fits in a single request
+    final var repository = createRepository();
+    final var updateCount = ElasticsearchIncidentUpdateRepository.BULK_CHUNK_SIZE + 1;
+    final var bulk = bulkUpdateOf(updateCount);
+    final var requests = ArgumentCaptor.forClass(BulkRequest.class);
+    Mockito.when(client.bulk(Mockito.any(BulkRequest.class)))
+        .thenAnswer(i -> CompletableFuture.completedFuture(buildBulkResponse(i.getArgument(0))));
+
+    // when
+    final var result = repository.bulkUpdate(bulk);
+
+    // then - the updates are spread over bounded requests, and every updated id is still reported
+    assertThat(result)
+        .succeedsWithin(Duration.ofSeconds(5))
+        .asInstanceOf(InstanceOfAssertFactories.list(String.class))
+        .hasSize(updateCount);
+    verify(client, Mockito.times(2)).bulk(requests.capture());
+    assertThat(requests.getAllValues())
+        .extracting(r -> r.operations().size())
+        .containsExactly(ElasticsearchIncidentUpdateRepository.BULK_CHUNK_SIZE, 1);
+  }
+
+  @Test
+  void shouldWaitForRefreshOnlyOnTheFinalChunk() {
+    // given
+    final var repository = createRepository();
+    final var bulk = bulkUpdateOf(ElasticsearchIncidentUpdateRepository.BULK_CHUNK_SIZE + 1);
+    final var requests = ArgumentCaptor.forClass(BulkRequest.class);
+    Mockito.when(client.bulk(Mockito.any(BulkRequest.class)))
+        .thenAnswer(i -> CompletableFuture.completedFuture(buildBulkResponse(i.getArgument(0))));
+
+    // when
+    repository.bulkUpdate(bulk);
+
+    // then - a refresh is index wide, so only the last chunk needs to wait for one; waiting on
+    // every chunk would add a refresh interval of latency per chunk
+    verify(client, Mockito.times(2)).bulk(requests.capture());
+    assertThat(requests.getAllValues())
+        .extracting(BulkRequest::refresh)
+        .containsExactly(Refresh.False, Refresh.WaitFor);
+  }
+
+  @Test
+  void shouldNotSendRemainingChunksWhenAChunkFails() {
+    // given - the first of three chunks fails
+    final var repository = createRepository();
+    final var bulk = bulkUpdateOf(2 * ElasticsearchIncidentUpdateRepository.BULK_CHUNK_SIZE + 1);
+    Mockito.when(client.bulk(Mockito.any(BulkRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("circuit breaker")));
+
+    // when
+    final var result = repository.bulkUpdate(bulk);
+
+    // then - the batch fails as a whole so it is retried from its recorded position, rather than
+    // pushing the remaining chunks at an already struggling cluster
+    assertThat(result).failsWithin(Duration.ofSeconds(5));
+    verify(client, Mockito.times(1)).bulk(Mockito.any(BulkRequest.class));
   }
 
   @Test
@@ -278,6 +345,35 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
 
     modifier.accept(response);
     return response.build();
+  }
+
+  private IncidentBulkUpdate bulkUpdateOf(final int updateCount) {
+    final var bulk = new IncidentBulkUpdate();
+    for (int i = 0; i < updateCount; i++) {
+      bulk.incidentRequests()
+          .add(
+              IncidentUpdate.id(String.valueOf(i))
+                  .index("incidentIndex")
+                  .state(IncidentState.ACTIVE)
+                  .build());
+    }
+    return bulk;
+  }
+
+  private BulkResponse buildBulkResponse(final BulkRequest request) {
+    final var items =
+        request.operations().stream()
+            .map(
+                operation ->
+                    new BulkResponseItem.Builder()
+                        .operationType(OperationType.Update)
+                        .status(200)
+                        .index("incidentIndex")
+                        .id(operation.update().id())
+                        .result("updated")
+                        .build())
+            .toList();
+    return new BulkResponse.Builder().took(1).errors(false).items(items).build();
   }
 
   private ElasticsearchIncidentUpdateRepository createRepository() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -809,6 +809,56 @@ abstract class IncidentUpdateRepositoryIT {
     }
 
     @Test
+    void shouldApplyEveryUpdateWhenTheBulkSpansMultipleChunks()
+        throws PersistenceException, IOException {
+      // given - more updates than fit in one bulk request, so the write is split into chunks
+      final var repository = createRepository();
+      final var bulk = new IncidentBulkUpdate();
+      final var updateCount = ElasticsearchIncidentUpdateRepository.BULK_CHUNK_SIZE + 1;
+      final var batchRequest = clientAdapter.createBatchRequest();
+      for (int i = 0; i < updateCount; i++) {
+        batchRequest.addWithId(
+            TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
+            String.valueOf(i),
+            new IncidentEntity()
+                .setKey(i)
+                .setState(IncidentState.PENDING)
+                .setErrorMessage("failure"));
+        bulk.incidentRequests()
+            .add(
+                IncidentUpdate.id(String.valueOf(i))
+                    .index(incidentTemplate.getFullQualifiedName())
+                    .state(IncidentState.ACTIVE)
+                    .build());
+      }
+      batchRequest.executeWithRefresh();
+
+      // when
+      final var result = repository.bulkUpdate(bulk);
+
+      // then - no update is lost at a chunk boundary, and the caller still learns about all of them
+      assertThat(result)
+          .succeedsWithin(Duration.ofSeconds(30))
+          .asInstanceOf(InstanceOfAssertFactories.list(String.class))
+          .hasSize(updateCount);
+      // the first update, the last of the first chunk, and the only update of the second chunk
+      final var boundaryIds =
+          List.of(
+              "0",
+              String.valueOf(ElasticsearchIncidentUpdateRepository.BULK_CHUNK_SIZE - 1),
+              String.valueOf(updateCount - 1));
+      final var incidents =
+          search(
+              incidentTemplate.getFullQualifiedName(),
+              IncidentTemplate.KEY,
+              boundaryIds,
+              IncidentEntity.class);
+      assertThat(incidents)
+          .hasSize(boundaryIds.size())
+          .allSatisfy(incident -> assertThat(incident.getState()).isEqualTo(IncidentState.ACTIVE));
+    }
+
+    @Test
     void shouldBulkUpdateListView() throws PersistenceException, IOException {
       // given
       final var repository = createRepository();


### PR DESCRIPTION
`postExport.batchSize` caps how many *incidents* the incident update task reads per cycle, not how many documents it writes: each incident fans out one update per process instance, flow node instance and list-view entry along its tree path, and the whole accumulation went out as a single bulk request. On a support cluster that built a ~667MB request against a ~665MB circuit-breaker limit, and the retry rebuilt the identical request.

Chunks the updates at 5,000 operations per request (matching the record exporter's own bulk size), sent sequentially, with the caller's refresh mode on the final chunk only — a refresh is index-wide, so waiting per chunk would only add latency. Chunking sits in the repository so both the incident and non-incident flush are covered and the store-agnostic task keeps no knowledge of request limits.

Elasticsearch only. OpenSearch has the same shape and is left for a follow-up, as is #59105 for `BatchOperationUpdateTask`.

The bound is a constant rather than a new config property — deliberately, since the existing knob is what proved unable to bound anything.

## Related issues

relates to #59112

🤖 Generated with [Claude Code](https://claude.com/claude-code)