### PR TITLE
Merge the Optimize 8.7.28 release branch back to Optimize 8.7 stable branch

### DIFF
--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.28</version>
+    <version>8.7.29-SNAPSHOT</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.28-SNAPSHOT</version>
+    <version>8.7.28</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.28</version>
+    <version>8.7.29-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.28-SNAPSHOT</version>
+    <version>8.7.28</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.28-SNAPSHOT</version>
+    <version>8.7.28</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.28</version>
+    <version>8.7.29-SNAPSHOT</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -14,7 +14,7 @@
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <zeebe.version>8.7.38</zeebe.version>
+    <zeebe.version>8.7.39</zeebe.version>
     <identity.version>8.7.24</identity.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>${zeebe.version}</zeebe.docker.version>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.7.28</version>
+  <version>8.7.29-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 
@@ -911,7 +911,7 @@
     <developerConnection>
       scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git
     </developerConnection>
-    <tag>8.7.28-optimize</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.7.28-SNAPSHOT</version>
+  <version>8.7.28</version>
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 
@@ -911,7 +911,7 @@
     <developerConnection>
       scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git
     </developerConnection>
-    <tag>HEAD</tag>
+    <tag>8.7.28-optimize</tag>
   </scm>
 
   <issueManagement>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.28</version>
+    <version>8.7.29-SNAPSHOT</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.28-SNAPSHOT</version>
+    <version>8.7.28</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade8728To8729PlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade8728To8729PlanFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.upgrade.plan.factories;
+
+import io.camunda.optimize.upgrade.plan.UpgradeExecutionDependencies;
+import io.camunda.optimize.upgrade.plan.UpgradePlan;
+import io.camunda.optimize.upgrade.plan.UpgradePlanBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Upgrade8728To8729PlanFactory implements UpgradePlanFactory {
+
+  @Override
+  public UpgradePlan createUpgradePlan(final UpgradeExecutionDependencies dependencies) {
+    return UpgradePlanBuilder.createUpgradePlan().fromVersion("8.7.28").toVersion("8.7.29").build();
+  }
+}

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.7.28</version>
+    <version>8.7.29-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.7.28-SNAPSHOT</version>
+    <version>8.7.28</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.optimize</groupId>
         <artifactId>optimize-parent</artifactId>
-        <version>8.7.28-SNAPSHOT</version>
+        <version>8.7.28</version>
     </parent>
 
     <artifactId>util</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.optimize</groupId>
         <artifactId>optimize-parent</artifactId>
-        <version>8.7.28</version>
+        <version>8.7.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>util</artifactId>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [ ] This PR does not need a linked issue

