### PR TITLE
fix: reduce OAuth token-fetch cooldown for load-test clients

### DIFF
--- a/load-tests/setup/scenarios/load-tester-values-defaults.yaml
+++ b/load-tests/setup/scenarios/load-tester-values-defaults.yaml
@@ -18,6 +18,12 @@ global:
       value: n2-standard-4
       effect: NoSchedule
 
+  # Default token-fetch-non-retryable-cooldown (5m) leaves clients unable to
+  # authenticate for minutes after a single 401 during identity/keycloak
+  # bootstrap; load-test clients need to recover fast during cluster startup.
+  extraConfig:
+    camunda.client.auth.token-fetch-non-retryable-cooldown: "PT30S"
+
   # Enable Stackdriver-formatted JSON logging on starter and worker pods so
   # Cloud Logging picks up severity, sourceLocation, and serviceContext the
   # same way it does for zeebe/operate/etc. Toggle is read by

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/main/none-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/none-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/main/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -143,3 +146,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -141,6 +144,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -175,7 +187,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -233,6 +245,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -279,6 +294,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -313,7 +337,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -371,6 +395,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -425,6 +452,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -459,7 +495,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -517,6 +553,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -563,6 +602,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -597,7 +645,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -655,6 +703,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -701,6 +752,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -735,7 +795,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -793,6 +853,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -841,3 +904,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-810/none-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -143,3 +146,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -141,6 +144,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -175,7 +187,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -233,6 +245,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -279,6 +294,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -313,7 +337,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -371,6 +395,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -425,6 +452,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -459,7 +495,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -517,6 +553,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -563,6 +602,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -597,7 +645,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -655,6 +703,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -701,6 +752,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -735,7 +795,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -793,6 +853,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -841,3 +904,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-87/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -143,3 +146,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -141,6 +144,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -175,7 +187,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -233,6 +245,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -279,6 +294,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -313,7 +337,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -371,6 +395,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -425,6 +452,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -459,7 +495,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -517,6 +553,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -563,6 +602,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -597,7 +645,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -655,6 +703,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -701,6 +752,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -735,7 +795,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -793,6 +853,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -841,3 +904,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -143,3 +146,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -141,6 +144,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -175,7 +187,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -233,6 +245,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -279,6 +294,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -313,7 +337,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -371,6 +395,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -425,6 +452,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -459,7 +495,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -517,6 +553,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -563,6 +602,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -597,7 +645,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -655,6 +703,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -701,6 +752,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -735,7 +795,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -793,6 +853,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -841,3 +904,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-89/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -15,5 +15,6 @@ metadata:
 data:
   load-test-config.yaml: |
     # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S
     load-tester:
       monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -139,3 +142,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -137,3 +140,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    camunda.client.auth.token-fetch-non-retryable-cooldown: PT30S

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -143,3 +146,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -31,7 +31,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -89,6 +89,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -141,6 +144,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -175,7 +187,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -233,6 +245,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -279,6 +294,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -313,7 +337,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -371,6 +395,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -425,6 +452,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -459,7 +495,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -517,6 +553,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -563,6 +602,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -597,7 +645,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -655,6 +703,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -701,6 +752,15 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754
 
 ---
 # Source: load-test-setup/charts/load-tester/templates/workers.yaml
@@ -735,7 +795,7 @@ spec:
         camunda.io/created-by: golden-test
         camunda.io/purpose: load-test
       annotations:
-        
+
         checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       imagePullSecrets:
@@ -793,6 +853,9 @@ spec:
                 secretKeyRef:
                   name: load-test-credentials
                   key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
             - name: LOAD_TESTER_LOG_APPENDER
               value: "Stackdriver"
             - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
@@ -841,3 +904,12 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754


### PR DESCRIPTION
## Description

Load-test starter/worker clients can hit a transient 401 while Camunda, Keycloak, and MGMT Identity are still bootstrapping in parallel (a client can obtain a token before Camunda has processed the init permissions that make it valid). The Camunda Java client's `OAuthCredentialsProvider` then latches into a non-retryable cooldown before retrying, and that cooldown defaults to 5 minutes (`camunda.client.auth.token-fetch-non-retryable-cooldown`, `PT5M`), so a single early 401 during cluster startup can leave a load-test client unable to authenticate for minutes.

This was found during a 2026-09-10 chaos day investigating #58983. Lowering the cooldown to 30s (`PT30S`) let clients recover from this race almost immediately instead of waiting out the full 5-minute window. This PR applies that value to `load-tests/setup/scenarios/load-tester-values-defaults.yaml`, so every self-managed load-test scenario (main and stable-8.x) gets it via `global.extraConfig`, mounted into starter/worker pods as an additional Spring config file. Golden files under `load-tests/setup/test/golden/` are regenerated to match.

Cloud/SaaS load tests use a separate values file not covered by this golden-file harness and are intentionally out of scope here.

**Trade-off considered:** the 30s cooldown applies to every non-retryable auth failure, not just the transient bootstrap race, so during a sustained Identity/Keycloak outage (e.g. the `chaos-killer` scenario's deliberate pod kills) load-test pods retry token fetch 10x more often than the 5-minute default. For load-test traffic volume this is an acceptable trade-off in exchange for fast recovery from the far more common transient bootstrap race.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #58983

🤖 Generated with [Claude Code](https://claude.com/claude-code)