### PR TITLE
ci: fix nightly aurora tests by removing variable

### DIFF
--- a/.github/terraform/aurora-replication-it/main.tf
+++ b/.github/terraform/aurora-replication-it/main.tf
@@ -73,13 +73,6 @@ variable "engine" {
   default = "aurora-postgresql"
 }
 
-# Left null so the module picks its own per-engine default (postgresql_engine_version /
-# mysql_engine_version). Set explicitly here only to pin a specific version.
-variable "engine_version" {
-  type    = string
-  default = null
-}
-
 # Scaled 1 -> 0 -> 1 by the test to remove/restore the replica instance while
 # keeping the secondary cluster (and storage replication) in place.
 variable "secondary_num_instances" {
@@ -128,7 +121,6 @@ module "aurora" {
 
   global_cluster_identifier = "${var.name_prefix}-global"
   engine                    = var.engine
-  engine_version            = var.engine_version
   master_username           = var.master_username
   master_password           = var.master_password
   instance_class            = var.instance_class

--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -83,15 +83,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions: {}
-    # Temporarily disabled while the Aurora async replication IT is buggy. The job remains
-    # available for manual re-enablement through the repository variable.
     if: |
-      vars.CI_ENABLE_AURORA_ASYNC_REPLICATION == 'true' &&
-      (github.event_name == 'schedule' ||
-       github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        (github.event.action == 'labeled' && github.event.label.name == 'run-aurora-tests' ||
-         github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-aurora-tests'))))
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       (github.event.action == 'labeled' && github.event.label.name == 'run-aurora-tests' ||
+        github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-aurora-tests')))
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description
The reference architecture now automatically defaults the engine version. Reason why it was failing it's because the variable has been removed in favour of "db" specific variable.

It also reverts the previous commit that disabled them. 
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

