### PR TITLE
test: keep AdvertisedAddressTest's proxied cluster traffic off the SSH host tunnel

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
@@ -46,8 +46,7 @@ public class HealthCheckIT {
 
   @Container
   private static final ToxiproxyContainer TOXIPROXY =
-      ProxyRegistry.addExposedPorts(
-          new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.5.0").withAccessToHost(true));
+      ProxyRegistry.addExposedPorts(new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.5.0"));
 
   @Container
   private static final LocalStackContainer S3 =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/AdvertisedAddressTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/AdvertisedAddressTest.java
@@ -41,8 +41,7 @@ final class AdvertisedAddressTest {
 
   @Container
   private static final ToxiproxyContainer TOXIPROXY =
-      ProxyRegistry.addExposedPorts(new ToxiproxyContainer(DockerImageName.parse(TOXIPROXY_IMAGE)))
-          .withAccessToHost(true);
+      ProxyRegistry.addExposedPorts(new ToxiproxyContainer(DockerImageName.parse(TOXIPROXY_IMAGE)));
 
   private static final ProxyRegistry PROXY_REGISTRY = new ProxyRegistry(TOXIPROXY);
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/ProxyRegistry.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/ProxyRegistry.java
@@ -11,9 +11,9 @@ import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.IntStream;
 import org.testcontainers.containers.ToxiproxyContainer;
 
@@ -29,19 +29,21 @@ import org.testcontainers.containers.ToxiproxyContainer;
 public final class ProxyRegistry {
 
   // used to generate unique listen ports on the Toxiproxy container; each proxy will use a single
-  // port, which must be unique to avoid collisions. Starts at 1024, since ports below are reserved
-  // by the kernel
+  // port, which must be unique to avoid collisions
   private static final int MIN_EXPOSED_PORT = 10_000;
   private static final int MAX_EXPOSED_PORT = MIN_EXPOSED_PORT + 32;
-  private static final AtomicInteger PORT_GENERATOR = new AtomicInteger(MIN_EXPOSED_PORT);
 
   // the name under which the container reaches ports bound on the host running the tests
   private static final String HOST_ALIAS = "host.testcontainers.internal";
 
-  // concurrent to allow static usage along with static containers and parallel tests
-  private final ConcurrentMap<String, ContainerProxy> proxies = new ConcurrentHashMap<>();
   private final ToxiproxyContainer toxiproxy;
-  private ToxiproxyClient lazyClient;
+
+  // everything below describes the container run identified by containerId, and is guarded by
+  // this; see resetIfContainerRestarted
+  private final Map<String, ContainerProxy> proxies = new HashMap<>();
+  private int nextPort = MIN_EXPOSED_PORT;
+  private ToxiproxyClient client;
+  private String containerId;
 
   public ProxyRegistry(final ToxiproxyContainer toxiproxy) {
     this.toxiproxy = toxiproxy;
@@ -69,7 +71,8 @@ public final class ProxyRegistry {
    * @param upstream the upstream endpoint that the proxy points to
    * @return a {@link ContainerProxy} which can be used to access the proxy
    */
-  public ContainerProxy getOrCreateProxy(final String upstream) {
+  public synchronized ContainerProxy getOrCreateProxy(final String upstream) {
+    resetIfContainerRestarted();
     return proxies.computeIfAbsent(upstream, this::createProxy);
   }
 
@@ -87,29 +90,41 @@ public final class ProxyRegistry {
   }
 
   private ContainerProxy createProxy(final String upstream) {
-    final var proxyPort = PORT_GENERATOR.getAndIncrement();
-
-    if (proxyPort >= MAX_EXPOSED_PORT) {
+    if (nextPort >= MAX_EXPOSED_PORT) {
       throw new IllegalStateException(
           "Cannot proxy more than %d ports with a single container"
               .formatted(MAX_EXPOSED_PORT - MIN_EXPOSED_PORT));
     }
 
+    final var proxyPort = nextPort++;
     try {
       final var proxy =
-          getClient().createProxy(upstream, "0.0.0.0:%d".formatted(proxyPort), upstream);
+          Objects.requireNonNull(client)
+              .createProxy(upstream, "0.0.0.0:%d".formatted(proxyPort), upstream);
       return new ContainerProxy(proxy, proxyPort);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
   }
 
-  private synchronized ToxiproxyClient getClient() {
-    if (lazyClient == null) {
-      lazyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+  /**
+   * Proxies live in the container, so a container that was stopped and started again is empty and
+   * publishes new host ports. That happens when a test class keeps the container and this registry
+   * in static fields and is rerun after a failure: the container is recreated, the registry is not.
+   * Forget everything recorded for the previous run, so that the client targets the live control
+   * port and each proxy is created anew instead of being looked up in a container that never had
+   * it.
+   */
+  private void resetIfContainerRestarted() {
+    final var currentId = toxiproxy.getContainerId();
+    if (Objects.equals(currentId, containerId)) {
+      return;
     }
 
-    return lazyClient;
+    containerId = currentId;
+    client = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+    proxies.clear();
+    nextPort = MIN_EXPOSED_PORT;
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/ProxyRegistry.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/ProxyRegistry.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
-import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.ToxiproxyContainer;
 
 /**
@@ -36,6 +35,9 @@ public final class ProxyRegistry {
   private static final int MAX_EXPOSED_PORT = MIN_EXPOSED_PORT + 32;
   private static final AtomicInteger PORT_GENERATOR = new AtomicInteger(MIN_EXPOSED_PORT);
 
+  // the name under which the container reaches ports bound on the host running the tests
+  private static final String HOST_ALIAS = "host.testcontainers.internal";
+
   // concurrent to allow static usage along with static containers and parallel tests
   private final ConcurrentMap<String, ContainerProxy> proxies = new ConcurrentHashMap<>();
   private final ToxiproxyContainer toxiproxy;
@@ -45,9 +47,19 @@ public final class ProxyRegistry {
     this.toxiproxy = toxiproxy;
   }
 
+  /**
+   * Exposes the ports proxies listen on, and lets the container reach ports bound on the host, as
+   * {@link #getOrCreateHostProxy(int)} requires.
+   *
+   * <p>The host is reached over Docker's {@code host-gateway}, i.e. directly through the bridge
+   * network, and deliberately not via {@link ToxiproxyContainer#withAccessToHost(boolean)}. That
+   * would send every proxied connection through an SSH tunnel whose client runs inside the test
+   * JVM; a cluster's membership and Raft traffic saturates it under CI load, and the sub-second
+   * membership timeouts then fail for minutes at a time.
+   */
   public static ToxiproxyContainer addExposedPorts(final ToxiproxyContainer container) {
     container.addExposedPorts(IntStream.range(MIN_EXPOSED_PORT, MAX_EXPOSED_PORT).toArray());
-    container.withAccessToHost(true);
+    container.withExtraHost(HOST_ALIAS, "host-gateway");
     return container;
   }
 
@@ -63,14 +75,15 @@ public final class ProxyRegistry {
 
   /**
    * Returns the proxy associated with the given port on the local host, or creates a new instance.
+   * The port must be bound on an interface the Docker bridge network can reach, e.g. {@code
+   * 0.0.0.0}, and the container must have been prepared with {@link
+   * #addExposedPorts(ToxiproxyContainer)}.
    *
    * @param port the upstream port that the proxy points to
    * @return a {@link ContainerProxy} which can be used to access the proxy
    */
   public ContainerProxy getOrCreateHostProxy(final int port) {
-    final var upstream = "host.testcontainers.internal:" + port;
-    Testcontainers.exposeHostPorts(port);
-    return getOrCreateProxy(upstream);
+    return getOrCreateProxy(HOST_ALIAS + ":" + port);
   }
 
   private ContainerProxy createProxy(final String upstream) {


### PR DESCRIPTION
## Description

`AdvertisedAddressTest.shouldCommunicateOverProxy` fails on `stable/8.9` CI with the gateway stuck at `Partition 1: UNHEALTHY` for the whole three minutes, and every failsafe rerun then dies in the test constructor with `Connection refused` from the Toxiproxy client (e.g. [run 34589070678](https://github.com/camunda/camunda/actions/runs/34589070678) on plain `stable/8.9`, and [run 34600869020](https://github.com/camunda/camunda/actions/runs/34600869020)). Two independent defects in the test tooling, one commit each:

1. **Proxied cluster traffic ran through the Testcontainers SSH host tunnel.** `ProxyRegistry#getOrCreateHostProxy` used `Testcontainers.exposeHostPorts`, i.e. an sshd container plus an SSH client inside the test JVM, and *all* SWIM, Raft, cluster-config and job-stream traffic of the three brokers and the gateway was multiplexed over that one session. In the failing run the broker logs show the path giving out, not the brokers: 3739 probes and 2599 syncs timed out at the 100 ms probe timeout, Raft polls timed out at 2.5 s, no membership sync completed after the first ten seconds, members were removed 154 times, and leadership never lasted more than a few seconds, while the brokers kept logging at a steady rate. Locally the test passes, but with the CPU oversubscribed two to one the timed-out probes go from 18-188 (idle) to 760.
   Fix: resolve `host.testcontainers.internal` to Docker's `host-gateway` instead (as `tasklist/qa` already does), so the proxied path is kernel networking only. Under the same oversubscription: 155 timed-out probes, three times as many completed syncs. `withAccessToHost(true)` is dropped from the two `ProxyRegistry` users.
2. **Reruns could never pass.** The test keeps the container and the `ProxyRegistry` in static fields; a rerun recreates the container (new control port, no proxies) but the registry kept its cached `ToxiproxyClient` and proxy map. The registry now resets itself when it sees a new container id.

Evidence and per-run numbers are in the commit messages. Verified locally on `stable/8.9`: 3 idle runs and 1 oversubscribed run green after the change; a scratch test (not committed) confirmed that proxies are recreated and reachable after a container stop/start.

Note: `main` has identical versions of the three touched files, so the same change applies there; I have not opened a `main` PR.

## Related issues

- [x] This PR does not need a linked issue
