### PR TITLE
fix: bound secret store calls by a configurable timeout

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -55,6 +55,17 @@ public class Secrets {
   private static final int MIN_DEFAULT_MAX_CONCURRENCY = 8;
 
   /**
+   * Default upper bound on one call to a cloud secret store, retries included, and on a single
+   * attempt within it. Shared by the AWS and GCP stores so both are bounded the same way; mirrored
+   * by {@code AwsSecretsManagerStoreConfig#DEFAULT_CALL_TIMEOUT} and {@code
+   * GcpSecretManagerStoreConfig#DEFAULT_CALL_TIMEOUT} in the store modules, which this module
+   * cannot depend on. Keep them in sync.
+   */
+  private static final Duration DEFAULT_CALL_TIMEOUT = Duration.ofSeconds(5);
+
+  private static final Duration DEFAULT_ATTEMPT_TIMEOUT = Duration.ofSeconds(2);
+
+  /**
    * Twice the core count, not once: the permits bound blocking backend round trips rather than CPU
    * work, and staying clear of the virtual-thread carrier pool (sized to the core count) leaves
    * room for a store whose client pins its carrier. It also keeps the default above
@@ -370,6 +381,22 @@ public class Secrets {
      */
     private @Nullable String containerSecretId;
 
+    /**
+     * Upper bound on one call to AWS Secrets Manager, retries included. The AWS SDK sets no such
+     * bound by default, which lets an unresponsive endpoint hold the caller for minutes. The
+     * background secret resolution calls the store from an IO-bound actor thread shared with every
+     * partition's exporter, so an unbounded call there stalls exporting broker-wide
+     * (camunda/camunda#62869). Must be positive.
+     */
+    private Duration callTimeout = DEFAULT_CALL_TIMEOUT;
+
+    /**
+     * Upper bound on a single HTTP attempt within a call, so one stalled socket does not consume
+     * the whole {@link #callTimeout} budget. Must be positive and not longer than {@link
+     * #callTimeout}, which would make it unreachable.
+     */
+    private Duration attemptTimeout = DEFAULT_ATTEMPT_TIMEOUT;
+
     public @Nullable String getRegion() {
       return region;
     }
@@ -410,6 +437,30 @@ public class Secrets {
       this.containerSecretId = containerSecretId;
     }
 
+    public Duration getCallTimeout() {
+      return callTimeout;
+    }
+
+    /**
+     * @param callTimeout the configured value, or {@code null}, bound to the default the same way
+     *     an unset property is, so an explicitly empty value does not leave the store unbounded
+     */
+    public void setCallTimeout(final @Nullable Duration callTimeout) {
+      this.callTimeout = callTimeout == null ? DEFAULT_CALL_TIMEOUT : callTimeout;
+    }
+
+    public Duration getAttemptTimeout() {
+      return attemptTimeout;
+    }
+
+    /**
+     * @param attemptTimeout the configured value, or {@code null}, bound to the same outcome {@code
+     *     callTimeout} already has for an empty value
+     */
+    public void setAttemptTimeout(final @Nullable Duration attemptTimeout) {
+      this.attemptTimeout = attemptTimeout == null ? DEFAULT_ATTEMPT_TIMEOUT : attemptTimeout;
+    }
+
     /**
      * Mirrors the invariants of {@code io.camunda.secretstore.aws.AwsSecretsManagerStoreConfig}'s
      * canonical constructor in the {@code secret-store-aws} module (not depended on from here, to
@@ -441,6 +492,29 @@ public class Secrets {
                 + storeId
                 + ".batch-enabled and .container-secret-id are mutually exclusive, but both were "
                 + "configured");
+      }
+      if (!callTimeout.isPositive()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.aws."
+                + storeId
+                + ".call-timeout must be positive, but was "
+                + callTimeout);
+      }
+      if (!attemptTimeout.isPositive()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.aws."
+                + storeId
+                + ".attempt-timeout must be positive, but was "
+                + attemptTimeout);
+      }
+      if (attemptTimeout.compareTo(callTimeout) > 0) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.aws."
+                + storeId
+                + ".attempt-timeout must not be longer than .call-timeout ("
+                + callTimeout
+                + "), but was "
+                + attemptTimeout);
       }
     }
   }
@@ -502,6 +576,14 @@ public class Secrets {
      */
     private @Nullable String containerSecretId;
 
+    /**
+     * Upper bound on one call to GCP Secret Manager, retries included. gax's defaults let an
+     * unresponsive endpoint hold the caller far longer than that. The background secret resolution
+     * calls the store from an IO-bound actor thread shared with every partition's exporter, so an
+     * unbounded call there stalls exporting broker-wide (camunda/camunda#62869). Must be positive.
+     */
+    private Duration callTimeout = DEFAULT_CALL_TIMEOUT;
+
     public @Nullable String getProjectId() {
       return projectId;
     }
@@ -532,6 +614,18 @@ public class Secrets {
 
     public void setContainerSecretId(final @Nullable String containerSecretId) {
       this.containerSecretId = containerSecretId;
+    }
+
+    public Duration getCallTimeout() {
+      return callTimeout;
+    }
+
+    /**
+     * @param callTimeout the configured value, or {@code null}, bound to the default the same way
+     *     an unset property is, so an explicitly empty value does not leave the store unbounded
+     */
+    public void setCallTimeout(final @Nullable Duration callTimeout) {
+      this.callTimeout = callTimeout == null ? DEFAULT_CALL_TIMEOUT : callTimeout;
     }
 
     /**
@@ -583,6 +677,13 @@ public class Secrets {
                 + "id, but was '"
                 + containerSecretId
                 + "'");
+      }
+      if (!callTimeout.isPositive()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.gcp."
+                + storeId
+                + ".call-timeout must be positive, but was "
+                + callTimeout);
       }
       if (containerSecretId != null) {
         final int fullLength =

--- a/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
@@ -956,4 +956,112 @@ class SecretsTest {
       assertThat(secrets.getMaxConcurrency()).isEqualTo(EXPECTED_DEFAULT_MAX_CONCURRENCY);
     }
   }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.secrets.stores.aws.tuned.call-timeout=8s",
+        "camunda.secrets.stores.aws.tuned.attempt-timeout=3s",
+        "camunda.secrets.stores.gcp.tuned.project-id=my-project",
+        "camunda.secrets.stores.gcp.tuned.call-timeout=9s"
+      })
+  class WithStoreTimeoutsConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithStoreTimeoutsConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldBindAwsTimeouts() {
+      // given call-timeout/attempt-timeout are set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then both are bound onto the named store
+      final var aws = secrets.getStores().getAws().get("tuned");
+      assertThat(aws.getCallTimeout()).isEqualTo(Duration.ofSeconds(8));
+      assertThat(aws.getAttemptTimeout()).isEqualTo(Duration.ofSeconds(3));
+    }
+
+    @Test
+    void shouldBindGcpCallTimeout() {
+      // given call-timeout is set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then it is bound onto the named store
+      assertThat(secrets.getStores().getGcp().get("tuned").getCallTimeout())
+          .isEqualTo(Duration.ofSeconds(9));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.stores.aws.untimed.region=eu-west-1"})
+  class WithoutStoreTimeoutsConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithoutStoreTimeoutsConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldDefaultAwsTimeouts() {
+      // given no timeout is configured (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the store is still bounded, so an unconfigured store cannot block indefinitely
+      final var aws = secrets.getStores().getAws().get("untimed");
+      assertThat(aws.getCallTimeout()).isEqualTo(Duration.ofSeconds(5));
+      assertThat(aws.getAttemptTimeout()).isEqualTo(Duration.ofSeconds(2));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.stores.aws.slow.call-timeout=0s"})
+  class WithNonPositiveCallTimeout {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithNonPositiveCallTimeout(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectNonPositiveCallTimeout() {
+      // given call-timeout is zero (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getAws).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.secrets.stores.aws.inverted.call-timeout=2s",
+        "camunda.secrets.stores.aws.inverted.attempt-timeout=5s"
+      })
+  class WithAttemptTimeoutWiderThanCallTimeout {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithAttemptTimeoutWiderThanCallTimeout(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectAttemptTimeoutWiderThanCallTimeout() {
+      // given an attempt bound wider than the total bound (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws, since the attempt bound could never take effect
+      assertThatThrownBy(stores::getAws).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
 }

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -330,7 +330,9 @@ public class SecretStoreConfiguration {
             null,
             AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
             config.isBatchEnabled(),
-            config.getBatchSize()));
+            config.getBatchSize(),
+            config.getCallTimeout(),
+            config.getAttemptTimeout()));
   }
 
   private static SecretStore gcpStore(
@@ -340,7 +342,9 @@ public class SecretStoreConfiguration {
             config.getProjectId(),
             config.getPathPrefix(),
             config.getEndpoint(),
-            config.getContainerSecretId()));
+            config.getContainerSecretId(),
+            false,
+            config.getCallTimeout()));
   }
 
   /**

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
@@ -100,14 +100,7 @@ public final class AwsSecretsManagerSecretStore implements SecretStore {
     final var builder =
         SecretsManagerClient.builder()
             .credentialsProvider(DefaultCredentialsProvider.builder().build())
-            .overrideConfiguration(
-                ClientOverrideConfiguration.builder()
-                    .retryStrategy(
-                        DefaultRetryStrategy.standardStrategyBuilder()
-                            // maxAttempts counts the initial try, maxRetries doesn't
-                            .maxAttempts(config.maxRetries() + 1)
-                            .build())
-                    .build());
+            .overrideConfiguration(overrideConfiguration(config));
     if (config.region() != null && !config.region().isBlank()) {
       builder.region(Region.of(config.region()));
     }
@@ -152,6 +145,35 @@ public final class AwsSecretsManagerSecretStore implements SecretStore {
           e.getMessage(),
           e);
     }
+  }
+
+  /**
+   * The client overrides for a store built from {@code config}: the retry strategy, and the
+   * timeouts that bound how long one call can take.
+   *
+   * <p>The bounds matter beyond the call that hits them. The background resolution reads this store
+   * from an IO-bound actor thread that every partition's exporter shares, so a call with no upper
+   * bound stalls exporting broker-wide rather than only delaying secret resolution
+   * (camunda/camunda#62869). They are also what makes the scheduler's existing defense work at all:
+   * it retries an unavailable store with a backoff and skips it while it cools down, and none of
+   * that can engage until the store reports the failure, which without a timeout it does not do for
+   * minutes.
+   *
+   * <p>Package-private so the bounds can be asserted without building a real client.
+   */
+  static ClientOverrideConfiguration overrideConfiguration(
+      final AwsSecretsManagerStoreConfig config) {
+    return ClientOverrideConfiguration.builder()
+        .retryStrategy(
+            DefaultRetryStrategy.standardStrategyBuilder()
+                // maxAttempts counts the initial try, maxRetries doesn't
+                .maxAttempts(config.maxRetries() + 1)
+                .build())
+        // bounds the whole call, retries included
+        .apiCallTimeout(config.callTimeout())
+        // bounds one HTTP attempt, so a stalled socket does not consume the whole call budget
+        .apiCallAttemptTimeout(config.attemptTimeout())
+        .build();
   }
 
   @Override

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerStoreConfig.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerStoreConfig.java
@@ -8,6 +8,7 @@
 package io.camunda.secretstore.aws;
 
 import java.net.URI;
+import java.time.Duration;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,6 +34,13 @@ import org.jspecify.annotations.Nullable;
  *     Mutually exclusive with {@code containerSecretId}
  * @param batchSize maximum secret ids per {@code BatchGetSecretValue} call when {@code
  *     batchEnabled} is set; must be between 1 and {@value #MAX_BATCH_SIZE} (AWS's hard limit)
+ * @param callTimeout upper bound on one {@code resolve}/{@code list} call to AWS, retries included.
+ *     Must be positive. The SDK sets no such bound by default, which lets an unresponsive endpoint
+ *     hold the caller for minutes; the background resolution calls this store from an IO-bound
+ *     actor thread shared with every partition's exporter, so an unbounded call there stalls
+ *     exporting broker-wide (camunda/camunda#62869)
+ * @param attemptTimeout upper bound on a single HTTP attempt within a call. Must be positive and
+ *     not longer than {@code callTimeout}, which would make it unreachable
  */
 public record AwsSecretsManagerStoreConfig(
     @Nullable String region,
@@ -41,7 +49,9 @@ public record AwsSecretsManagerStoreConfig(
     @Nullable URI endpoint,
     int maxRetries,
     boolean batchEnabled,
-    int batchSize) {
+    int batchSize,
+    Duration callTimeout,
+    Duration attemptTimeout) {
 
   /** Default number of retries applied when none is configured. */
   public static final int DEFAULT_MAX_RETRIES = 3;
@@ -51,6 +61,17 @@ public record AwsSecretsManagerStoreConfig(
 
   /** Default batch size when batching is enabled but none is configured. */
   public static final int DEFAULT_BATCH_SIZE = MAX_BATCH_SIZE;
+
+  /**
+   * Default upper bound on one call to AWS, retries included. Chosen so that a store that has
+   * stopped answering is reported unavailable within a few resolution cycles rather than after
+   * minutes: that is what lets the scheduler's retry ladder and its cooldown skip engage, which is
+   * the mechanism that actually keeps an unreachable store off the IO threads.
+   */
+  public static final Duration DEFAULT_CALL_TIMEOUT = Duration.ofSeconds(5);
+
+  /** Default upper bound on a single HTTP attempt within a call. */
+  public static final Duration DEFAULT_ATTEMPT_TIMEOUT = Duration.ofSeconds(2);
 
   // batchSize/containerSecretId invariants below are mirrored (with property-path-aware messages)
   // by io.camunda.configuration.Secrets.AwsSecretsManagerStore#validate in the configuration
@@ -70,6 +91,44 @@ public record AwsSecretsManagerStoreConfig(
       throw new IllegalArgumentException(
           "batchEnabled and containerSecretId are mutually exclusive, but both were set");
     }
+    if (callTimeout == null || !callTimeout.isPositive()) {
+      throw new IllegalArgumentException("callTimeout must be positive, but was " + callTimeout);
+    }
+    if (attemptTimeout == null || !attemptTimeout.isPositive()) {
+      throw new IllegalArgumentException(
+          "attemptTimeout must be positive, but was " + attemptTimeout);
+    }
+    if (attemptTimeout.compareTo(callTimeout) > 0) {
+      throw new IllegalArgumentException(
+          "attemptTimeout must not be longer than callTimeout ("
+              + callTimeout
+              + "), but was "
+              + attemptTimeout);
+    }
+  }
+
+  /**
+   * Creates a config with the default timeouts. Every caller that does not tune them goes through
+   * here, so a store is bounded whether or not an operator configured it.
+   */
+  public AwsSecretsManagerStoreConfig(
+      final @Nullable String region,
+      final @Nullable String pathPrefix,
+      final @Nullable String containerSecretId,
+      final @Nullable URI endpoint,
+      final int maxRetries,
+      final boolean batchEnabled,
+      final int batchSize) {
+    this(
+        region,
+        pathPrefix,
+        containerSecretId,
+        endpoint,
+        maxRetries,
+        batchEnabled,
+        batchSize,
+        DEFAULT_CALL_TIMEOUT,
+        DEFAULT_ATTEMPT_TIMEOUT);
   }
 
   /**

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
@@ -22,6 +22,7 @@ import io.camunda.secretstore.SecretResolutionResult;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
 import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -723,5 +724,43 @@ class AwsSecretsManagerSecretStoreTest {
 
     // then — the client is kept open so the error surfaces on first real use instead
     verify(resolver).validateConnectivity();
+  }
+
+  @Test
+  void shouldBoundClientCallsByTheConfiguredTimeouts() {
+    // given
+    final var config =
+        new AwsSecretsManagerStoreConfig(
+            null,
+            null,
+            null,
+            null,
+            AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+            false,
+            20,
+            Duration.ofSeconds(7),
+            Duration.ofSeconds(3));
+
+    // when
+    final var override = AwsSecretsManagerSecretStore.overrideConfiguration(config);
+
+    // then - an unresponsive endpoint cannot hold the caller past these bounds
+    assertThat(override.apiCallTimeout()).hasValue(Duration.ofSeconds(7));
+    assertThat(override.apiCallAttemptTimeout()).hasValue(Duration.ofSeconds(3));
+  }
+
+  @Test
+  void shouldBoundClientCallsByTheDefaultTimeouts() {
+    // given a config that does not mention timeouts at all
+    final var config = AwsSecretsManagerStoreConfig.of("camunda/");
+
+    // when
+    final var override = AwsSecretsManagerSecretStore.overrideConfiguration(config);
+
+    // then - the defaults still bound the call, so an unconfigured store is never unbounded
+    assertThat(override.apiCallTimeout())
+        .hasValue(AwsSecretsManagerStoreConfig.DEFAULT_CALL_TIMEOUT);
+    assertThat(override.apiCallAttemptTimeout())
+        .hasValue(AwsSecretsManagerStoreConfig.DEFAULT_ATTEMPT_TIMEOUT);
   }
 }

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerStoreConfigTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerStoreConfigTest.java
@@ -10,6 +10,7 @@ package io.camunda.secretstore.aws;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 class AwsSecretsManagerStoreConfigTest {
@@ -103,5 +104,80 @@ class AwsSecretsManagerStoreConfigTest {
     assertThat(config.containerSecretId()).isNull();
     assertThat(config.batchEnabled()).isFalse();
     assertThat(config.batchSize()).isEqualTo(AwsSecretsManagerStoreConfig.DEFAULT_BATCH_SIZE);
+  }
+
+  @Test
+  void shouldDefaultTimeoutsInFactory() {
+    // when
+    final var config = AwsSecretsManagerStoreConfig.of("camunda/");
+
+    // then
+    assertThat(config.callTimeout()).isEqualTo(AwsSecretsManagerStoreConfig.DEFAULT_CALL_TIMEOUT);
+    assertThat(config.attemptTimeout())
+        .isEqualTo(AwsSecretsManagerStoreConfig.DEFAULT_ATTEMPT_TIMEOUT);
+  }
+
+  @Test
+  void shouldDefaultTimeoutsInBackwardsCompatibleConstructor() {
+    // when
+    final var config =
+        new AwsSecretsManagerStoreConfig(
+            null, null, null, null, AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES, false, 20);
+
+    // then
+    assertThat(config.callTimeout()).isEqualTo(AwsSecretsManagerStoreConfig.DEFAULT_CALL_TIMEOUT);
+    assertThat(config.attemptTimeout())
+        .isEqualTo(AwsSecretsManagerStoreConfig.DEFAULT_ATTEMPT_TIMEOUT);
+  }
+
+  @Test
+  void shouldRejectNonPositiveCallTimeout() {
+    // when / then
+    assertThatThrownBy(() -> configWithTimeouts(Duration.ZERO, Duration.ofSeconds(2)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("callTimeout");
+  }
+
+  @Test
+  void shouldRejectNonPositiveAttemptTimeout() {
+    // when / then
+    assertThatThrownBy(() -> configWithTimeouts(Duration.ofSeconds(5), Duration.ofSeconds(-1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("attemptTimeout");
+  }
+
+  @Test
+  void shouldRejectAttemptTimeoutLongerThanCallTimeout() {
+    // given an attempt bound wider than the total bound, which can never take effect
+
+    // when / then
+    assertThatThrownBy(() -> configWithTimeouts(Duration.ofSeconds(2), Duration.ofSeconds(5)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("attemptTimeout");
+  }
+
+  @Test
+  void shouldRejectNullTimeouts() {
+    // when / then
+    assertThatThrownBy(() -> configWithTimeouts(null, Duration.ofSeconds(2)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("callTimeout");
+    assertThatThrownBy(() -> configWithTimeouts(Duration.ofSeconds(5), null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("attemptTimeout");
+  }
+
+  private static AwsSecretsManagerStoreConfig configWithTimeouts(
+      final Duration callTimeout, final Duration attemptTimeout) {
+    return new AwsSecretsManagerStoreConfig(
+        null,
+        null,
+        null,
+        null,
+        AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+        false,
+        20,
+        callTimeout,
+        attemptTimeout);
   }
 }

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStore.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStore.java
@@ -8,6 +8,7 @@
 package io.camunda.secretstore.gcp;
 
 import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
@@ -17,6 +18,7 @@ import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreUnavailableException;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -141,6 +143,7 @@ public final class GcpSecretManagerSecretStore implements SecretStore {
       } else if (config.endpoint() != null && !config.endpoint().isBlank()) {
         settings.setEndpoint(config.endpoint());
       }
+      applyCallTimeout(settings, config.callTimeout());
       client = SecretManagerServiceClient.create(settings.build());
     } catch (final IOException | RuntimeException e) {
       throw new SecretStoreUnavailableException(
@@ -174,6 +177,46 @@ public final class GcpSecretManagerSecretStore implements SecretStore {
           e.getMessage(),
           e);
     }
+  }
+
+  /**
+   * Bounds every RPC the resolvers issue by {@code callTimeout}, keeping the rest of gax's retry
+   * settings as they are.
+   *
+   * <p>The bound matters beyond the call that hits it. The background resolution reads this store
+   * from an IO-bound actor thread that every partition's exporter shares, so a call with no upper
+   * bound stalls exporting broker-wide rather than only delaying secret resolution
+   * (camunda/camunda#62869). It is also what makes the scheduler's existing defense work at all: it
+   * retries an unavailable store with a backoff and skips it while it cools down, and none of that
+   * can engage until the store reports the failure.
+   *
+   * <p>Both the total and the per-attempt RPC bounds are set. gax caps one attempt separately from
+   * the total, and its defaults for these RPCs are wider than the total set here, which would let a
+   * single attempt outlive the bound.
+   *
+   * <p>Package-private so the bounds can be asserted without opening a client.
+   */
+  static void applyCallTimeout(
+      final SecretManagerServiceSettings.Builder settings, final Duration callTimeout) {
+    boundRetrySettings(settings.accessSecretVersionSettings(), callTimeout);
+    boundRetrySettings(settings.listSecretsSettings(), callTimeout);
+  }
+
+  private static void boundRetrySettings(
+      final UnaryCallSettings.Builder<?, ?> callSettings, final Duration callTimeout) {
+    final var retrySettings = callSettings.getRetrySettings();
+    callSettings.setRetrySettings(
+        retrySettings.toBuilder()
+            .setTotalTimeoutDuration(callTimeout)
+            // an attempt must not be allowed to outlive the total it sits inside
+            .setInitialRpcTimeoutDuration(
+                min(retrySettings.getInitialRpcTimeoutDuration(), callTimeout))
+            .setMaxRpcTimeoutDuration(min(retrySettings.getMaxRpcTimeoutDuration(), callTimeout))
+            .build());
+  }
+
+  private static Duration min(final Duration left, final Duration right) {
+    return left.compareTo(right) <= 0 ? left : right;
   }
 
   @Override

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerStoreConfig.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerStoreConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.secretstore.gcp;
 
+import java.time.Duration;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -31,13 +32,27 @@ import org.jspecify.annotations.Nullable;
  *     at a local Secret Manager emulator. Requires {@code endpoint} to be set and must never be
  *     enabled against real GCP; production always leaves this {@code false} and authenticates via
  *     the Application Default Credentials chain.
+ * @param callTimeout upper bound on one {@code resolve}/{@code list} call to GCP, retries included.
+ *     Must be positive. gax's defaults let an unresponsive endpoint hold the caller far longer than
+ *     that; the background resolution calls this store from an IO-bound actor thread shared with
+ *     every partition's exporter, so an unbounded call there stalls exporting broker-wide
+ *     (camunda/camunda#62869)
  */
 public record GcpSecretManagerStoreConfig(
     @Nullable String projectId,
     @Nullable String pathPrefix,
     @Nullable String endpoint,
     @Nullable String containerSecretId,
-    boolean withoutAuthentication) {
+    boolean withoutAuthentication,
+    Duration callTimeout) {
+
+  /**
+   * Default upper bound on one call to GCP, retries included. Matches the AWS store's default, and
+   * is chosen so that a store that has stopped answering is reported unavailable within a few
+   * resolution cycles rather than after minutes: that is what lets the scheduler's retry ladder and
+   * its cooldown skip engage.
+   */
+  public static final Duration DEFAULT_CALL_TIMEOUT = Duration.ofSeconds(5);
 
   public GcpSecretManagerStoreConfig {
     if (projectId != null && projectId.isBlank()) {
@@ -50,6 +65,28 @@ public record GcpSecretManagerStoreConfig(
       throw new IllegalArgumentException(
           "endpoint must be set when authentication is disabled (emulator testing only)");
     }
+    if (callTimeout == null || !callTimeout.isPositive()) {
+      throw new IllegalArgumentException("callTimeout must be positive, but was " + callTimeout);
+    }
+  }
+
+  /**
+   * Creates a config with the default call timeout. Every caller that does not tune it goes through
+   * here, so a store is bounded whether or not an operator configured it.
+   */
+  public GcpSecretManagerStoreConfig(
+      final @Nullable String projectId,
+      final @Nullable String pathPrefix,
+      final @Nullable String endpoint,
+      final @Nullable String containerSecretId,
+      final boolean withoutAuthentication) {
+    this(
+        projectId,
+        pathPrefix,
+        endpoint,
+        containerSecretId,
+        withoutAuthentication,
+        DEFAULT_CALL_TIMEOUT);
   }
 
   /**

--- a/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStoreTest.java
+++ b/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStoreTest.java
@@ -37,6 +37,7 @@ import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
 import io.camunda.secretstore.SecretStoreUnavailableException;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -649,5 +650,36 @@ class GcpSecretManagerSecretStoreTest {
         return null;
       }
     };
+  }
+
+  @Test
+  void shouldBoundEveryUsedRpcByTheConfiguredCallTimeout() throws Exception {
+    // given
+    final var settings = SecretManagerServiceSettings.newBuilder();
+
+    // when
+    GcpSecretManagerSecretStore.applyCallTimeout(settings, Duration.ofSeconds(7));
+
+    // then - both RPCs the resolvers issue are bounded, so neither can hold the caller
+    assertThat(settings.accessSecretVersionSettings().getRetrySettings().getTotalTimeoutDuration())
+        .isEqualTo(Duration.ofSeconds(7));
+    assertThat(settings.listSecretsSettings().getRetrySettings().getTotalTimeoutDuration())
+        .isEqualTo(Duration.ofSeconds(7));
+  }
+
+  @Test
+  void shouldBoundSingleRpcAttemptsByTheCallTimeoutAsWell() throws Exception {
+    // given - gax caps one attempt separately from the total, and its default is wider than the
+    // total we set here, which would let a single attempt outlive the bound
+    final var settings = SecretManagerServiceSettings.newBuilder();
+
+    // when
+    GcpSecretManagerSecretStore.applyCallTimeout(settings, Duration.ofSeconds(4));
+
+    // then
+    assertThat(settings.accessSecretVersionSettings().getRetrySettings().getMaxRpcTimeoutDuration())
+        .isLessThanOrEqualTo(Duration.ofSeconds(4));
+    assertThat(settings.listSecretsSettings().getRetrySettings().getMaxRpcTimeoutDuration())
+        .isLessThanOrEqualTo(Duration.ofSeconds(4));
   }
 }

--- a/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerStoreConfigTest.java
+++ b/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerStoreConfigTest.java
@@ -10,6 +10,7 @@ package io.camunda.secretstore.gcp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 class GcpSecretManagerStoreConfigTest {
@@ -77,5 +78,46 @@ class GcpSecretManagerStoreConfigTest {
     // then
     assertThat(config.withoutAuthentication()).isTrue();
     assertThat(config.endpoint()).isEqualTo("localhost:9090");
+  }
+
+  @Test
+  void shouldDefaultCallTimeout() {
+    // when
+    final var config = GcpSecretManagerStoreConfig.of("my-project", "camunda-");
+
+    // then
+    assertThat(config.callTimeout()).isEqualTo(GcpSecretManagerStoreConfig.DEFAULT_CALL_TIMEOUT);
+  }
+
+  @Test
+  void shouldDefaultCallTimeoutInBackwardsCompatibleConstructors() {
+    // when
+    final var fourArg = new GcpSecretManagerStoreConfig("my-project", null, null, null);
+    final var fiveArg =
+        new GcpSecretManagerStoreConfig("my-project", null, "localhost:9090", null, true);
+
+    // then
+    assertThat(fourArg.callTimeout()).isEqualTo(GcpSecretManagerStoreConfig.DEFAULT_CALL_TIMEOUT);
+    assertThat(fiveArg.callTimeout()).isEqualTo(GcpSecretManagerStoreConfig.DEFAULT_CALL_TIMEOUT);
+  }
+
+  @Test
+  void shouldRejectNonPositiveCallTimeout() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                new GcpSecretManagerStoreConfig(
+                    "my-project", null, null, null, false, Duration.ZERO))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("callTimeout");
+  }
+
+  @Test
+  void shouldRejectNullCallTimeout() {
+    // when / then
+    assertThatThrownBy(
+            () -> new GcpSecretManagerStoreConfig("my-project", null, null, null, false, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("callTimeout");
   }
 }


### PR DESCRIPTION
## Description

The background secret resolution reads the configured store synchronously from an IO-bound actor
thread, and every partition's `ExporterDirector` shares that same thread group (`io-thread-count`
defaults to 2). Neither cloud store bounded how long a call could take, so an unresponsive AWS or
GCP endpoint held those threads for minutes, stalling exporting broker-wide, and with it log
compaction, until the broker pauses processing at the disk watermark.

This adds an upper bound to both stores and exposes it as configuration.

The bound is not only damage control. The scheduler already retries an unavailable store with a
backoff and skips it while it cools down, but that machinery cannot engage until the store reports
the failure, which without a timeout it does not do for minutes. The ladder was not missing a
mechanism, it was starved of its input signal.

| | IO-thread occupancy before references are failed into incidents |
| --- | --- |
| before | ~18 min (3 ladder attempts over a ~6 min cycle) |
| after, at the 5s default | ~45 s, with the cooldown suppressing calls in between |

Three commits, reviewable in order:

1. bound AWS calls (`apiCallTimeout` + `apiCallAttemptTimeout`)
2. bound GCP calls (gax total and per-attempt RPC timeouts on both RPCs the resolvers issue)
3. expose both as `camunda.secrets.stores.{aws,gcp}.<id>.call-timeout` (plus `.attempt-timeout`
   for AWS) and wire them through

New properties, defaulting to 5s total and 2s per attempt:

```yaml
camunda:
  secrets:
    stores:
      aws:
        default:
          call-timeout: 5s     # whole call, retries included
          attempt-timeout: 2s  # one HTTP attempt
      gcp:
        default:
          call-timeout: 5s
```

An explicitly empty value binds to the default rather than to null, the same way `ttl`, `max-size`
and `max-concurrency` already behave, so an unset environment variable cannot leave a store
unbounded. `defaults.yaml` is unchanged: the stores are map-typed, so the generated metadata
exposes the maps and never their entries' properties.

## Scope

This deliberately does not touch the engine or the scheduler. Bounding the call is what resolves
the reported bug: it stops an unresponsive store from holding an IO thread, and it feeds the
scheduler's existing retry ladder and cooldown the failure signal they were missing, so an
unavailable store is skipped rather than re-blocked.

Removing the blocking from the actor thread entirely, by splitting the resolution cycle so the
store call runs off-actor, remains desirable as a hardening step and is tracked separately.

Only the AWS and GCP stores are affected. The file store reads locally and is never wrapped for
concurrency, and the noop store returns immediately.

## Alternatives considered

- **Give `SECRET_RESOLUTION` its own actor thread group, or raise `io-thread-count`.** Moves the
  problem: a dedicated group still starves itself across partitions, and a fixed thread count does
  not scale with partitions per broker.
- **Make the concurrency semaphore per partition.** Removes the cross-partition amplification but
  not the blocking, and multiplies backend concurrency by the partition count, which is exactly
  what the shared semaphore exists to prevent.

## Related issues

closes #62869
