### PR TITLE
fix: step down current leader when TimeoutNow is acknowledged

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/TimeoutNowPromotion.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/TimeoutNowPromotion.java
@@ -17,8 +17,10 @@ package io.atomix.raft.rebalance;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.TimeoutNowRequest;
 import io.atomix.utils.concurrent.Scheduled;
 import java.util.concurrent.CompletableFuture;
@@ -31,11 +33,15 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Promotes the desired leader by sending it TimeoutNow, resending every {@code heartbeatInterval}
- * until leadership actually moves or {@code maxTransferAttempts} sends are spent. Completes with
- * {@link LeadershipTransferResult#TRANSFERRED} only once the <em>selected</em> target is observed
- * to have become leader; if a different node wins instead, or leadership otherwise moves away, we
- * report {@link LeadershipTransferResult#LEADER_CHANGED}. If the leadership doesn't move before our
- * attempt budget runs out, we report {@link LeadershipTransferResult#TIMEOUT_NOW_EXHAUSTED}.
+ * until leadership actually moves or {@code maxTransferAttempts} sends are spent. Once the target
+ * acknowledges a TimeoutNow we step down, in order to ensure that we won't have a race between
+ * resuming the partition on the current leader and the election triggered on the desired leader.
+ *
+ * <p>Completes with {@link LeadershipTransferResult#TRANSFERRED} only once the <em>selected</em>
+ * target is observed to have become leader; if a different node wins instead, or leadership
+ * otherwise moves away, we report {@link LeadershipTransferResult#LEADER_CHANGED}. If the
+ * leadership doesn't move before our attempt budget runs out, we report {@link
+ * LeadershipTransferResult#TIMEOUT_NOW_EXHAUSTED}.
  */
 @NullMarked
 final class TimeoutNowPromotion implements TransferPhase {
@@ -129,11 +135,29 @@ final class TimeoutNowPromotion implements TransferPhase {
             (response, error) -> {
               if (error != null) {
                 LOG.trace("TimeoutNow to {} failed, will retry if budget remains", target, error);
+              } else if (response.status() == RaftResponse.Status.OK) {
+                onTimeoutNowAccepted();
               } else {
-                LOG.trace("TimeoutNow to {} acknowledged: {}", target, response);
+                LOG.debug(
+                    "TimeoutNow to {} rejected with {}, will retry if budget remains",
+                    target,
+                    response.error());
               }
             },
             raft.getThreadContext());
+  }
+
+  private void onTimeoutNowAccepted() {
+    raft.checkThread();
+    if (result.isDone() || steppedDown || !leaderRunning.getAsBoolean()) {
+      return;
+    }
+    LOG.info(
+        "Target {} accepted TimeoutNow on attempt {}; stepping down so it can win the election",
+        target,
+        attempts);
+    // the step-down calls back into onLeaderStopped, which cancels the retries
+    raft.transition(Role.FOLLOWER);
   }
 
   private void onLeaderObserved(final RaftMember newLeader) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -216,7 +216,16 @@ public final class FollowerRole extends ActiveRole {
 
     final var response =
         logResponse(TimeoutNowResponse.builder().withStatus(RaftResponse.Status.OK).build());
-    raft.transition(RaftServer.Role.CANDIDATE);
+
+    raft.getThreadContext()
+        .execute(
+            () -> {
+              if (!isRunning()
+                  || !isTimeoutNowFromCurrentLeader(request.term(), request.leader())) {
+                return;
+              }
+              raft.transition(RaftServer.Role.CANDIDATE);
+            });
 
     return CompletableFuture.completedFuture(response);
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPromoteTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferPromoteTest.java
@@ -19,11 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.raft.protocol.PollRequest;
+import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.TimeoutNowResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
@@ -153,6 +156,112 @@ public class RaftLeadershipTransferPromoteTest {
     Awaitility.await("the target becomes leader")
         .atMost(Duration.ofSeconds(15))
         .until(() -> target.getRole() == RaftServer.Role.LEADER);
+  }
+
+  @Test
+  public void shouldTransferWhenTheTargetAcknowledgesButItsTransitionStalls() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    final var stalled = new CountDownLatch(1);
+    final var heldVotes = new CompletableFuture<Void>();
+    stallTransitionTo(target, RaftServer.Role.CANDIDATE, stalled);
+    holdVotes(target, heldVotes);
+
+    try {
+      // when
+      final var ack = driver.initiate(target);
+
+      // then
+      assertThat(ack.accepted()).isTrue();
+      Awaitility.await("the leader steps down on the acknowledgement, not on the transition")
+          .atMost(Duration.ofSeconds(15))
+          .until(() -> leader.getRole() != RaftServer.Role.LEADER);
+    } finally {
+      stalled.countDown();
+      heldVotes.complete(null);
+    }
+
+    assertThat(driver.reportedResult())
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.TRANSFERRED);
+    Awaitility.await("the target becomes leader")
+        .atMost(Duration.ofSeconds(15))
+        .until(() -> target.getRole() == RaftServer.Role.LEADER);
+  }
+
+  @Test
+  public void shouldKeepLeadershipAndRetryWhenTheTargetRejectsTimeoutNow() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var driver = new CoordinatedTransferDriver(raftRule, leader);
+    final var target = driver.followerOutsideCoordinator();
+    final var sends = countTimeoutNow(leader);
+    rejectTimeoutNow(target);
+
+    // when
+    final var ack = driver.initiate(target);
+
+    // then
+    assertThat(ack.accepted()).isTrue();
+    assertThat(driver.reportedResult())
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.TIMEOUT_NOW_EXHAUSTED);
+    assertThat(sends.sum())
+        .as("a rejection is not an acknowledgement, so the leader keeps retrying")
+        .isGreaterThanOrEqualTo(2);
+    assertThat(leader.getRole())
+        .as("the leader only steps down for an acknowledgement, not for a rejection")
+        .isEqualTo(RaftServer.Role.LEADER);
+  }
+
+  private static void rejectTimeoutNow(final RaftServer member) {
+    ((TestRaftServerProtocol) member.getContext().getProtocol())
+        .registerTimeoutNowHandler(
+            request ->
+                CompletableFuture.completedFuture(
+                    TimeoutNowResponse.builder()
+                        .withStatus(RaftResponse.Status.ERROR)
+                        .withError(RaftError.Type.ILLEGAL_MEMBER_STATE)
+                        .build()));
+  }
+
+  private static LongAdder countTimeoutNow(final RaftServer leader) {
+    final var sends = new LongAdder();
+    ((TestRaftServerProtocol) leader.getContext().getProtocol())
+        .interceptRequest(
+            TimeoutNowRequest.class,
+            request -> {
+              sends.increment();
+            });
+    return sends;
+  }
+
+  private static void holdVotes(final RaftServer member, final CompletableFuture<Void> release) {
+    ((TestRaftServerProtocol) member.getContext().getProtocol())
+        .interceptRequest(VoteRequest.class, request -> release);
+  }
+
+  private static void stallTransitionTo(
+      final RaftServer member, final RaftServer.Role role, final CountDownLatch release) {
+    member
+        .getContext()
+        .addRoleChangeListener(
+            (newRole, term) -> {
+              if (newRole != role) {
+                return;
+              }
+              try {
+                release.await(30, TimeUnit.SECONDS);
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
   }
 
   /** A barrier that freezes nothing but counts how often the writes were reopened. */


### PR DESCRIPTION
In #61443 we've seen a case where rebalancing run concurrently with other IO-bound operations (opening an exporter on the desired leader) can stall the role transition which happens as part of processing a TimeoutNow request. This can cause the current leader to give up on the transfer with TIMEOUT_NOW_EXHAUSTED and resume processing on the partition - when the stalled role transition completes, the desired leader calls an election which it loses because it hadn't replicated the entries created after processing resumed.

The original solution proposal called for eagerly stepping down the current leader when sending TimeoutNow - I avoided this in order to reduce disruption in the case of failed transfers, but in the scenario where we know the desired leader has received a TimeoutNow it seems more likely that resuming processing on the current leader will create disruption itself. I think a reasonable synthesis is to step down when we know the TimeoutNow has been acknowledged - though for this to be effective, we also need the follower to acknowledge the request before executing its potentially-blocking role transition.

## Related issues

Relates to #61443.

