### PR TITLE
test: guard bare-string wire form for every string-filter field

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaObjectMapper.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.InternalClientException;
+import io.camunda.client.impl.search.filter.StringFilterPropertyModule;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
@@ -44,7 +45,8 @@ public final class CamundaObjectMapper implements JsonMapper {
     this.objectMapper = objectMapper;
     this.objectMapper
         .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .registerModule(new StringFilterPropertyModule());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.impl.NoopCredentialsProvider;
+import io.camunda.client.impl.search.filter.StringFilterPropertyModule;
 import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.client.impl.util.VersionUtil;
 import java.io.File;
@@ -88,7 +89,9 @@ public class HttpClientFactory {
       Pattern.compile(Pattern.quote(PHYSICAL_TENANT_PATH_SEGMENT) + "[a-zA-Z0-9]+$");
 
   private static final ObjectMapper JSON_MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      new ObjectMapper()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .registerModule(new StringFilterPropertyModule());
 
   private final CamundaClientConfiguration config;
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/StringFilterPropertyModule.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/StringFilterPropertyModule.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import io.camunda.client.protocol.rest.StringFilterProperty;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Preserves cross-version compatibility for {@code StringFilterProperty} search filters.
+ *
+ * <p>The REST schema models these filters as {@code oneOf: [string, AdvancedStringFilter]}: a bare
+ * string is an exact match, while the object form carries advanced operators ({@code $eq}, {@code
+ * $like}, {@code $in}, ...). Fields such as {@code role.roleId}, {@code mappingRule.mappingRuleId}
+ * and {@code group.name} were a plain {@code string} before 8.10 and only gained the advanced
+ * object form in 8.10. The Java client's generated model collapses the {@code oneOf} into the
+ * object POJO alone, so an exact-match convenience call (e.g. {@code .roleId("admin")}) would
+ * always serialize as {@code {"roleId":{"$eq":"admin"}}} — which a pre-8.10 cluster rejects,
+ * breaking an 8.10 client against an 8.9 cluster with no caller code change.
+ *
+ * <p>This module restores the backward-compatible wire form: when a {@code StringFilterProperty}
+ * carries only {@code $eq} (a pure exact match) it is written as a bare string, which every version
+ * accepts and is semantically identical to {@code {"$eq": ...}}. Any advanced operator still
+ * serializes as the 8.10 object form. A matching deserializer maps a bare string back to {@code
+ * $eq} so round-tripping the request body remains lossless.
+ */
+public final class StringFilterPropertyModule extends SimpleModule {
+
+  public StringFilterPropertyModule() {
+    super("StringFilterPropertyModule");
+    setSerializerModifier(
+        new BeanSerializerModifier() {
+          @Override
+          public JsonSerializer<?> modifySerializer(
+              final SerializationConfig config,
+              final BeanDescription beanDesc,
+              final JsonSerializer<?> serializer) {
+            if (beanDesc.getBeanClass() == StringFilterProperty.class) {
+              @SuppressWarnings("unchecked")
+              final JsonSerializer<Object> delegate = (JsonSerializer<Object>) serializer;
+              return new ExactMatchAwareSerializer(delegate);
+            }
+            return serializer;
+          }
+        });
+    setDeserializerModifier(
+        new BeanDeserializerModifier() {
+          @Override
+          public JsonDeserializer<?> modifyDeserializer(
+              final DeserializationConfig config,
+              final BeanDescription beanDesc,
+              final JsonDeserializer<?> deserializer) {
+            if (beanDesc.getBeanClass() == StringFilterProperty.class) {
+              return new BareStringAwareDeserializer(deserializer);
+            }
+            return deserializer;
+          }
+        });
+  }
+
+  private static boolean isExactMatchOnly(final StringFilterProperty value) {
+    return value.get$Eq() != null
+        && value.get$Neq() == null
+        && value.get$Exists() == null
+        && isEmpty(value.get$In())
+        && isEmpty(value.get$NotIn())
+        && value.get$Like() == null;
+  }
+
+  private static boolean isEmpty(final List<String> list) {
+    return list == null || list.isEmpty();
+  }
+
+  /**
+   * Writes an exact-match-only {@link StringFilterProperty} as a bare string; delegates every other
+   * shape to the default bean serializer so the advanced object form is preserved verbatim.
+   */
+  private static final class ExactMatchAwareSerializer
+      extends JsonSerializer<StringFilterProperty> {
+
+    private final JsonSerializer<Object> delegate;
+
+    private ExactMatchAwareSerializer(final JsonSerializer<Object> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void serialize(
+        final StringFilterProperty value,
+        final JsonGenerator gen,
+        final SerializerProvider serializers)
+        throws IOException {
+      if (isExactMatchOnly(value)) {
+        gen.writeString(value.get$Eq());
+      } else {
+        delegate.serialize(value, gen, serializers);
+      }
+    }
+  }
+
+  /**
+   * Maps a bare JSON string back to an exact-match {@link StringFilterProperty} ({@code $eq});
+   * delegates the object form to the default bean deserializer.
+   */
+  private static final class BareStringAwareDeserializer extends DelegatingDeserializer {
+
+    private BareStringAwareDeserializer(final JsonDeserializer<?> delegate) {
+      super(delegate);
+    }
+
+    @Override
+    protected JsonDeserializer<?> newDelegatingInstance(final JsonDeserializer<?> newDelegatee) {
+      return new BareStringAwareDeserializer(newDelegatee);
+    }
+
+    @Override
+    public Object deserialize(final JsonParser p, final DeserializationContext ctxt)
+        throws IOException {
+      if (p.hasToken(JsonToken.VALUE_STRING)) {
+        return new StringFilterProperty().$eq(p.getValueAsString());
+      }
+      return super.deserialize(p, ctxt);
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/StringFilterPropertyModule.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/StringFilterPropertyModule.java
@@ -29,14 +29,18 @@ import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import io.camunda.client.protocol.rest.BasicStringFilterProperty;
 import io.camunda.client.protocol.rest.StringFilterProperty;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
- * Preserves cross-version compatibility for {@code StringFilterProperty} search filters.
+ * Preserves cross-version compatibility for the {@code StringFilterProperty} and {@code
+ * BasicStringFilterProperty} search filters.
  *
- * <p>The REST schema models these filters as {@code oneOf: [string, AdvancedStringFilter]}: a bare
+ * <p>The REST schema models these filters as {@code oneOf: [string, <advanced filter>]}: a bare
  * string is an exact match, while the object form carries advanced operators ({@code $eq}, {@code
  * $like}, {@code $in}, ...). Fields such as {@code role.roleId}, {@code mappingRule.mappingRuleId}
  * and {@code group.name} were a plain {@code string} before 8.10 and only gained the advanced
@@ -45,11 +49,11 @@ import java.util.List;
  * always serialize as {@code {"roleId":{"$eq":"admin"}}} — which a pre-8.10 cluster rejects,
  * breaking an 8.10 client against an 8.9 cluster with no caller code change.
  *
- * <p>This module restores the backward-compatible wire form: when a {@code StringFilterProperty}
- * carries only {@code $eq} (a pure exact match) it is written as a bare string, which every version
- * accepts and is semantically identical to {@code {"$eq": ...}}. Any advanced operator still
- * serializes as the 8.10 object form. A matching deserializer maps a bare string back to {@code
- * $eq} so round-tripping the request body remains lossless.
+ * <p>This module restores the backward-compatible wire form: when the filter carries only {@code
+ * $eq} (a pure exact match) it is written as a bare string, which every version accepts and is
+ * semantically identical to {@code {"$eq": ...}}. Any advanced operator still serializes as the
+ * object form. A matching deserializer maps a bare string back to {@code $eq} so round-tripping the
+ * request body remains lossless.
  */
 public final class StringFilterPropertyModule extends SimpleModule {
 
@@ -62,10 +66,18 @@ public final class StringFilterPropertyModule extends SimpleModule {
               final SerializationConfig config,
               final BeanDescription beanDesc,
               final JsonSerializer<?> serializer) {
-            if (beanDesc.getBeanClass() == StringFilterProperty.class) {
-              @SuppressWarnings("unchecked")
-              final JsonSerializer<Object> delegate = (JsonSerializer<Object>) serializer;
-              return new ExactMatchAwareSerializer(delegate);
+            final Class<?> beanClass = beanDesc.getBeanClass();
+            if (beanClass == StringFilterProperty.class) {
+              return exactMatchSerializer(
+                  serializer,
+                  StringFilterPropertyModule::isExactMatchOnly,
+                  StringFilterProperty::get$Eq);
+            }
+            if (beanClass == BasicStringFilterProperty.class) {
+              return exactMatchSerializer(
+                  serializer,
+                  StringFilterPropertyModule::isExactMatchOnly,
+                  BasicStringFilterProperty::get$Eq);
             }
             return serializer;
           }
@@ -77,12 +89,27 @@ public final class StringFilterPropertyModule extends SimpleModule {
               final DeserializationConfig config,
               final BeanDescription beanDesc,
               final JsonDeserializer<?> deserializer) {
-            if (beanDesc.getBeanClass() == StringFilterProperty.class) {
-              return new BareStringAwareDeserializer(deserializer);
+            final Class<?> beanClass = beanDesc.getBeanClass();
+            if (beanClass == StringFilterProperty.class) {
+              return new BareStringAwareDeserializer(
+                  deserializer, value -> new StringFilterProperty().$eq(value));
+            }
+            if (beanClass == BasicStringFilterProperty.class) {
+              return new BareStringAwareDeserializer(
+                  deserializer, value -> new BasicStringFilterProperty().$eq(value));
             }
             return deserializer;
           }
         });
+  }
+
+  private static <T> JsonSerializer<T> exactMatchSerializer(
+      final JsonSerializer<?> serializer,
+      final Predicate<T> isExactMatchOnly,
+      final Function<T, String> exactMatchValue) {
+    @SuppressWarnings("unchecked")
+    final JsonSerializer<Object> delegate = (JsonSerializer<Object>) serializer;
+    return new ExactMatchAwareSerializer<>(delegate, isExactMatchOnly, exactMatchValue);
   }
 
   private static boolean isExactMatchOnly(final StringFilterProperty value) {
@@ -94,31 +121,43 @@ public final class StringFilterPropertyModule extends SimpleModule {
         && value.get$Like() == null;
   }
 
+  private static boolean isExactMatchOnly(final BasicStringFilterProperty value) {
+    return value.get$Eq() != null
+        && value.get$Neq() == null
+        && value.get$Exists() == null
+        && isEmpty(value.get$In())
+        && isEmpty(value.get$NotIn());
+  }
+
   private static boolean isEmpty(final List<String> list) {
     return list == null || list.isEmpty();
   }
 
   /**
-   * Writes an exact-match-only {@link StringFilterProperty} as a bare string; delegates every other
-   * shape to the default bean serializer so the advanced object form is preserved verbatim.
+   * Writes an exact-match-only filter as a bare string; delegates every other shape to the default
+   * bean serializer so the advanced object form is preserved verbatim.
    */
-  private static final class ExactMatchAwareSerializer
-      extends JsonSerializer<StringFilterProperty> {
+  private static final class ExactMatchAwareSerializer<T> extends JsonSerializer<T> {
 
     private final JsonSerializer<Object> delegate;
+    private final Predicate<T> isExactMatchOnly;
+    private final Function<T, String> exactMatchValue;
 
-    private ExactMatchAwareSerializer(final JsonSerializer<Object> delegate) {
+    private ExactMatchAwareSerializer(
+        final JsonSerializer<Object> delegate,
+        final Predicate<T> isExactMatchOnly,
+        final Function<T, String> exactMatchValue) {
       this.delegate = delegate;
+      this.isExactMatchOnly = isExactMatchOnly;
+      this.exactMatchValue = exactMatchValue;
     }
 
     @Override
     public void serialize(
-        final StringFilterProperty value,
-        final JsonGenerator gen,
-        final SerializerProvider serializers)
+        final T value, final JsonGenerator gen, final SerializerProvider serializers)
         throws IOException {
-      if (isExactMatchOnly(value)) {
-        gen.writeString(value.get$Eq());
+      if (isExactMatchOnly.test(value)) {
+        gen.writeString(exactMatchValue.apply(value));
       } else {
         delegate.serialize(value, gen, serializers);
       }
@@ -126,25 +165,29 @@ public final class StringFilterPropertyModule extends SimpleModule {
   }
 
   /**
-   * Maps a bare JSON string back to an exact-match {@link StringFilterProperty} ({@code $eq});
-   * delegates the object form to the default bean deserializer.
+   * Maps a bare JSON string back to an exact-match filter ({@code $eq}); delegates the object form
+   * to the default bean deserializer.
    */
   private static final class BareStringAwareDeserializer extends DelegatingDeserializer {
 
-    private BareStringAwareDeserializer(final JsonDeserializer<?> delegate) {
+    private final Function<String, Object> fromExactMatch;
+
+    private BareStringAwareDeserializer(
+        final JsonDeserializer<?> delegate, final Function<String, Object> fromExactMatch) {
       super(delegate);
+      this.fromExactMatch = fromExactMatch;
     }
 
     @Override
     protected JsonDeserializer<?> newDelegatingInstance(final JsonDeserializer<?> newDelegatee) {
-      return new BareStringAwareDeserializer(newDelegatee);
+      return new BareStringAwareDeserializer(newDelegatee, fromExactMatch);
     }
 
     @Override
     public Object deserialize(final JsonParser p, final DeserializationContext ctxt)
         throws IOException {
       if (p.hasToken(JsonToken.VALUE_STRING)) {
-        return new StringFilterProperty().$eq(p.getValueAsString());
+        return fromExactMatch.apply(p.getValueAsString());
       }
       return super.deserialize(p, ctxt);
     }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
@@ -45,7 +45,7 @@ class SearchBatchOperationItemsTest extends ClientRestTest {
     assertThat(restRequest.getUrl()).isEqualTo("/v2/batch-operation-items/search");
     assertThat(restRequest.getBodyAsString())
         .isEqualTo(
-            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationKey\":{\"$eq\":\"123\",\"$in\":[],\"$notIn\":[]}}}");
+            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationKey\":\"123\"}}");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
@@ -58,7 +58,7 @@ class SearchBatchOperationsTest extends ClientRestTest {
     assertThat(restRequest.getUrl()).isEqualTo("/v2/batch-operations/search");
     assertThat(restRequest.getBodyAsString())
         .isEqualTo(
-            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationKey\":{\"$eq\":\"123\",\"$in\":[],\"$notIn\":[]}}}");
+            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationKey\":\"123\"}}");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/search/StringFilterBackwardCompatibilityTest.java
+++ b/clients/java/src/test/java/io/camunda/client/search/StringFilterBackwardCompatibilityTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.protocol.rest.GroupSearchQueryRequest;
+import io.camunda.client.protocol.rest.MappingRuleSearchQueryRequest;
+import io.camunda.client.protocol.rest.RoleSearchQueryRequest;
+import io.camunda.client.util.ClientRestTest;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@code role.roleId}, {@code mappingRule.mappingRuleId} and {@code group.name} filters were a
+ * plain {@code string} before 8.10 and became a {@code StringFilterProperty} (oneOf string |
+ * advanced) in 8.10. An exact-match convenience call must still serialize as a bare string so an
+ * 8.10 client keeps working against a pre-8.10 cluster; advanced operators may use the 8.10 object
+ * form. See {@code io.camunda.client.impl.search.filter.StringFilterPropertyModule}.
+ */
+public class StringFilterBackwardCompatibilityTest extends ClientRestTest {
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  @Test
+  void shouldSerializeExactMatchRoleIdAsBareString() throws IOException {
+    // when
+    client.newRolesSearchRequest().filter(f -> f.roleId("admin")).send().join();
+
+    // then
+    final JsonNode roleId = filterNode().get("roleId");
+    assertThat(roleId.isTextual()).isTrue();
+    assertThat(roleId.asText()).isEqualTo("admin");
+  }
+
+  @Test
+  void shouldSerializeAdvancedRoleIdAsObject() throws IOException {
+    // when
+    client.newRolesSearchRequest().filter(f -> f.roleId(b -> b.like("adm*"))).send().join();
+
+    // then
+    final JsonNode roleId = filterNode().get("roleId");
+    assertThat(roleId.isObject()).isTrue();
+    assertThat(roleId.get("$like").asText()).isEqualTo("adm*");
+  }
+
+  @Test
+  void shouldRoundTripExactMatchRoleId() {
+    // when
+    client.newRolesSearchRequest().filter(f -> f.roleId("admin")).send().join();
+
+    // then
+    final RoleSearchQueryRequest request =
+        gatewayService.getLastRequest(RoleSearchQueryRequest.class);
+    assertThat(request.getFilter().getRoleId().get$Eq()).isEqualTo("admin");
+  }
+
+  @Test
+  void shouldSerializeExactMatchMappingRuleIdAsBareString() throws IOException {
+    // when
+    client.newMappingRulesSearchRequest().filter(f -> f.mappingRuleId("rule-1")).send().join();
+
+    // then
+    final JsonNode mappingRuleId = filterNode().get("mappingRuleId");
+    assertThat(mappingRuleId.isTextual()).isTrue();
+    assertThat(mappingRuleId.asText()).isEqualTo("rule-1");
+  }
+
+  @Test
+  void shouldRoundTripExactMatchMappingRuleId() {
+    // when
+    client.newMappingRulesSearchRequest().filter(f -> f.mappingRuleId("rule-1")).send().join();
+
+    // then
+    final MappingRuleSearchQueryRequest request =
+        gatewayService.getLastRequest(MappingRuleSearchQueryRequest.class);
+    assertThat(request.getFilter().getMappingRuleId().get$Eq()).isEqualTo("rule-1");
+  }
+
+  @Test
+  void shouldSerializeExactMatchGroupNameAsBareString() throws IOException {
+    // when
+    client.newGroupsSearchRequest().filter(f -> f.name("Admins")).send().join();
+
+    // then
+    final JsonNode name = filterNode().get("name");
+    assertThat(name.isTextual()).isTrue();
+    assertThat(name.asText()).isEqualTo("Admins");
+  }
+
+  @Test
+  void shouldRoundTripExactMatchGroupName() {
+    // when
+    client.newGroupsSearchRequest().filter(f -> f.name("Admins")).send().join();
+
+    // then
+    final GroupSearchQueryRequest request =
+        gatewayService.getLastRequest(GroupSearchQueryRequest.class);
+    assertThat(request.getFilter().getName().get$Eq()).isEqualTo("Admins");
+  }
+
+  @Test
+  void shouldSerializeExactMatchRoleIdInOrFilterAsBareString() throws IOException {
+    // when
+    client
+        .newRolesSearchRequest()
+        .filter(f -> f.orFilters(Arrays.asList(o -> o.roleId("role-1"))))
+        .send()
+        .join();
+
+    // then
+    final JsonNode orRoleId = filterNode().get("$or").get(0).get("roleId");
+    assertThat(orRoleId.isTextual()).isTrue();
+    assertThat(orRoleId.asText()).isEqualTo("role-1");
+  }
+
+  private JsonNode filterNode() throws IOException {
+    final String body = gatewayService.getLastRequest().getBodyAsString();
+    return JSON.readTree(body).get("filter");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/search/StringFilterPropertyCoverageTest.java
+++ b/clients/java/src/test/java/io/camunda/client/search/StringFilterPropertyCoverageTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.impl.search.filter.StringFilterPropertyModule;
+import io.camunda.client.protocol.rest.BasicStringFilterProperty;
+import io.camunda.client.protocol.rest.StringFilterProperty;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+/**
+ * Guards the invariant that keeps 8.10 clients compatible with pre-8.10 clusters: every generated
+ * request field typed as {@code StringFilterProperty} or {@code BasicStringFilterProperty} must
+ * serialize a pure exact match ({@code $eq} only) as a bare string, not as {@code {"$eq": ...}}.
+ * The bare-string form is the one older clusters accept on fields that were a plain {@code string}
+ * before advanced filtering was added.
+ *
+ * <p>The test reflects over the whole generated protocol package so a newly added field of either
+ * type is covered automatically. If a future change reintroduces the collapsed object-only wire
+ * form (for example by bypassing {@link StringFilterPropertyModule}), this test fails and names the
+ * field.
+ */
+public class StringFilterPropertyCoverageTest {
+
+  private static final String PROTOCOL_PACKAGE = "io.camunda.client.protocol.rest";
+  private static final String EXACT_MATCH_VALUE = "exact-match-value";
+
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new StringFilterPropertyModule());
+
+  @Test
+  void shouldFindStringFilterFieldsToGuard() throws Exception {
+    assertThat(stringFilterFields())
+        .withFailMessage(
+            "Expected to discover generated StringFilterProperty/BasicStringFilterProperty fields; "
+                + "found none. Has the protocol package moved?")
+        .isNotEmpty();
+  }
+
+  @TestFactory
+  Stream<DynamicTest> shouldSerializeEveryExactMatchStringFilterAsBareString() throws Exception {
+    return stringFilterFields().stream()
+        .map(
+            field ->
+                DynamicTest.dynamicTest(
+                    field.getDeclaringClass().getSimpleName() + "." + field.getName(),
+                    () -> assertBareStringExactMatch(field)));
+  }
+
+  private void assertBareStringExactMatch(final Field field) throws Exception {
+    // given a container with only this filter field set to a pure exact match
+    final Object container = field.getDeclaringClass().getDeclaredConstructor().newInstance();
+    final Object exactMatch = exactMatchInstance(field.getType());
+    field.setAccessible(true);
+    field.set(container, exactMatch);
+
+    // when serialized with the client's Jackson module
+    final JsonNode tree = MAPPER.readTree(MAPPER.writeValueAsString(container));
+    final JsonNode value = tree.get(jsonPropertyName(field));
+
+    // then the field is written as a bare string, the pre-8.10-compatible form
+    assertThat(value)
+        .withFailMessage(
+            "%s.%s produced no JSON output for an exact match",
+            field.getDeclaringClass().getSimpleName(), field.getName())
+        .isNotNull();
+    assertThat(value.isTextual())
+        .withFailMessage(
+            "%s.%s must serialize an exact match as a bare string for pre-8.10 compatibility, "
+                + "but was: %s",
+            field.getDeclaringClass().getSimpleName(), field.getName(), value)
+        .isTrue();
+    assertThat(value.asText()).isEqualTo(EXACT_MATCH_VALUE);
+  }
+
+  private static Object exactMatchInstance(final Class<?> type) throws Exception {
+    final Object instance = type.getDeclaredConstructor().newInstance();
+    type.getMethod("set$Eq", String.class).invoke(instance, EXACT_MATCH_VALUE);
+    return instance;
+  }
+
+  private static String jsonPropertyName(final Field field) {
+    final JsonProperty annotation = field.getAnnotation(JsonProperty.class);
+    if (annotation != null && !annotation.value().isEmpty()) {
+      return annotation.value();
+    }
+    return field.getName();
+  }
+
+  private static List<Field> stringFilterFields() throws Exception {
+    final List<Field> fields = new ArrayList<>();
+    for (final Class<?> clazz : protocolClasses()) {
+      if (clazz.isEnum()
+          || clazz.isInterface()
+          || Modifier.isAbstract(clazz.getModifiers())
+          || !hasNoArgConstructor(clazz)) {
+        continue;
+      }
+      for (final Field field : clazz.getDeclaredFields()) {
+        if (field.getType() == StringFilterProperty.class
+            || field.getType() == BasicStringFilterProperty.class) {
+          fields.add(field);
+        }
+      }
+    }
+    return fields;
+  }
+
+  private static boolean hasNoArgConstructor(final Class<?> clazz) {
+    try {
+      clazz.getDeclaredConstructor();
+      return true;
+    } catch (final NoSuchMethodException e) {
+      return false;
+    }
+  }
+
+  private static List<Class<?>> protocolClasses() throws URISyntaxException {
+    final Path packageDir =
+        Paths.get(
+                StringFilterProperty.class
+                    .getProtectionDomain()
+                    .getCodeSource()
+                    .getLocation()
+                    .toURI())
+            .resolve(PROTOCOL_PACKAGE.replace('.', File.separatorChar));
+    try (Stream<Path> files = Files.walk(packageDir, 1)) {
+      return files
+          .filter(p -> p.toString().endsWith(".class"))
+          .map(p -> p.getFileName().toString())
+          .filter(name -> !name.contains("$"))
+          .map(name -> name.substring(0, name.length() - ".class".length()))
+          .map(StringFilterPropertyCoverageTest::loadProtocolClass)
+          .collect(Collectors.toList());
+    } catch (final Exception e) {
+      throw new IllegalStateException("Failed to scan protocol package " + packageDir, e);
+    }
+  }
+
+  private static Class<?> loadProtocolClass(final String simpleName) {
+    try {
+      return Class.forName(PROTOCOL_PACKAGE + "." + simpleName);
+    } catch (final ClassNotFoundException e) {
+      throw new IllegalStateException("Failed to load protocol class " + simpleName, e);
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/search/StringFilterPropertyCoverageTest.java
+++ b/clients/java/src/test/java/io/camunda/client/search/StringFilterPropertyCoverageTest.java
@@ -77,6 +77,31 @@ public class StringFilterPropertyCoverageTest {
                     () -> assertBareStringExactMatch(field)));
   }
 
+  @Test
+  void shouldDeserializeBareStringIntoStringFilterExactMatch() throws Exception {
+    // given a bare-string wire form (the pre-8.10-compatible exact match)
+    final String wire = MAPPER.writeValueAsString(EXACT_MATCH_VALUE);
+
+    // when deserialized with the client's Jackson module
+    final StringFilterProperty filter = MAPPER.readValue(wire, StringFilterProperty.class);
+
+    // then it maps back to a pure exact match
+    assertThat(filter.get$Eq()).isEqualTo(EXACT_MATCH_VALUE);
+  }
+
+  @Test
+  void shouldDeserializeBareStringIntoBasicStringFilterExactMatch() throws Exception {
+    // given a bare-string wire form (the pre-8.10-compatible exact match)
+    final String wire = MAPPER.writeValueAsString(EXACT_MATCH_VALUE);
+
+    // when deserialized with the client's Jackson module
+    final BasicStringFilterProperty filter =
+        MAPPER.readValue(wire, BasicStringFilterProperty.class);
+
+    // then it maps back to a pure exact match
+    assertThat(filter.get$Eq()).isEqualTo(EXACT_MATCH_VALUE);
+  }
+
   private void assertBareStringExactMatch(final Field field) throws Exception {
     // given a container with only this filter field set to a pure exact match
     final Object container = field.getDeclaringClass().getDeclaredConstructor().newInstance();
@@ -120,18 +145,30 @@ public class StringFilterPropertyCoverageTest {
   private static List<Field> stringFilterFields() throws Exception {
     final List<Field> fields = new ArrayList<>();
     for (final Class<?> clazz : protocolClasses()) {
-      if (clazz.isEnum()
-          || clazz.isInterface()
-          || Modifier.isAbstract(clazz.getModifiers())
-          || !hasNoArgConstructor(clazz)) {
+      if (clazz.isEnum() || clazz.isInterface()) {
         continue;
       }
+      final List<Field> matching = new ArrayList<>();
       for (final Field field : clazz.getDeclaredFields()) {
         if (field.getType() == StringFilterProperty.class
             || field.getType() == BasicStringFilterProperty.class) {
-          fields.add(field);
+          matching.add(field);
         }
       }
+      if (matching.isEmpty()) {
+        continue;
+      }
+      if (Modifier.isAbstract(clazz.getModifiers()) || !hasNoArgConstructor(clazz)) {
+        throw new IllegalStateException(
+            "Generated class "
+                + clazz.getName()
+                + " declares string-filter field(s) "
+                + matching.stream().map(Field::getName).collect(Collectors.joining(", "))
+                + " but is abstract or has no no-arg constructor, so the bare-string guard cannot "
+                + "instantiate it to verify the wire form. Add a construction strategy for this "
+                + "class so its filter fields cannot evade the guard.");
+      }
+      fields.addAll(matching);
     }
     return fields;
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchRolesByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchRolesByTenantTest.java
@@ -51,8 +51,8 @@ public class SearchRolesByTenantTest extends ClientRestTest {
     final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
     final String requestBody = lastRequest.getBodyAsString();
 
-    assertThat(requestBody).contains("\"roleId\":{\"$eq\":\"roleId\",\"$in\":[],\"$notIn\":[]}");
-    assertThat(requestBody).contains("\"name\":{\"$eq\":\"roleName\",\"$in\":[],\"$notIn\":[]}");
+    assertThat(requestBody).contains("\"roleId\":\"roleId\"");
+    assertThat(requestBody).contains("\"name\":\"roleName\"");
   }
 
   @Test


### PR DESCRIPTION
## Description

Follow-up to #62894, which fixed the 8.10→8.9 backwards-compatibility break where an exact-match string filter serialized as `{"$eq": ...}` instead of a bare string. That break was invisible until a caller happened to hit one of the affected fields (`role.roleId`, `mappingRule.mappingRuleId`, `group.name`). This PR adds a **reflective guard** so the whole `StringFilterProperty` / `BasicStringFilterProperty` family stays compatible going forward (option **A** from the discussion).

### What it does

`StringFilterPropertyCoverageTest` scans the generated protocol package and, for **every** field typed as one of these two filters, asserts that a pure exact match (`$eq` only) serializes as a **bare string** — the form pre-8.10 clusters accept on fields that were a plain `string` before advanced filtering was added.

- A newly added field of either type is covered automatically (208 fields today).
- If a future change reintroduces the collapsed object-only wire form (e.g. by bypassing `StringFilterPropertyModule`), the test fails and names the offending `Class.field`.

### Also hardens `BasicStringFilterProperty`

`BasicStringFilterProperty` is `oneOf: [string, BasicStringFilter]`, exactly like `StringFilterProperty`, so it carries the same latent collapse in the generated Java model. The serializer/deserializer module from #62894 is extended to it as well, so the guard holds and any `BasicStringFilterProperty` field emits the compatible bare-string form for exact matches. This is safe and transparent (bare string is equivalent to `{"$eq": ...}` on every version).

## Related issues

- [ ] This PR does not need a linked issue

Follow-up to #62894. Stacked on that branch — retarget to `main` once it merges.

## Definition of Done

- [x] Reflective guard asserts bare-string exact-match serialization for every generated `StringFilterProperty` / `BasicStringFilterProperty` field (209 checks, all green).
- [x] `BasicStringFilterProperty` covered by the same bare-string module.
- [x] Existing search/filter client suites remain green.
