### PR TITLE
feat: announce webapp locations via /.well-known/camunda/webapps

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
@@ -43,10 +43,11 @@ public final class SecurityPaths {
   // a health endpoint. Here the Authorization header is never inspected. The exact path is listed,
   // so the rest of /cluster/v2/** stays with the cluster-admin chains. /cluster/v2/status/upgrade
   // is listed for the identical reason (camunda/camunda#61619).
-  // /.well-known/camunda/** is the discovery document for the setup's webapps
+  // /.well-known/camunda/webapps is the discovery document for the setup's webapps
   // (camunda/camunda#46649). Clients fetch it before they know how (or whether) to authenticate
   // against the cluster, so it needs the same credential-agnostic treatment as the health
-  // endpoints above.
+  // endpoints above. Listed as an exact path for the same reason: any future well-known document
+  // must opt into the filter-less chain explicitly.
   public static final Set<String> UNPROTECTED_PATHS =
       Set.of(
           "/error",
@@ -57,7 +58,7 @@ public final class SecurityPaths {
           "/favicon.ico",
           "/cluster/v2/status",
           "/cluster/v2/status/upgrade",
-          "/.well-known/camunda/**");
+          "/.well-known/camunda/webapps");
 
   private SecurityPaths() {}
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
@@ -43,6 +43,10 @@ public final class SecurityPaths {
   // a health endpoint. Here the Authorization header is never inspected. The exact path is listed,
   // so the rest of /cluster/v2/** stays with the cluster-admin chains. /cluster/v2/status/upgrade
   // is listed for the identical reason (camunda/camunda#61619).
+  // /.well-known/camunda/** is the discovery document for the setup's webapps
+  // (camunda/camunda#46649). Clients fetch it before they know how (or whether) to authenticate
+  // against the cluster, so it needs the same credential-agnostic treatment as the health
+  // endpoints above.
   public static final Set<String> UNPROTECTED_PATHS =
       Set.of(
           "/error",
@@ -52,7 +56,8 @@ public final class SecurityPaths {
           "/startup",
           "/favicon.ico",
           "/cluster/v2/status",
-          "/cluster/v2/status/upgrade");
+          "/cluster/v2/status/upgrade",
+          "/.well-known/camunda/**");
 
   private SecurityPaths() {}
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -55,7 +55,7 @@ class SecurityPathAdapterTest {
             "/favicon.ico",
             "/cluster/v2/status",
             "/cluster/v2/status/upgrade",
-            "/.well-known/camunda/**");
+            "/.well-known/camunda/webapps");
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -54,7 +54,8 @@ class SecurityPathAdapterTest {
             "/startup",
             "/favicon.ico",
             "/cluster/v2/status",
-            "/cluster/v2/status/upgrade");
+            "/cluster/v2/status/upgrade",
+            "/.well-known/camunda/**");
   }
 
   @Test

--- a/configuration/src/main/java/io/camunda/configuration/Webapp.java
+++ b/configuration/src/main/java/io/camunda/configuration/Webapp.java
@@ -26,8 +26,8 @@ public class Webapp {
    *
    * <p>Set this when the webapp is reachable under a different origin or path than the
    * orchestration cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is
-   * enabled, the discovery endpoint announces the webapp's default path on the same origin as the
-   * API. If the webapp UI is disabled and no URL is set, the webapp is not announced.
+   * enabled, the discovery endpoint announces the webapp's default path relative to the API (e.g.
+   * {@code /operate}). If the webapp UI is disabled and no URL is set, the webapp is not announced.
    */
   private @Nullable String url;
 

--- a/configuration/src/main/java/io/camunda/configuration/Webapp.java
+++ b/configuration/src/main/java/io/camunda/configuration/Webapp.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.configuration;
 
+import org.jspecify.annotations.Nullable;
+
 public class Webapp {
 
   /** Whether the webapp is enabled or not. This also affects the webapp API. */
@@ -17,6 +19,17 @@ public class Webapp {
    * the webapp itself will not be accessible with a web browser.
    */
   private boolean uiEnabled = true;
+
+  /**
+   * The external base URL of the webapp UI (e.g. {@code https://operate.example.com}), announced to
+   * clients via the unauthenticated {@code /.well-known/camunda/webapps} discovery endpoint.
+   *
+   * <p>Set this when the webapp is reachable under a different origin or path than the
+   * orchestration cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is
+   * enabled, the discovery endpoint announces the webapp's default path on the same origin as the
+   * API. If the webapp UI is disabled and no URL is set, the webapp is not announced.
+   */
+  private @Nullable String url;
 
   public boolean isEnabled() {
     return enabled;
@@ -32,5 +45,13 @@ public class Webapp {
 
   public void setUiEnabled(final boolean uiEnabled) {
     this.uiEnabled = uiEnabled;
+  }
+
+  public @Nullable String getUrl() {
+    return url;
+  }
+
+  public void setUrl(final @Nullable String url) {
+    this.url = url;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Webapp.java
+++ b/configuration/src/main/java/io/camunda/configuration/Webapp.java
@@ -28,6 +28,9 @@ public class Webapp {
    * orchestration cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is
    * enabled, the discovery endpoint announces the webapp's default path relative to the API (e.g.
    * {@code /operate}). If the webapp UI is disabled and no URL is set, the webapp is not announced.
+   *
+   * <p>Currently only Operate and Tasklist are announced by the discovery endpoint; setting a URL
+   * for other webapps has no effect.
    */
   private @Nullable String url;
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
@@ -105,6 +105,12 @@ final class PhysicalTenantOverridePolicyValidation {
               "api.long-polling",
               // camunda.data.* cluster wide
               "data.secondary-storage.rdbms.max-varchar-field-length",
+              // camunda.webapps.*.url — announced cluster-wide by the
+              // /.well-known/camunda/webapps discovery endpoint (camunda/camunda#46649); the
+              // controller is cluster-scoped, so a per-tenant override would be silently ignored
+              "webapps.identity.url",
+              "webapps.operate.url",
+              "webapps.tasklist.url",
               // #56648: a per-tenant override of the partition data directory is not allowed,
               // because this directory refers to the root directory shared by all partitions and
               // physical tenants. The root directory also consists of shared data such as

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -149,3 +149,6 @@ system.io-thread-count
 system.restore.ignore-files-in-target
 system.restore.validate-config
 system.upgrade.enable-version-check
+webapps.identity.url
+webapps.operate.url
+webapps.tasklist.url

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -424,10 +424,7 @@ security.saas.organization-id
 system.clock-controlled
 webapps.identity.enabled
 webapps.identity.ui-enabled
-webapps.identity.url
 webapps.operate.enabled
 webapps.operate.ui-enabled
-webapps.operate.url
 webapps.tasklist.enabled
 webapps.tasklist.ui-enabled
-webapps.tasklist.url

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -424,7 +424,10 @@ security.saas.organization-id
 system.clock-controlled
 webapps.identity.enabled
 webapps.identity.ui-enabled
+webapps.identity.url
 webapps.operate.enabled
 webapps.operate.ui-enabled
+webapps.operate.url
 webapps.tasklist.enabled
 webapps.tasklist.ui-enabled
+webapps.tasklist.url

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1697,6 +1697,13 @@ camunda: # Type: io.camunda.configuration.Camunda
       # Whether the webapp UI is enabled or not. If false, the webapp API will still be available, but the
       # webapp itself will not be accessible with a web browser.
       ui-enabled: true # Type: Boolean, Env: CAMUNDA_WEBAPPS_IDENTITY_UIENABLED
+      # The external base URL of the webapp UI (e.g. `https://operate.example.com`), announced to clients
+      # via the unauthenticated `/.well-known/camunda/webapps` discovery endpoint.
+      # Set this when the webapp is reachable under a different origin or path than the orchestration
+      # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
+      # discovery endpoint announces the webapp's default path on the same origin as the API. If the webapp
+      # UI is disabled and no URL is set, the webapp is not announced.
+      url: null # Type: String, Env: CAMUNDA_WEBAPPS_IDENTITY_URL
     
     operate: # Type: io.camunda.configuration.Webapp  
       # Whether the webapp is enabled or not. This also affects the webapp API.
@@ -1704,6 +1711,13 @@ camunda: # Type: io.camunda.configuration.Camunda
       # Whether the webapp UI is enabled or not. If false, the webapp API will still be available, but the
       # webapp itself will not be accessible with a web browser.
       ui-enabled: true # Type: Boolean, Env: CAMUNDA_WEBAPPS_OPERATE_UIENABLED
+      # The external base URL of the webapp UI (e.g. `https://operate.example.com`), announced to clients
+      # via the unauthenticated `/.well-known/camunda/webapps` discovery endpoint.
+      # Set this when the webapp is reachable under a different origin or path than the orchestration
+      # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
+      # discovery endpoint announces the webapp's default path on the same origin as the API. If the webapp
+      # UI is disabled and no URL is set, the webapp is not announced.
+      url: null # Type: String, Env: CAMUNDA_WEBAPPS_OPERATE_URL
     
     tasklist: # Type: io.camunda.configuration.Webapp  
       # Whether the webapp is enabled or not. This also affects the webapp API.
@@ -1711,6 +1725,13 @@ camunda: # Type: io.camunda.configuration.Camunda
       # Whether the webapp UI is enabled or not. If false, the webapp API will still be available, but the
       # webapp itself will not be accessible with a web browser.
       ui-enabled: true # Type: Boolean, Env: CAMUNDA_WEBAPPS_TASKLIST_UIENABLED
+      # The external base URL of the webapp UI (e.g. `https://operate.example.com`), announced to clients
+      # via the unauthenticated `/.well-known/camunda/webapps` discovery endpoint.
+      # Set this when the webapp is reachable under a different origin or path than the orchestration
+      # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
+      # discovery endpoint announces the webapp's default path on the same origin as the API. If the webapp
+      # UI is disabled and no URL is set, the webapp is not announced.
+      url: null # Type: String, Env: CAMUNDA_WEBAPPS_TASKLIST_URL
 
 zeebe: # Type:   
   broker: # Type: io.camunda.configuration.beans.LegacyBrokerBasedProperties  

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1701,8 +1701,8 @@ camunda: # Type: io.camunda.configuration.Camunda
       # via the unauthenticated `/.well-known/camunda/webapps` discovery endpoint.
       # Set this when the webapp is reachable under a different origin or path than the orchestration
       # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
-      # discovery endpoint announces the webapp's default path on the same origin as the API. If the webapp
-      # UI is disabled and no URL is set, the webapp is not announced.
+      # discovery endpoint announces the webapp's default path relative to the API (e.g. `/operate`). If the
+      # webapp UI is disabled and no URL is set, the webapp is not announced.
       url: null # Type: String, Env: CAMUNDA_WEBAPPS_IDENTITY_URL
     
     operate: # Type: io.camunda.configuration.Webapp  
@@ -1715,8 +1715,8 @@ camunda: # Type: io.camunda.configuration.Camunda
       # via the unauthenticated `/.well-known/camunda/webapps` discovery endpoint.
       # Set this when the webapp is reachable under a different origin or path than the orchestration
       # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
-      # discovery endpoint announces the webapp's default path on the same origin as the API. If the webapp
-      # UI is disabled and no URL is set, the webapp is not announced.
+      # discovery endpoint announces the webapp's default path relative to the API (e.g. `/operate`). If the
+      # webapp UI is disabled and no URL is set, the webapp is not announced.
       url: null # Type: String, Env: CAMUNDA_WEBAPPS_OPERATE_URL
     
     tasklist: # Type: io.camunda.configuration.Webapp  
@@ -1729,8 +1729,8 @@ camunda: # Type: io.camunda.configuration.Camunda
       # via the unauthenticated `/.well-known/camunda/webapps` discovery endpoint.
       # Set this when the webapp is reachable under a different origin or path than the orchestration
       # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
-      # discovery endpoint announces the webapp's default path on the same origin as the API. If the webapp
-      # UI is disabled and no URL is set, the webapp is not announced.
+      # discovery endpoint announces the webapp's default path relative to the API (e.g. `/operate`). If the
+      # webapp UI is disabled and no URL is set, the webapp is not announced.
       url: null # Type: String, Env: CAMUNDA_WEBAPPS_TASKLIST_URL
 
 zeebe: # Type:   

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1703,6 +1703,8 @@ camunda: # Type: io.camunda.configuration.Camunda
       # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
       # discovery endpoint announces the webapp's default path relative to the API (e.g. `/operate`). If the
       # webapp UI is disabled and no URL is set, the webapp is not announced.
+      # Currently only Operate and Tasklist are announced by the discovery endpoint; setting a URL for other
+      # webapps has no effect.
       url: null # Type: String, Env: CAMUNDA_WEBAPPS_IDENTITY_URL
     
     operate: # Type: io.camunda.configuration.Webapp  
@@ -1717,6 +1719,8 @@ camunda: # Type: io.camunda.configuration.Camunda
       # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
       # discovery endpoint announces the webapp's default path relative to the API (e.g. `/operate`). If the
       # webapp UI is disabled and no URL is set, the webapp is not announced.
+      # Currently only Operate and Tasklist are announced by the discovery endpoint; setting a URL for other
+      # webapps has no effect.
       url: null # Type: String, Env: CAMUNDA_WEBAPPS_OPERATE_URL
     
     tasklist: # Type: io.camunda.configuration.Webapp  
@@ -1731,6 +1735,8 @@ camunda: # Type: io.camunda.configuration.Camunda
       # cluster REST API, e.g. behind a dedicated ingress. If unset and the webapp UI is enabled, the
       # discovery endpoint announces the webapp's default path relative to the API (e.g. `/operate`). If the
       # webapp UI is disabled and no URL is set, the webapp is not announced.
+      # Currently only Operate and Tasklist are announced by the discovery endpoint; setting a URL for other
+      # webapps has no effect.
       url: null # Type: String, Env: CAMUNDA_WEBAPPS_TASKLIST_URL
 
 zeebe: # Type:   

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -199,11 +199,12 @@ public class ClusterAdminBasicAuthenticationIT {
     // when — the webapps discovery document is fetched with no credentials
     final HttpResponse<String> response = send(clusterUri(PATH_WELL_KNOWN_WEBAPPS), null);
 
-    // then — it announces the setup's webapps, by default co-located with the API
+    // then — it announces the setup's webapps, by default as paths relative to the API origin,
+    // so the answer stays correct behind TLS-terminating proxies
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
     final var body = new ObjectMapper().readTree(response.body());
-    assertThat(body.get("operateUrl").asText()).endsWith("/operate");
-    assertThat(body.get("tasklistUrl").asText()).endsWith("/tasklist");
+    assertThat(body.get("operateUrl").asText()).isEqualTo("/operate");
+    assertThat(body.get("tasklistUrl").asText()).isEqualTo("/tasklist");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -50,6 +50,7 @@ public class ClusterAdminBasicAuthenticationIT {
   public static final String PATH_CLUSTER_RUNTIME_BACKUP_STATE = "cluster/v2/backups/runtime/state";
   public static final String PATH_CLUSTER_REBALANCE = "cluster/v2/rebalance";
   public static final String PATH_V2_AUTHENTICATION_ME = "v2/authentication/me";
+  public static final String PATH_WELL_KNOWN_WEBAPPS = ".well-known/camunda/webapps";
 
   private static final String CLUSTER_ADMIN_USER = "cluster-operator";
   private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
@@ -191,6 +192,29 @@ public class ClusterAdminBasicAuthenticationIT {
 
     // then — cluster-admin users exist only for /cluster/v2/**
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldAllowWebappsDiscoveryEndpointWithoutCredentials() throws Exception {
+    // when — the webapps discovery document is fetched with no credentials
+    final HttpResponse<String> response = send(clusterUri(PATH_WELL_KNOWN_WEBAPPS), null);
+
+    // then — it announces the setup's webapps, by default co-located with the API
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+    final var body = new ObjectMapper().readTree(response.body());
+    assertThat(body.get("operateUrl").asText()).endsWith("/operate");
+    assertThat(body.get("tasklistUrl").asText()).endsWith("/tasklist");
+  }
+
+  @Test
+  void shouldAllowWebappsDiscoveryEndpointWithWrongCredentials() throws Exception {
+    // when — a discovery client sends credentials a Basic chain would reject if it inspected them
+    final HttpResponse<String> response =
+        send(clusterUri(PATH_WELL_KNOWN_WEBAPPS), basicAuth(CLUSTER_ADMIN_USER, "wrong-password"));
+
+    // then — the unprotected chain installs no authentication filter, so the header is ignored.
+    // Discovery must work before a client knows how (or whether) to authenticate.
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -70,7 +70,12 @@ public class ClusterAdminBasicAuthenticationIT {
               "camunda.security.cluster-admin.basic.users[0].password", CLUSTER_ADMIN_PASSWORD)
           .withProperty("camunda.security.cluster-admin.basic.users[1].name", CLUSTER_ADMIN_USER_2)
           .withProperty(
-              "camunda.security.cluster-admin.basic.users[1].password", CLUSTER_ADMIN_PASSWORD_2);
+              "camunda.security.cluster-admin.basic.users[1].password", CLUSTER_ADMIN_PASSWORD_2)
+          // an explicit webapp location, announced even though this broker serves no webapp
+          // profiles — the standalone-gateway deployment model
+          .withProperty("camunda.webapps.operate.url", "http://operate.example.test")
+          // the broker runs no Tasklist profile, so it must not be announced
+          .withUnifiedConfig(cfg -> cfg.getWebapps().getTasklist().setEnabled(false));
 
   // A real, secondary-storage-backed user — used to prove it cannot reach the cluster-admin chain.
   @UserDefinition
@@ -196,15 +201,16 @@ public class ClusterAdminBasicAuthenticationIT {
 
   @Test
   void shouldAllowWebappsDiscoveryEndpointWithoutCredentials() throws Exception {
-    // when — the webapps discovery document is fetched with no credentials
+    // when — the webapps discovery document is fetched with no credentials. This broker serves no
+    // webapp profiles, but an explicit location makes discovery announce it anyway: the deployment
+    // model where a bare gateway points at webapps hosted elsewhere.
     final HttpResponse<String> response = send(clusterUri(PATH_WELL_KNOWN_WEBAPPS), null);
 
-    // then — it announces the setup's webapps, by default as paths relative to the API origin,
-    // so the answer stays correct behind TLS-terminating proxies
+    // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
     final var body = new ObjectMapper().readTree(response.body());
-    assertThat(body.get("operateUrl").asText()).isEqualTo("/operate");
-    assertThat(body.get("tasklistUrl").asText()).isEqualTo("/tasklist");
+    assertThat(body.get("operateUrl").asText()).isEqualTo("http://operate.example.test");
+    assertThat(body.has("tasklistUrl")).isFalse();
   }
 
   @Test

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/WebappsDiscoveryProperties.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/WebappsDiscoveryProperties.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.config;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Binds the {@code camunda.webapps} keys the {@code /.well-known/camunda/webapps} discovery
+ * endpoint needs. The unified configuration module binds the same keys through its own {@code
+ * Camunda} bean; gateway-rest cannot depend on that module (the dependency points the other way),
+ * so it binds the subtree it consumes on its own. Keep the fields aligned with {@code
+ * io.camunda.configuration.Webapp}.
+ */
+@ConfigurationProperties(prefix = "camunda.webapps")
+public class WebappsDiscoveryProperties {
+
+  private Webapp operate = new Webapp();
+  private Webapp tasklist = new Webapp();
+
+  public Webapp getOperate() {
+    return operate;
+  }
+
+  public void setOperate(final Webapp operate) {
+    this.operate = operate;
+  }
+
+  public Webapp getTasklist() {
+    return tasklist;
+  }
+
+  public void setTasklist(final Webapp tasklist) {
+    this.tasklist = tasklist;
+  }
+
+  public static class Webapp {
+
+    /**
+     * External base URL of the webapp UI, announced as-is when set. When unset, the webapp's
+     * default path on the API's origin is announced instead, as long as the UI is enabled.
+     */
+    private @Nullable String url;
+
+    /** Whether the webapp is enabled or not. */
+    private boolean enabled = true;
+
+    /** Whether the webapp UI is enabled or not. */
+    private boolean uiEnabled = true;
+
+    public @Nullable String getUrl() {
+      return url;
+    }
+
+    public void setUrl(final @Nullable String url) {
+      this.url = url;
+    }
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public boolean isUiEnabled() {
+      return uiEnabled;
+    }
+
+    public void setUiEnabled(final boolean uiEnabled) {
+      this.uiEnabled = uiEnabled;
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryController.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.gateway.rest.config.WebappsDiscoveryProperties;
 import io.camunda.zeebe.gateway.rest.config.WebappsDiscoveryProperties.Webapp;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
  * Publishes where this setup's webapps (Operate, Tasklist) live, so client applications (e.g. the
@@ -30,8 +30,15 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
  * <p>The cluster cannot detect where frontends are exposed (they may sit behind a different
  * ingress), so operators announce split deployments explicitly via {@code
  * camunda.webapps.<app>.url}. Without an explicit URL, a webapp with its UI enabled is announced
- * under its default path on the same origin as the API, derived from the current request — the
- * layout of the default Helm chart and c8run.
+ * under its default path, relative to the API — the layout of the default Helm chart and c8run.
+ *
+ * <p>The fallback deliberately returns a root-relative path rather than an absolute URL derived
+ * from the servlet request: behind a TLS-terminating proxy the request reaches the app as plain
+ * HTTP with a rewritten Host, so the derived absolute URL would advertise the wrong scheme and
+ * port. Relative URLs resolve against the origin the client used for the API call, which is correct
+ * by construction. Deployments where the webapps live on a different origin than the API must set
+ * {@code camunda.webapps.<app>.url} explicitly (the Helm chart derives these from its ingress
+ * values).
  */
 @CamundaRestController
 @ClusterScoped
@@ -43,28 +50,33 @@ public class WebappsDiscoveryController {
   private static final String TASKLIST_PATH = "/tasklist";
 
   private final WebappsDiscoveryProperties properties;
+  private final Environment environment;
 
-  public WebappsDiscoveryController(final WebappsDiscoveryProperties properties) {
+  public WebappsDiscoveryController(
+      final WebappsDiscoveryProperties properties, final Environment environment) {
     this.properties = properties;
+    this.environment = environment;
   }
 
   @CamundaGetMapping(path = "/webapps")
   public WebappsDiscoveryResponse getWebapps() {
     return new WebappsDiscoveryResponse(
-        resolveUrl(properties.getOperate(), OPERATE_PATH),
-        resolveUrl(properties.getTasklist(), TASKLIST_PATH));
+        resolveUrl(properties.getOperate(), "operate", OPERATE_PATH),
+        resolveUrl(properties.getTasklist(), "tasklist", TASKLIST_PATH));
   }
 
-  private static @Nullable String resolveUrl(final Webapp webapp, final String defaultPath) {
+  private @Nullable String resolveUrl(
+      final Webapp webapp, final String webappName, final String defaultPath) {
     if (webapp.getUrl() != null && !webapp.getUrl().isBlank()) {
       return webapp.getUrl();
     }
-    if (!webapp.isEnabled() || !webapp.isUiEnabled()) {
+    // Mirror WebappsHelper: a webapp is served only when both the unified key and the legacy
+    // per-app kill-switch (camunda.<app>.webappEnabled) allow it.
+    final var legacyWebappEnabled =
+        environment.getProperty("camunda." + webappName + ".webappEnabled", Boolean.class, true);
+    if (!webapp.isEnabled() || !webapp.isUiEnabled() || !legacyWebappEnabled) {
       return null;
     }
-    return ServletUriComponentsBuilder.fromCurrentContextPath()
-        .path(defaultPath)
-        .build()
-        .toUriString();
+    return defaultPath;
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
+import io.camunda.zeebe.gateway.rest.config.WebappsDiscoveryProperties;
+import io.camunda.zeebe.gateway.rest.config.WebappsDiscoveryProperties.Webapp;
+import org.jspecify.annotations.Nullable;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * Publishes where this setup's webapps (Operate, Tasklist) live, so client applications (e.g. the
+ * Camunda Modeler) can link to them instead of asking users to configure each UI URL separately
+ * (camunda/camunda#46649). The contract is shared with the modeler: {@code GET
+ * ${BASE_URL}/.well-known/camunda/webapps} returns {@code {"operateUrl": ..., "tasklistUrl": ...}},
+ * omitting webapps that are not part of the setup.
+ *
+ * <p>The endpoint is unauthenticated via {@code SecurityPaths.UNPROTECTED_PATHS} — a chain without
+ * any authentication filter — so discovery works before a client knows how (or whether) to
+ * authenticate, and stray credentials cannot turn it into a 401.
+ *
+ * <p>The cluster cannot detect where frontends are exposed (they may sit behind a different
+ * ingress), so operators announce split deployments explicitly via {@code
+ * camunda.webapps.<app>.url}. Without an explicit URL, a webapp with its UI enabled is announced
+ * under its default path on the same origin as the API, derived from the current request — the
+ * layout of the default Helm chart and c8run.
+ */
+@CamundaRestController
+@ClusterScoped
+@EnableConfigurationProperties(WebappsDiscoveryProperties.class)
+@RequestMapping("/.well-known/camunda")
+public class WebappsDiscoveryController {
+
+  private static final String OPERATE_PATH = "/operate";
+  private static final String TASKLIST_PATH = "/tasklist";
+
+  private final WebappsDiscoveryProperties properties;
+
+  public WebappsDiscoveryController(final WebappsDiscoveryProperties properties) {
+    this.properties = properties;
+  }
+
+  @CamundaGetMapping(path = "/webapps")
+  public WebappsDiscoveryResponse getWebapps() {
+    return new WebappsDiscoveryResponse(
+        resolveUrl(properties.getOperate(), OPERATE_PATH),
+        resolveUrl(properties.getTasklist(), TASKLIST_PATH));
+  }
+
+  private static @Nullable String resolveUrl(final Webapp webapp, final String defaultPath) {
+    if (webapp.getUrl() != null && !webapp.getUrl().isBlank()) {
+      return webapp.getUrl();
+    }
+    if (!webapp.isEnabled() || !webapp.isUiEnabled()) {
+      return null;
+    }
+    return ServletUriComponentsBuilder.fromCurrentContextPath()
+        .path(defaultPath)
+        .build()
+        .toUriString();
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryController.java
@@ -29,14 +29,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
  *
  * <p>The cluster cannot detect where frontends are exposed (they may sit behind a different
  * ingress), so operators announce split deployments explicitly via {@code
- * camunda.webapps.<app>.url}. Without an explicit URL, a webapp with its UI enabled is announced
- * under its default path, relative to the API — the layout of the default Helm chart and c8run.
+ * camunda.webapps.<app>.url}. Without an explicit URL, a webapp is announced under its default path
+ * (servlet context path included), relative to the API — the layout of the default Helm chart and
+ * c8run.
  *
- * <p>The fallback deliberately returns a root-relative path rather than an absolute URL derived
- * from the servlet request: behind a TLS-terminating proxy the request reaches the app as plain
- * HTTP with a rewritten Host, so the derived absolute URL would advertise the wrong scheme and
- * port. Relative URLs resolve against the origin the client used for the API call, which is correct
- * by construction. Deployments where the webapps live on a different origin than the API must set
+ * <p>The fallback deliberately returns a relative path rather than an absolute URL derived from the
+ * servlet request: behind a TLS-terminating proxy the request reaches the app as plain HTTP with a
+ * rewritten Host, so the derived absolute URL would advertise the wrong scheme and port. Relative
+ * URLs resolve against the origin the client used for the API call, which is correct by
+ * construction. Deployments where the webapps live on a different origin than the API must set
  * {@code camunda.webapps.<app>.url} explicitly (the Helm chart derives these from its ingress
  * values).
  */
@@ -46,8 +47,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/.well-known/camunda")
 public class WebappsDiscoveryController {
 
-  private static final String OPERATE_PATH = "/operate";
-  private static final String TASKLIST_PATH = "/tasklist";
+  private static final String OPERATE_PATH = "operate";
+  private static final String TASKLIST_PATH = "tasklist";
+  private static final String CONTEXT_PATH_PROPERTY = "server.servlet.context-path";
 
   private final WebappsDiscoveryProperties properties;
   private final Environment environment;
@@ -70,13 +72,21 @@ public class WebappsDiscoveryController {
     if (webapp.getUrl() != null && !webapp.getUrl().isBlank()) {
       return webapp.getUrl();
     }
-    // Mirror WebappsHelper: a webapp is served only when both the unified key and the legacy
-    // per-app kill-switch (camunda.<app>.webappEnabled) allow it.
-    final var legacyWebappEnabled =
-        environment.getProperty("camunda." + webappName + ".webappEnabled", Boolean.class, true);
-    if (!webapp.isEnabled() || !webapp.isUiEnabled() || !legacyWebappEnabled) {
+    if (!isServedByThisApp(webapp, webappName)) {
       return null;
     }
-    return defaultPath;
+    // The UIs are mounted below the servlet context path (e.g. /camunda/operate for
+    // server.servlet.context-path=/camunda), so the relative fallback must include it.
+    return environment.getProperty(CONTEXT_PATH_PROPERTY, "") + "/" + defaultPath;
+  }
+
+  /**
+   * Whether the webapp is available to link to, mirroring {@code WebappsHelper}: both the unified
+   * keys and the legacy kill-switch {@code camunda.<app>.webappEnabled} must allow it.
+   */
+  private boolean isServedByThisApp(final Webapp webapp, final String webappName) {
+    final var legacyWebappEnabled =
+        environment.getProperty("camunda." + webappName + ".webappEnabled", Boolean.class, true);
+    return webapp.isEnabled() && webapp.isUiEnabled() && legacyWebappEnabled;
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryResponse.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Payload of {@code GET /.well-known/camunda/webapps}. A {@code null} URL means the webapp is not
+ * part of this setup and is omitted from the JSON document.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record WebappsDiscoveryResponse(@Nullable String operateUrl, @Nullable String tasklistUrl) {}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryControllerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.startsWith;
+
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.WebappsDiscoveryProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@WebMvcTest(WebappsDiscoveryController.class)
+class WebappsDiscoveryControllerTest extends RestControllerTest {
+
+  static final String WEBAPPS_DISCOVERY_URL = "/.well-known/camunda/webapps";
+
+  @Test
+  void shouldAnnounceWebappsOnApiOriginByDefault() {
+    // given no explicit camunda.webapps.*.url configuration
+
+    // when / then
+    webClient
+        .get()
+        .uri(WEBAPPS_DISCOVERY_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.operateUrl")
+        .value(startsWith("http"))
+        .jsonPath("$.operateUrl")
+        .value(endsWith("/operate"))
+        .jsonPath("$.tasklistUrl")
+        .value(startsWith("http"))
+        .jsonPath("$.tasklistUrl")
+        .value(endsWith("/tasklist"));
+  }
+
+  @Test
+  void shouldAnnounceExplicitlyConfiguredUrls() {
+    // given
+    final var properties = new WebappsDiscoveryProperties();
+    properties.getOperate().setUrl("https://operate.example.com");
+    properties.getTasklist().setUrl("https://tasklist.example.com/ui");
+
+    // when
+    final var response = invokeController(properties);
+
+    // then
+    assertThat(response.operateUrl()).isEqualTo("https://operate.example.com");
+    assertThat(response.tasklistUrl()).isEqualTo("https://tasklist.example.com/ui");
+  }
+
+  @Test
+  void shouldDeriveUrlFromRequestOriginWhenNoUrlConfigured() {
+    // given
+    final var properties = new WebappsDiscoveryProperties();
+
+    // when
+    final var response = invokeController(properties);
+
+    // then
+    assertThat(response.operateUrl()).isEqualTo("https://cluster.example.com/operate");
+    assertThat(response.tasklistUrl()).isEqualTo("https://cluster.example.com/tasklist");
+  }
+
+  @Test
+  void shouldNotAnnounceWebappWhenDisabled() {
+    // given
+    final var properties = new WebappsDiscoveryProperties();
+    properties.getOperate().setEnabled(false);
+
+    // when
+    final var response = invokeController(properties);
+
+    // then
+    assertThat(response.operateUrl()).isNull();
+    assertThat(response.tasklistUrl()).isEqualTo("https://cluster.example.com/tasklist");
+  }
+
+  @Test
+  void shouldNotAnnounceWebappWhenUiDisabled() {
+    // given — the API stays available, but there is no UI to link to
+    final var properties = new WebappsDiscoveryProperties();
+    properties.getTasklist().setUiEnabled(false);
+
+    // when
+    final var response = invokeController(properties);
+
+    // then
+    assertThat(response.operateUrl()).isEqualTo("https://cluster.example.com/operate");
+    assertThat(response.tasklistUrl()).isNull();
+  }
+
+  @Test
+  void shouldAnnounceExplicitUrlEvenWhenWebappIsDisabled() {
+    // given — the webapp is not served by this app, but lives at a known location
+    final var properties = new WebappsDiscoveryProperties();
+    properties.getOperate().setEnabled(false);
+    properties.getOperate().setUrl("https://operate.example.com");
+
+    // when
+    final var response = invokeController(properties);
+
+    // then
+    assertThat(response.operateUrl()).isEqualTo("https://operate.example.com");
+  }
+
+  private static WebappsDiscoveryResponse invokeController(
+      final WebappsDiscoveryProperties properties) {
+    final var request = new MockHttpServletRequest("GET", WEBAPPS_DISCOVERY_URL);
+    request.setScheme("https");
+    request.setServerName("cluster.example.com");
+    request.setServerPort(443);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    try {
+      return new WebappsDiscoveryController(properties).getWebapps();
+    } finally {
+      RequestContextHolder.resetRequestAttributes();
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryControllerTest.java
@@ -8,17 +8,13 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.startsWith;
 
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.config.WebappsDiscoveryProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.mock.env.MockEnvironment;
 
 @WebMvcTest(WebappsDiscoveryController.class)
 class WebappsDiscoveryControllerTest extends RestControllerTest {
@@ -26,8 +22,9 @@ class WebappsDiscoveryControllerTest extends RestControllerTest {
   static final String WEBAPPS_DISCOVERY_URL = "/.well-known/camunda/webapps";
 
   @Test
-  void shouldAnnounceWebappsOnApiOriginByDefault() {
-    // given no explicit camunda.webapps.*.url configuration
+  void shouldAnnounceWebappsAsRelativePathsByDefault() {
+    // given no explicit camunda.webapps.*.url configuration — relative URLs resolve against the
+    // origin the client used for the API call, correct behind proxies by construction
 
     // when / then
     webClient
@@ -38,14 +35,7 @@ class WebappsDiscoveryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .jsonPath("$.operateUrl")
-        .value(startsWith("http"))
-        .jsonPath("$.operateUrl")
-        .value(endsWith("/operate"))
-        .jsonPath("$.tasklistUrl")
-        .value(startsWith("http"))
-        .jsonPath("$.tasklistUrl")
-        .value(endsWith("/tasklist"));
+        .json("{\"operateUrl\":\"/operate\",\"tasklistUrl\":\"/tasklist\"}");
   }
 
   @Test
@@ -64,19 +54,6 @@ class WebappsDiscoveryControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldDeriveUrlFromRequestOriginWhenNoUrlConfigured() {
-    // given
-    final var properties = new WebappsDiscoveryProperties();
-
-    // when
-    final var response = invokeController(properties);
-
-    // then
-    assertThat(response.operateUrl()).isEqualTo("https://cluster.example.com/operate");
-    assertThat(response.tasklistUrl()).isEqualTo("https://cluster.example.com/tasklist");
-  }
-
-  @Test
   void shouldNotAnnounceWebappWhenDisabled() {
     // given
     final var properties = new WebappsDiscoveryProperties();
@@ -87,7 +64,7 @@ class WebappsDiscoveryControllerTest extends RestControllerTest {
 
     // then
     assertThat(response.operateUrl()).isNull();
-    assertThat(response.tasklistUrl()).isEqualTo("https://cluster.example.com/tasklist");
+    assertThat(response.tasklistUrl()).isEqualTo("/tasklist");
   }
 
   @Test
@@ -100,8 +77,23 @@ class WebappsDiscoveryControllerTest extends RestControllerTest {
     final var response = invokeController(properties);
 
     // then
-    assertThat(response.operateUrl()).isEqualTo("https://cluster.example.com/operate");
+    assertThat(response.operateUrl()).isEqualTo("/operate");
     assertThat(response.tasklistUrl()).isNull();
+  }
+
+  @Test
+  void shouldNotAnnounceWebappWhenLegacyWebappEnabledIsFalse() {
+    // given — disabled via the legacy kill-switch, which still gates the actual webapp
+    final var properties = new WebappsDiscoveryProperties();
+    final var environment =
+        new MockEnvironment().withProperty("camunda.operate.webappEnabled", "false");
+
+    // when
+    final var response = invokeController(properties, environment);
+
+    // then
+    assertThat(response.operateUrl()).isNull();
+    assertThat(response.tasklistUrl()).isEqualTo("/tasklist");
   }
 
   @Test
@@ -120,15 +112,11 @@ class WebappsDiscoveryControllerTest extends RestControllerTest {
 
   private static WebappsDiscoveryResponse invokeController(
       final WebappsDiscoveryProperties properties) {
-    final var request = new MockHttpServletRequest("GET", WEBAPPS_DISCOVERY_URL);
-    request.setScheme("https");
-    request.setServerName("cluster.example.com");
-    request.setServerPort(443);
-    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-    try {
-      return new WebappsDiscoveryController(properties).getWebapps();
-    } finally {
-      RequestContextHolder.resetRequestAttributes();
-    }
+    return invokeController(properties, new MockEnvironment());
+  }
+
+  private static WebappsDiscoveryResponse invokeController(
+      final WebappsDiscoveryProperties properties, final MockEnvironment environment) {
+    return new WebappsDiscoveryController(properties, environment).getWebapps();
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/WebappsDiscoveryControllerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(WebappsDiscoveryController.class)
 class WebappsDiscoveryControllerTest extends RestControllerTest {
@@ -35,7 +36,23 @@ class WebappsDiscoveryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json("{\"operateUrl\":\"/operate\",\"tasklistUrl\":\"/tasklist\"}");
+        .json(
+            "{\"operateUrl\":\"/operate\",\"tasklistUrl\":\"/tasklist\"}", JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldIncludeServletContextPathInFallback() {
+    // given — the UIs are mounted below the servlet context path, e.g. /camunda/operate
+    final var properties = new WebappsDiscoveryProperties();
+    final var environment =
+        new MockEnvironment().withProperty("server.servlet.context-path", "/camunda");
+
+    // when
+    final var response = invokeController(properties, environment);
+
+    // then
+    assertThat(response.operateUrl()).isEqualTo("/camunda/operate");
+    assertThat(response.tasklistUrl()).isEqualTo("/camunda/tasklist");
   }
 
   @Test


### PR DESCRIPTION
## Description

Clients integrating with the orchestration cluster (Desktop Modeler, CLIs) had no way to learn where a setup's Operate and Tasklist UIs live, forcing per-app URL configuration in every client. This PR adds the unauthenticated discovery endpoint `GET /.well-known/camunda/webapps` agreed with the modeler team, returning `{"operateUrl": ..., "tasklistUrl": ...}` and omitting webapps that are not part of the setup.

**Resolution semantics** (in order):
1. `camunda.webapps.<app>.url` — announced as-is, for deployments where frontends live on a different origin than the API (the chart sets these from its ingress values, see the related Helm PR).
2. Otherwise a webapp with its UI enabled is announced as a root-relative path (`/operate`, `/tasklist`) — correct by construction behind TLS-terminating proxies, which is why the fallback is not a request-derived absolute URL.
3. Disabled webapps (unified key or legacy `camunda.<app>.webappEnabled`) without an explicit URL are omitted.

The endpoint is served wherever the REST gateway runs (incl. standalone gateway) and sits on the filter-less unprotected chain (exact path, like `/cluster/v2/status`), so discovery works before a client knows how to authenticate.

**Contract note for client implementers** (camunda/camunda-modeler#5131): values may be root-relative paths; resolve them against the origin used for the API call.

## Related issues

closes #46649