### PR TITLE
test: use quay hosted minio image

### DIFF
--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionIT.java
@@ -53,7 +53,7 @@ final class CompressionIT {
   @SuppressWarnings("resource")
   @Container
   private static final GenericContainer<?> S3 =
-      new GenericContainer<>(DockerImageName.parse("minio/minio"))
+      new GenericContainer<>(DockerImageName.parse("quay.io/minio/minio"))
           .withCommand("server /data")
           .withExposedPorts(DEFAULT_PORT)
           .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CustomBasePathIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CustomBasePathIT.java
@@ -41,7 +41,7 @@ final class CustomBasePathIT {
     @SuppressWarnings("resource")
     @Container
     private static final GenericContainer<?> S3 =
-        new GenericContainer<>(DockerImageName.parse("minio/minio"))
+        new GenericContainer<>(DockerImageName.parse("quay.io/minio/minio"))
             .withCommand("server /data")
             .withExposedPorts(DEFAULT_PORT)
             .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
@@ -94,7 +94,7 @@ final class CustomBasePathIT {
     @SuppressWarnings("resource")
     @Container
     private static final GenericContainer<?> S3 =
-        new GenericContainer<>(DockerImageName.parse("minio/minio"))
+        new GenericContainer<>(DockerImageName.parse("quay.io/minio/minio"))
             .withCommand("server /data")
             .withExposedPorts(DEFAULT_PORT)
             .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
@@ -37,7 +37,7 @@ final class MinioBackupStoreIT implements S3BackupStoreTests {
   @SuppressWarnings("resource")
   @Container
   private static final GenericContainer<?> S3 =
-      new GenericContainer<>(DockerImageName.parse("minio/minio"))
+      new GenericContainer<>(DockerImageName.parse("quay.io/minio/minio"))
           .withCommand("server /data")
           .withExposedPorts(DEFAULT_PORT)
           .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioLegacyMd5IT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioLegacyMd5IT.java
@@ -32,7 +32,8 @@ public class MinioLegacyMd5IT implements S3BackupStoreTests {
   public static final String SECRET_KEY = "letmein1234";
   public static final int DEFAULT_PORT = 9000;
   // Deliberately using an old MinIO image to verify AWS legacy MD5 support
-  private static final String LEGACY_MINIO_IMAGE = "minio/minio:RELEASE.2023-11-20T22-40-07Z";
+  private static final String LEGACY_MINIO_IMAGE =
+      "quay.io/minio/minio:RELEASE.2023-11-20T22-40-07Z";
   private static final Logger LOG = LoggerFactory.getLogger(MinioLegacyMd5IT.class);
   private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/MinioContainer.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/MinioContainer.java
@@ -30,7 +30,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class MinioContainer extends GenericContainer<MinioContainer> {
 
-  private static final DockerImageName IMAGE = DockerImageName.parse("minio/minio");
+  private static final DockerImageName IMAGE = DockerImageName.parse("quay.io/minio/minio");
   private static final int PORT = 9000;
   private static final String DEFAULT_REGION = "us-east-1";
   private static final String DEFAULT_ACCESS_KEY = "accessKey";


### PR DESCRIPTION
The minio/minio image is gone from Docker Hub as of the 11th - we should really move away from using it entirely, but to fix the build we can use the quay.io version.

## Related issues

- [x] This PR does not need a linked issue

